### PR TITLE
install wizard moved to UI

### DIFF
--- a/cmd/server/frontend/dist/index.html
+++ b/cmd/server/frontend/dist/index.html
@@ -11,8 +11,8 @@
       rel="stylesheet"
     />
     <title>Nimbus — Spin up a machine.</title>
-    <script type="module" crossorigin src="/assets/index-B9Q1CSRz.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DW0KDDPr.css">
+    <script type="module" crossorigin src="/assets/index-B8pDrncw.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DT-l51ai.css">
   </head>
   <body>
     <div id="root"></div>

--- a/cmd/server/frontend/dist/index.html
+++ b/cmd/server/frontend/dist/index.html
@@ -11,8 +11,8 @@
       rel="stylesheet"
     />
     <title>Nimbus — Spin up a machine.</title>
-    <script type="module" crossorigin src="/assets/index-CPK8R0YC.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-rSsbFzco.css">
+    <script type="module" crossorigin src="/assets/index-DhF4tYFu.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DiZJvFXS.css">
   </head>
   <body>
     <div id="root"></div>

--- a/cmd/server/frontend/dist/index.html
+++ b/cmd/server/frontend/dist/index.html
@@ -11,8 +11,8 @@
       rel="stylesheet"
     />
     <title>Nimbus — Spin up a machine.</title>
-    <script type="module" crossorigin src="/assets/index-DhF4tYFu.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DiZJvFXS.css">
+    <script type="module" crossorigin src="/assets/index-B9Q1CSRz.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DW0KDDPr.css">
   </head>
   <body>
     <div id="root"></div>

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,12 +8,14 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"syscall"
 	"time"
 
 	"nimbus/internal/api"
 	"nimbus/internal/build"
 	"nimbus/internal/config"
 	"nimbus/internal/db"
+	"nimbus/internal/install"
 	"nimbus/internal/ippool"
 	"nimbus/internal/provision"
 	"nimbus/internal/proxmox"
@@ -23,6 +25,11 @@ import (
 var frontendFS embed.FS
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "install" {
+		install.Run()
+		return
+	}
+
 	flags := flag.NewFlagSet("nimbus", flag.ExitOnError)
 	port := flags.String("port", "", "server port (overrides PORT env var)")
 	dbPath := flags.String("db", "", "database path (overrides DB_PATH env var)")
@@ -44,8 +51,30 @@ func main() {
 	if *dbPath != "" {
 		cfg.DBPath = *dbPath
 	}
-	if err := cfg.Validate(); err != nil {
-		log.Fatalf("invalid configuration: %v", err)
+
+	distFS, err := fs.Sub(frontendFS, "frontend/dist")
+	if err != nil {
+		log.Fatalf("failed to create frontend sub-filesystem: %v", err)
+	}
+
+	// Start in setup mode when required config is absent.
+	if !cfg.IsConfigured() {
+		log.Printf("nimbus %s starting in setup mode on :%s", build.Version, cfg.Port)
+		router := api.NewSetupRouter(cfg, restartSelf)
+
+		mux := http.NewServeMux()
+		mux.Handle("/api/", router)
+		mux.Handle("/", spaHandler(http.FS(distFS)))
+
+		srv := &http.Server{
+			Addr:              ":" + cfg.Port,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		if err := srv.ListenAndServe(); err != nil {
+			log.Fatalf("server error: %v", err)
+		}
+		return
 	}
 
 	database, err := db.New(cfg.DBPath, ippool.Model(), &db.VM{})
@@ -72,12 +101,9 @@ func main() {
 		Provision: provSvc,
 		Pool:      pool,
 		Proxmox:   pveClient,
+		Config:    cfg,
+		Restart:   restartSelf,
 	})
-
-	distFS, err := fs.Sub(frontendFS, "frontend/dist")
-	if err != nil {
-		log.Fatalf("failed to create frontend sub-filesystem: %v", err)
-	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/api/", router)
@@ -92,6 +118,20 @@ func main() {
 	}
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("server error: %v", err)
+	}
+}
+
+// restartSelf replaces the current process image with a fresh start via exec.
+// The new process inherits the current environment (with any os.Setenv changes
+// applied by the setup handler before this is called).
+func restartSelf() {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Printf("restart: cannot locate executable: %v", err)
+		return
+	}
+	if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+		log.Printf("restart: exec failed: %v", err)
 	}
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,37 @@
+import { useEffect, useState } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Background from '@/components/Background'
 import Layout from '@/components/Layout'
 import MyVMs from '@/pages/MyVMs'
 import Nodes from '@/pages/Nodes'
 import Provision from '@/pages/Provision'
+import Setup from '@/pages/Setup'
+import { getSetupStatus } from '@/api/client'
+
+type AppState = 'loading' | 'setup' | 'ready'
 
 export default function App() {
+  const [state, setState] = useState<AppState>('loading')
+
+  useEffect(() => {
+    getSetupStatus()
+      .then((s) => setState(s.configured ? 'ready' : 'setup'))
+      .catch(() => setState('setup'))
+  }, [])
+
+  if (state === 'loading') {
+    return (
+      <div className="min-h-screen grid place-items-center">
+        <Background />
+        <div className="brand-mark brand-mark-lg animate-pulse" />
+      </div>
+    )
+  }
+
+  if (state === 'setup') {
+    return <Setup />
+  }
+
   return (
     <BrowserRouter>
       <Background />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -73,6 +73,7 @@ export async function provisionVM(req: ProvisionRequest): Promise<ProvisionResul
 export interface DiscoverResult {
   is_hypervisor: boolean
   endpoints: string[]
+  suggested_gateway?: string
 }
 
 export async function discoverProxmox(): Promise<DiscoverResult> {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -70,4 +70,53 @@ export async function provisionVM(req: ProvisionRequest): Promise<ProvisionResul
   return data
 }
 
+export interface DiscoverResult {
+  is_hypervisor: boolean
+  endpoints: string[]
+}
+
+export async function discoverProxmox(): Promise<DiscoverResult> {
+  const { data } = await api.get<DiscoverResult>('/setup/discover')
+  return data
+}
+
+export interface SetupStatus {
+  configured: boolean
+}
+
+export interface TestConnRequest {
+  proxmox_host: string
+  proxmox_token_id: string
+  proxmox_token_secret: string
+}
+
+export interface SaveConfigRequest {
+  proxmox_host: string
+  proxmox_token_id: string
+  proxmox_token_secret: string
+  ip_pool_start: string
+  ip_pool_end: string
+  gateway_ip: string
+  nameserver?: string
+  search_domain?: string
+  port?: string
+}
+
+export async function getSetupStatus(): Promise<SetupStatus> {
+  const { data } = await api.get<SetupStatus>('/setup/status')
+  return data
+}
+
+export async function testProxmoxConnection(
+  req: TestConnRequest,
+): Promise<{ proxmox_version: string }> {
+  const { data } = await api.post<{ proxmox_version: string }>('/setup/test', req)
+  return data
+}
+
+export async function saveSetupConfig(req: SaveConfigRequest): Promise<{ message: string }> {
+  const { data } = await api.post<{ message: string }>('/setup/save', req)
+  return data
+}
+
 export default api

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -2,6 +2,7 @@ import { InputHTMLAttributes, ReactNode, forwardRef } from 'react'
 
 interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
   label?: string
+  labelAddon?: ReactNode
   hint?: string
   error?: string
   prefix?: ReactNode
@@ -12,13 +13,14 @@ const baseInput =
   'w-full px-3.5 py-3 rounded-[10px] bg-white/85 font-sans text-sm text-ink border border-line-2 transition-all duration-150 outline-none focus:border-ink focus:bg-white placeholder:text-ink-3 disabled:opacity-60'
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ label, hint, error, prefix, suffix, className = '', ...props }, ref) => {
+  ({ label, labelAddon, hint, error, prefix, suffix, className = '', ...props }, ref) => {
     const fieldId = props.id ?? props.name
     return (
       <div className="flex flex-col gap-2">
         {label && (
-          <label htmlFor={fieldId} className="text-[13px] font-medium text-ink">
+          <label htmlFor={fieldId} className="text-[13px] font-medium text-ink flex items-center gap-2">
             {label}
+            {labelAddon}
           </label>
         )}
         {prefix || suffix ? (

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -1,0 +1,663 @@
+import { useEffect, useState } from 'react'
+import Background from '@/components/Background'
+import Card from '@/components/ui/Card'
+import Button from '@/components/ui/Button'
+import Input from '@/components/ui/Input'
+import {
+  getSetupStatus,
+  testProxmoxConnection,
+  saveSetupConfig,
+  discoverProxmox,
+  type SaveConfigRequest,
+  type DiscoverResult,
+} from '@/api/client'
+
+type Step = 'proxmox' | 'network' | 'review' | 'restarting'
+
+interface ProxmoxFields {
+  host: string
+  tokenId: string
+  tokenSecret: string
+}
+
+interface NetworkFields {
+  ipPoolStart: string
+  ipPoolEnd: string
+  gatewayIp: string
+  nameserver: string
+  searchDomain: string
+  port: string
+}
+
+export default function Setup() {
+  const [step, setStep] = useState<Step>('proxmox')
+  const [proxmox, setProxmox] = useState<ProxmoxFields>({
+    host: 'https://localhost:8006',
+    tokenId: 'root@pam!nimbus',
+    tokenSecret: '',
+  })
+  const [network, setNetwork] = useState<NetworkFields>({
+    ipPoolStart: '',
+    ipPoolEnd: '',
+    gatewayIp: '',
+    nameserver: '',
+    searchDomain: '',
+    port: '',
+  })
+  const [testing, setTesting] = useState(false)
+  const [testOk, setTestOk] = useState<string | null>(null)
+  const [testError, setTestError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const updateProxmox = (key: keyof ProxmoxFields, value: string) => {
+    setProxmox((p) => ({ ...p, [key]: value }))
+    setTestOk(null)
+    setTestError(null)
+  }
+
+  const handleTest = async () => {
+    setTesting(true)
+    setTestOk(null)
+    setTestError(null)
+    try {
+      const res = await testProxmoxConnection({
+        proxmox_host: proxmox.host,
+        proxmox_token_id: proxmox.tokenId,
+        proxmox_token_secret: proxmox.tokenSecret,
+      })
+      setTestOk(`Connected — Proxmox VE ${res.proxmox_version}`)
+    } catch (err) {
+      setTestError(err instanceof Error ? err.message : 'connection failed')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setSaveError(null)
+    const req: SaveConfigRequest = {
+      proxmox_host: proxmox.host,
+      proxmox_token_id: proxmox.tokenId,
+      proxmox_token_secret: proxmox.tokenSecret,
+      ip_pool_start: network.ipPoolStart,
+      ip_pool_end: network.ipPoolEnd,
+      gateway_ip: network.gatewayIp,
+    }
+    if (network.nameserver) req.nameserver = network.nameserver
+    if (network.searchDomain) req.search_domain = network.searchDomain
+    if (network.port) req.port = network.port
+    try {
+      await saveSetupConfig(req)
+      setStep('restarting')
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'save failed')
+      setSaving(false)
+    }
+  }
+
+  if (step === 'restarting') {
+    return <RestartingView />
+  }
+
+  const steps: Step[] = ['proxmox', 'network', 'review']
+  const stepIndex = steps.indexOf(step)
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Background />
+
+      {/* Minimal header */}
+      <div
+        className="sticky top-0 z-50 border-b border-line"
+        style={{
+          backdropFilter: 'blur(20px) saturate(140%)',
+          WebkitBackdropFilter: 'blur(20px) saturate(140%)',
+          background: 'rgba(255,255,255,0.75)',
+        }}
+      >
+        <div className="max-w-[720px] mx-auto px-8 py-4 flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <div className="brand-mark" />
+            <span className="font-display font-semibold text-xl tracking-tight">Nimbus</span>
+          </div>
+          <div className="font-mono text-xs text-ink-3 tracking-widest uppercase">
+            Setup wizard
+          </div>
+        </div>
+      </div>
+
+      <main className="flex-1 max-w-[720px] mx-auto w-full px-8 py-12 animate-fadeIn">
+        {/* Step indicator */}
+        <div className="flex items-center gap-3 mb-10 flex-wrap">
+          {(['proxmox', 'network', 'review'] as const).map((s, i) => (
+            <div key={s} className="flex items-center gap-3">
+              <div
+                className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-mono font-medium transition-colors ${
+                  i < stepIndex
+                    ? 'bg-ink text-white'
+                    : i === stepIndex
+                      ? 'bg-ink text-white'
+                      : 'bg-[rgba(27,23,38,0.07)] text-ink-3'
+                }`}
+              >
+                {i < stepIndex ? '✓' : i + 1}
+              </div>
+              <span
+                className={`text-sm font-medium capitalize ${
+                  i === stepIndex ? 'text-ink' : 'text-ink-3'
+                }`}
+              >
+                {s === 'proxmox' ? 'Proxmox' : s === 'network' ? 'Network' : 'Review'}
+              </span>
+              <div className="w-8 h-px bg-line-2" />
+            </div>
+          ))}
+
+          {/* Future steps — visible but locked */}
+          <div className="flex items-center gap-3">
+            <div className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-mono font-medium bg-[rgba(27,23,38,0.04)] text-ink-3 border border-dashed border-line-2">
+              4
+            </div>
+            <span className="text-sm font-medium text-ink-3">Gopher</span>
+            <span className="text-[9px] font-mono uppercase tracking-widest text-ink-3 bg-[rgba(27,23,38,0.05)] px-1.5 py-0.5 rounded border border-line-2">
+              optional · soon
+            </span>
+          </div>
+          <div className="w-8 h-px bg-line-2" />
+          <div className="flex items-center gap-3">
+            <div className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-mono font-medium bg-[rgba(27,23,38,0.04)] text-ink-3 border border-dashed border-line-2">
+              5
+            </div>
+            <span className="text-sm font-medium text-ink-3">Templates</span>
+            <span className="text-[9px] font-mono uppercase tracking-widest text-ink-3 bg-[rgba(27,23,38,0.05)] px-1.5 py-0.5 rounded border border-line-2">
+              soon
+            </span>
+          </div>
+        </div>
+
+        {step === 'proxmox' && (
+          <ProxmoxStep
+            fields={proxmox}
+            onChange={updateProxmox}
+            onTest={handleTest}
+            testing={testing}
+            testOk={testOk}
+            testError={testError}
+            onNext={() => setStep('network')}
+          />
+        )}
+        {step === 'network' && (
+          <NetworkStep
+            fields={network}
+            onChange={(key, val) => setNetwork((n) => ({ ...n, [key]: val }))}
+            onBack={() => setStep('proxmox')}
+            onNext={() => setStep('review')}
+          />
+        )}
+        {step === 'review' && (
+          <ReviewStep
+            proxmox={proxmox}
+            network={network}
+            onBack={() => setStep('network')}
+            onSave={handleSave}
+            saving={saving}
+            saveError={saveError}
+          />
+        )}
+      </main>
+    </div>
+  )
+}
+
+// ── Step 1: Proxmox ──────────────────────────────────────────────────────────
+
+interface ProxmoxStepProps {
+  fields: ProxmoxFields
+  onChange: (key: keyof ProxmoxFields, value: string) => void
+  onTest: () => void
+  testing: boolean
+  testOk: string | null
+  testError: string | null
+  onNext: () => void
+}
+
+function ProxmoxStep({ fields, onChange, onTest, testing, testOk, testError, onNext }: ProxmoxStepProps) {
+  const canNext = !!fields.host && !!fields.tokenId && !!fields.tokenSecret && !!testOk
+  const [discovery, setDiscovery] = useState<DiscoverResult | null>(null)
+  const [discovering, setDiscovering] = useState(true)
+  const [guideOpen, setGuideOpen] = useState(false)
+
+  useEffect(() => {
+    discoverProxmox()
+      .then(setDiscovery)
+      .catch(() => setDiscovery({ is_hypervisor: false, endpoints: [] }))
+      .finally(() => setDiscovering(false))
+  }, [])
+
+  return (
+    <div>
+      <div className="eyebrow">Step 1 of 3</div>
+      <h2 className="text-3xl mt-1 mb-2">Connect to Proxmox</h2>
+      <p className="text-base text-ink-2 leading-relaxed mb-6">
+        Nimbus needs an API token to talk to your Proxmox cluster. Enter the URL of any
+        cluster node — Nimbus discovers the rest automatically.
+      </p>
+
+      {/* Discovery banner */}
+      <div className="mb-5">
+        {discovering ? (
+          <div className="flex items-center gap-2 text-sm text-ink-3 py-2">
+            <span className="w-1.5 h-1.5 rounded-full bg-ink-3 animate-pulse inline-block" />
+            Scanning local network for Proxmox nodes…
+          </div>
+        ) : discovery && discovery.is_hypervisor ? (
+          <div className="flex items-start gap-3 p-3.5 rounded-[10px] bg-[rgba(45,125,90,0.07)] border border-[rgba(45,125,90,0.2)] text-sm">
+            <span className="text-good mt-0.5">✓</span>
+            <div>
+              <span className="font-medium text-good">Running on a Proxmox host.</span>
+              <span className="text-ink-2">
+                {' '}
+                <code className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
+                  https://localhost:8006
+                </code>{' '}
+                is pre-filled — you can use it as-is.
+              </span>
+            </div>
+          </div>
+        ) : discovery && discovery.endpoints.length > 0 ? (
+          <div className="p-3.5 rounded-[10px] bg-[rgba(27,23,38,0.04)] border border-line-2 text-sm">
+            <div className="text-[11px] font-mono uppercase tracking-widest text-ink-3 mb-2">
+              Detected on this network
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {discovery.endpoints.map((ep) => (
+                <button
+                  key={ep}
+                  onClick={() => onChange('host', ep)}
+                  className={`font-mono text-xs px-3 py-1.5 rounded-[8px] border transition-colors cursor-pointer ${
+                    fields.host === ep
+                      ? 'bg-ink text-white border-ink'
+                      : 'bg-white border-line-2 text-ink hover:border-ink-3'
+                  }`}
+                >
+                  {ep}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start gap-3 p-3.5 rounded-[10px] bg-[rgba(27,23,38,0.04)] border border-line-2 text-sm text-ink-2">
+            <span className="text-ink-3 mt-0.5">○</span>
+            No Proxmox nodes found on this network. Enter the cluster URL manually — it
+            may be on a different subnet or reachable via a public endpoint.
+          </div>
+        )}
+      </div>
+
+      <Card className="p-8 flex flex-col gap-5">
+        <Input
+          label="Proxmox API URL"
+          placeholder="https://192.168.0.1:8006"
+          value={fields.host}
+          onChange={(e) => onChange('host', e.target.value)}
+          hint="Any node in your cluster — include https:// and port 8006. Nimbus discovers the rest of the cluster from here. Self-signed TLS certs are accepted."
+        />
+        <Input
+          label="Token ID"
+          placeholder="root@pam!nimbus"
+          value={fields.tokenId}
+          onChange={(e) => onChange('tokenId', e.target.value)}
+          hint="Format: user@realm!tokenname — e.g. root@pam!nimbus. See the guide below if you haven't created one yet."
+        />
+        <Input
+          label="Token secret"
+          type="password"
+          placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+          value={fields.tokenSecret}
+          onChange={(e) => onChange('tokenSecret', e.target.value)}
+          hint="The UUID shown once when you created the token. Lost it? Delete the token in the Proxmox UI and create a new one."
+        />
+
+        <div className="flex items-center gap-3 mt-1">
+          <Button
+            variant="ghost"
+            onClick={onTest}
+            disabled={!fields.host || !fields.tokenId || !fields.tokenSecret || testing}
+          >
+            {testing ? 'Testing…' : 'Test connection'}
+          </Button>
+          {testOk && (
+            <span className="text-sm text-good flex items-center gap-1.5">
+              <span className="w-1.5 h-1.5 rounded-full bg-good inline-block" />
+              {testOk}
+            </span>
+          )}
+          {testError && <span className="text-sm text-bad">{testError}</span>}
+        </div>
+      </Card>
+
+      {/* Inline token creation guide */}
+      <div className="mt-4 rounded-[10px] border border-line-2 overflow-hidden">
+        <button
+          className="w-full flex items-center justify-between px-5 py-3.5 text-sm font-medium text-ink hover:bg-[rgba(27,23,38,0.03)] transition-colors text-left"
+          onClick={() => setGuideOpen((o) => !o)}
+        >
+          <span className="flex items-center gap-2">
+            <span className="text-ink-3">?</span>
+            How to create a Proxmox API token
+          </span>
+          <span className="text-ink-3 text-xs">{guideOpen ? '▲' : '▼'}</span>
+        </button>
+
+        {guideOpen && (
+          <div className="px-5 pb-5 border-t border-line bg-[rgba(27,23,38,0.02)]">
+            <ol className="mt-4 flex flex-col gap-3 text-sm text-ink-2">
+              <GuideStep n={1}>
+                Open the Proxmox web UI in your browser at{' '}
+                <span className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
+                  https://&lt;your-node-ip&gt;:8006
+                </span>{' '}
+                and log in.
+              </GuideStep>
+              <GuideStep n={2}>
+                In the left sidebar, click{' '}
+                <strong className="text-ink">Datacenter</strong> (the top-level item, not a
+                specific node).
+              </GuideStep>
+              <GuideStep n={3}>
+                Go to{' '}
+                <span className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
+                  Permissions → API Tokens
+                </span>{' '}
+                in the submenu, then click <strong className="text-ink">Add</strong>.
+              </GuideStep>
+              <GuideStep n={4}>
+                Set <strong className="text-ink">User</strong> to{' '}
+                <code className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
+                  root@pam
+                </code>{' '}
+                and <strong className="text-ink">Token ID</strong> to{' '}
+                <code className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
+                  nimbus
+                </code>
+                .
+              </GuideStep>
+              <GuideStep n={5} highlight>
+                <strong>Uncheck "Privilege Separation".</strong> Without this, the token
+                has no effective permissions and all API calls will fail with 403.
+              </GuideStep>
+              <GuideStep n={6}>
+                Click <strong className="text-ink">Add</strong>. Copy the token secret from
+                the popup immediately — Proxmox will not show it again. If you miss it,
+                delete the token and create a new one.
+              </GuideStep>
+              <GuideStep n={7}>
+                Paste the Token ID (
+                <code className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
+                  root@pam!nimbus
+                </code>
+                ) and secret into the fields above, then click{' '}
+                <strong className="text-ink">Test connection</strong>.
+              </GuideStep>
+            </ol>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end mt-6">
+        <Button onClick={onNext} disabled={!canNext}>
+          Next: Network →
+        </Button>
+      </div>
+      {!testOk && fields.tokenSecret && (
+        <p className="text-xs text-ink-3 text-right mt-2">
+          Test the connection before continuing.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function GuideStep({
+  n,
+  children,
+  highlight = false,
+}: {
+  n: number
+  children: React.ReactNode
+  highlight?: boolean
+}) {
+  return (
+    <li
+      className={`flex gap-3 ${highlight ? 'p-3 rounded-[8px] bg-[rgba(184,101,15,0.06)] border border-[rgba(184,101,15,0.2)] text-warn' : ''}`}
+    >
+      <span
+        className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-mono font-medium mt-0.5 ${
+          highlight ? 'bg-warn text-white' : 'bg-[rgba(27,23,38,0.07)] text-ink-3'
+        }`}
+      >
+        {n}
+      </span>
+      <span className="leading-relaxed">{children}</span>
+    </li>
+  )
+}
+
+// ── Step 2: Network ──────────────────────────────────────────────────────────
+
+interface NetworkStepProps {
+  fields: NetworkFields
+  onChange: (key: keyof NetworkFields, value: string) => void
+  onBack: () => void
+  onNext: () => void
+}
+
+function NetworkStep({ fields, onChange, onBack, onNext }: NetworkStepProps) {
+  const canNext = !!fields.ipPoolStart && !!fields.ipPoolEnd && !!fields.gatewayIp
+  const missing = !canNext && (fields.ipPoolStart || fields.ipPoolEnd || fields.gatewayIp)
+  return (
+    <div>
+      <div className="eyebrow">Step 2 of 3</div>
+      <h2 className="text-3xl mt-1 mb-2">Network</h2>
+      <p className="text-base text-ink-2 leading-relaxed mb-8">
+        Nimbus allocates a static IP from this pool for every VM it provisions. Pick a
+        contiguous range of unused addresses on your LAN — nothing outside this range will
+        ever be touched.
+      </p>
+
+      {/* Required fields */}
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-[11px] font-mono font-medium uppercase tracking-widest text-ink">
+          Required
+        </span>
+        <span className="text-bad text-sm leading-none">*</span>
+      </div>
+      <Card className="p-8 flex flex-col gap-5 mb-6 border-[1.5px] border-line-2">
+        <div className="grid grid-cols-2 gap-4">
+          <Input
+            label="Pool start IP *"
+            placeholder="192.168.0.100"
+            value={fields.ipPoolStart}
+            onChange={(e) => onChange('ipPoolStart', e.target.value)}
+            hint="First IP Nimbus may assign. Must be inside your LAN subnet and not already in use."
+          />
+          <Input
+            label="Pool end IP *"
+            placeholder="192.168.0.200"
+            value={fields.ipPoolEnd}
+            onChange={(e) => onChange('ipPoolEnd', e.target.value)}
+            hint="Last IP in the range (inclusive). A /24 gives you up to 101 addresses between .100–.200."
+          />
+        </div>
+        <Input
+          label="Gateway IP *"
+          placeholder="192.168.0.1"
+          value={fields.gatewayIp}
+          onChange={(e) => onChange('gatewayIp', e.target.value)}
+          hint="Your router's LAN IP — the default route injected into every VM via cloud-init. Usually ends in .1."
+        />
+      </Card>
+
+      {/* Optional fields */}
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-[11px] font-mono font-medium uppercase tracking-widest text-ink-3">
+          Optional
+        </span>
+        <span className="text-[11px] text-ink-3">— safe defaults apply if left blank</span>
+      </div>
+      <Card className="p-8 flex flex-col gap-5">
+        <div className="grid grid-cols-2 gap-4">
+          <Input
+            label="Nameserver"
+            placeholder="1.1.1.1 8.8.8.8"
+            value={fields.nameserver}
+            onChange={(e) => onChange('nameserver', e.target.value)}
+            hint="DNS resolvers injected into VMs. Space-separated. Defaults to Cloudflare + Google."
+          />
+          <Input
+            label="Search domain"
+            placeholder="local"
+            value={fields.searchDomain}
+            onChange={(e) => onChange('searchDomain', e.target.value)}
+            hint="Appended to unqualified hostnames inside VMs (e.g. 'local' so 'myhost' resolves as 'myhost.local')."
+          />
+        </div>
+        <Input
+          label="HTTP port"
+          placeholder="8080"
+          value={fields.port}
+          onChange={(e) => onChange('port', e.target.value)}
+          hint="Port this Nimbus server listens on. Change if 8080 is already taken on this host."
+        />
+      </Card>
+
+      {missing && (
+        <p className="text-xs text-bad mt-4 text-right">
+          Fill in all required fields to continue.
+        </p>
+      )}
+
+      <div className="flex justify-between mt-6">
+        <Button variant="ghost" onClick={onBack}>
+          ← Back
+        </Button>
+        <Button onClick={onNext} disabled={!canNext}>
+          Next: Review →
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ── Step 3: Review ───────────────────────────────────────────────────────────
+
+interface ReviewStepProps {
+  proxmox: ProxmoxFields
+  network: NetworkFields
+  onBack: () => void
+  onSave: () => void
+  saving: boolean
+  saveError: string | null
+}
+
+function ReviewStep({ proxmox, network, onBack, onSave, saving, saveError }: ReviewStepProps) {
+  return (
+    <div>
+      <div className="eyebrow">Step 3 of 3</div>
+      <h2 className="text-3xl mt-1 mb-2">Review & save</h2>
+      <p className="text-base text-ink-2 leading-relaxed mb-8">
+        Nimbus will write these values to the config file and restart.
+      </p>
+
+      <Card className="p-8">
+        <SectionLabel>Proxmox</SectionLabel>
+        <ReviewRow label="API URL" value={proxmox.host} />
+        <ReviewRow label="Token ID" value={proxmox.tokenId} />
+        <ReviewRow label="Token secret" value={'•'.repeat(16)} />
+
+        <SectionLabel className="mt-6">Network</SectionLabel>
+        <ReviewRow label="IP pool" value={`${network.ipPoolStart} – ${network.ipPoolEnd}`} />
+        <ReviewRow label="Gateway" value={network.gatewayIp} />
+        <ReviewRow label="Nameserver" value={network.nameserver || '1.1.1.1 8.8.8.8'} />
+        <ReviewRow label="Search domain" value={network.searchDomain || 'local'} />
+        <ReviewRow label="Port" value={network.port || '8080'} />
+      </Card>
+
+      {saveError && (
+        <div className="mt-4 p-3.5 rounded-[10px] bg-[rgba(184,58,58,0.06)] border border-[rgba(184,58,58,0.2)] text-bad text-sm">
+          {saveError}
+        </div>
+      )}
+
+      <div className="flex justify-between mt-6">
+        <Button variant="ghost" onClick={onBack} disabled={saving}>
+          ← Back
+        </Button>
+        <Button onClick={onSave} disabled={saving}>
+          {saving ? 'Saving…' : 'Save & start Nimbus →'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function SectionLabel({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`text-[10px] font-mono uppercase tracking-widest text-ink-3 mb-3 ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between py-2.5 border-b border-dashed border-line text-[13px] last:border-b-0">
+      <span className="text-ink-3">{label}</span>
+      <span className="font-mono text-ink text-xs">{value}</span>
+    </div>
+  )
+}
+
+// ── Restarting ───────────────────────────────────────────────────────────────
+
+function RestartingView() {
+  useEffect(() => {
+    let cancelled = false
+    const poll = async () => {
+      while (!cancelled) {
+        await new Promise((r) => setTimeout(r, 1500))
+        try {
+          const status = await getSetupStatus()
+          if (status.configured) {
+            window.location.replace('/')
+            return
+          }
+        } catch {
+          // server is restarting — keep polling
+        }
+      }
+    }
+    poll()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Background />
+      <div className="flex-1 grid place-items-center">
+        <Card className="w-full max-w-[480px] p-12 text-center mx-4">
+          <div className="brand-mark brand-mark-lg mx-auto animate-pulse" />
+          <div className="eyebrow mt-7">One moment</div>
+          <h2 className="text-3xl mt-1">Starting Nimbus…</h2>
+          <p className="text-base text-ink-2 mt-4 leading-relaxed">
+            Configuration saved. The server is restarting — you'll be redirected automatically.
+          </p>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -32,7 +32,7 @@ interface NetworkFields {
 export default function Setup() {
   const [step, setStep] = useState<Step>('proxmox')
   const [proxmox, setProxmox] = useState<ProxmoxFields>({
-    host: 'https://localhost:8006',
+    host: '',
     tokenId: 'root@pam!nimbus',
     tokenSecret: '',
   })
@@ -44,11 +44,38 @@ export default function Setup() {
     searchDomain: '',
     port: '',
   })
+  const [discovery, setDiscovery] = useState<DiscoverResult | null>(null)
+  const [discovering, setDiscovering] = useState(true)
+  const [hostAutofilled, setHostAutofilled] = useState(false)
+  const [gatewayAutofilled, setGatewayAutofilled] = useState(false)
   const [testing, setTesting] = useState(false)
   const [testOk, setTestOk] = useState<string | null>(null)
   const [testError, setTestError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    discoverProxmox()
+      .then((d) => {
+        setDiscovery(d)
+        if (d.is_hypervisor && d.endpoints.length > 0) {
+          setProxmox((p) => {
+            if (p.host) return p
+            setHostAutofilled(true)
+            return { ...p, host: d.endpoints[0] }
+          })
+        }
+        if (d.suggested_gateway) {
+          setNetwork((n) => {
+            if (n.gatewayIp) return n
+            setGatewayAutofilled(true)
+            return { ...n, gatewayIp: d.suggested_gateway! }
+          })
+        }
+      })
+      .catch(() => setDiscovery({ is_hypervisor: false, endpoints: [] }))
+      .finally(() => setDiscovering(false))
+  }, [])
 
   const updateProxmox = (key: keyof ProxmoxFields, value: string) => {
     setProxmox((p) => ({ ...p, [key]: value }))
@@ -185,13 +212,21 @@ export default function Setup() {
             testing={testing}
             testOk={testOk}
             testError={testError}
+            discovery={discovery}
+            discovering={discovering}
+            hostAutofilled={hostAutofilled}
+            onDismissHostHint={() => setHostAutofilled(false)}
             onNext={() => setStep('network')}
           />
         )}
         {step === 'network' && (
           <NetworkStep
             fields={network}
-            onChange={(key, val) => setNetwork((n) => ({ ...n, [key]: val }))}
+            onChange={(key, val) => {
+              if (key === 'gatewayIp') setGatewayAutofilled(false)
+              setNetwork((n) => ({ ...n, [key]: val }))
+            }}
+            gatewayAutofilled={gatewayAutofilled}
             onBack={() => setStep('proxmox')}
             onNext={() => setStep('review')}
           />
@@ -220,21 +255,16 @@ interface ProxmoxStepProps {
   testing: boolean
   testOk: string | null
   testError: string | null
+  discovery: DiscoverResult | null
+  discovering: boolean
+  hostAutofilled: boolean
+  onDismissHostHint: () => void
   onNext: () => void
 }
 
-function ProxmoxStep({ fields, onChange, onTest, testing, testOk, testError, onNext }: ProxmoxStepProps) {
+function ProxmoxStep({ fields, onChange, onTest, testing, testOk, testError, discovery, discovering, hostAutofilled, onDismissHostHint, onNext }: ProxmoxStepProps) {
   const canNext = !!fields.host && !!fields.tokenId && !!fields.tokenSecret && !!testOk
-  const [discovery, setDiscovery] = useState<DiscoverResult | null>(null)
-  const [discovering, setDiscovering] = useState(true)
   const [guideOpen, setGuideOpen] = useState(false)
-
-  useEffect(() => {
-    discoverProxmox()
-      .then(setDiscovery)
-      .catch(() => setDiscovery({ is_hypervisor: false, endpoints: [] }))
-      .finally(() => setDiscovering(false))
-  }, [])
 
   return (
     <div>
@@ -245,65 +275,46 @@ function ProxmoxStep({ fields, onChange, onTest, testing, testOk, testError, onN
         cluster node — Nimbus discovers the rest automatically.
       </p>
 
-      {/* Discovery banner */}
-      <div className="mb-5">
-        {discovering ? (
-          <div className="flex items-center gap-2 text-sm text-ink-3 py-2">
-            <span className="w-1.5 h-1.5 rounded-full bg-ink-3 animate-pulse inline-block" />
-            Scanning local network for Proxmox nodes…
-          </div>
-        ) : discovery && discovery.is_hypervisor ? (
-          <div className="flex items-start gap-3 p-3.5 rounded-[10px] bg-[rgba(45,125,90,0.07)] border border-[rgba(45,125,90,0.2)] text-sm">
-            <span className="text-good mt-0.5">✓</span>
-            <div>
-              <span className="font-medium text-good">Running on a Proxmox host.</span>
-              <span className="text-ink-2">
-                {' '}
-                <code className="font-mono text-xs bg-[rgba(27,23,38,0.06)] px-1.5 py-0.5 rounded">
-                  https://localhost:8006
-                </code>{' '}
-                is pre-filled — you can use it as-is.
-              </span>
-            </div>
-          </div>
-        ) : discovery && discovery.endpoints.length > 0 ? (
-          <div className="p-3.5 rounded-[10px] bg-[rgba(27,23,38,0.04)] border border-line-2 text-sm">
-            <div className="text-[11px] font-mono uppercase tracking-widest text-ink-3 mb-2">
-              Detected on this network
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {discovery.endpoints.map((ep) => (
-                <button
-                  key={ep}
-                  onClick={() => onChange('host', ep)}
-                  className={`font-mono text-xs px-3 py-1.5 rounded-[8px] border transition-colors cursor-pointer ${
-                    fields.host === ep
-                      ? 'bg-ink text-white border-ink'
-                      : 'bg-white border-line-2 text-ink hover:border-ink-3'
-                  }`}
-                >
-                  {ep}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-start gap-3 p-3.5 rounded-[10px] bg-[rgba(27,23,38,0.04)] border border-line-2 text-sm text-ink-2">
-            <span className="text-ink-3 mt-0.5">○</span>
-            No Proxmox nodes found on this network. Enter the cluster URL manually — it
-            may be on a different subnet or reachable via a public endpoint.
-          </div>
-        )}
-      </div>
-
       <Card className="p-8 flex flex-col gap-5">
         <Input
           label="Proxmox API URL"
+          labelAddon={
+            hostAutofilled ? (
+              <AutofillBadge message="API URL auto-detected — this machine is a Proxmox node. Verify it looks correct before continuing." />
+            ) : undefined
+          }
           placeholder="https://192.168.0.1:8006"
           value={fields.host}
-          onChange={(e) => onChange('host', e.target.value)}
-          hint="Any node in your cluster — include https:// and port 8006. Nimbus discovers the rest of the cluster from here. Self-signed TLS certs are accepted."
+          onChange={(e) => {
+            onDismissHostHint()
+            onChange('host', e.target.value)
+          }}
+          hint="Any node in your cluster — include https:// and port 8006. Self-signed TLS certs are accepted."
         />
+        {/* Detected endpoints — subtle inline suggestion */}
+        {discovering ? (
+          <div className="flex items-center gap-1.5 text-[11px] text-ink-3 -mt-2">
+            <span className="w-1 h-1 rounded-full bg-ink-3 animate-pulse inline-block" />
+            Scanning for PVE nodes…
+          </div>
+        ) : discovery && discovery.endpoints.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5 -mt-2">
+            <span className="text-[11px] text-ink-3 font-mono">detected:</span>
+            {discovery.endpoints.map((ep) => (
+              <button
+                key={ep}
+                onClick={() => onChange('host', ep)}
+                className={`font-mono text-[11px] px-2 py-0.5 rounded-[5px] border transition-colors cursor-pointer ${
+                  fields.host === ep
+                    ? 'bg-ink text-white border-ink'
+                    : 'bg-transparent border-line-2 text-ink-2 hover:border-ink-3 hover:text-ink'
+                }`}
+              >
+                {ep}
+              </button>
+            ))}
+          </div>
+        ) : null}
         <Input
           label="Token ID"
           placeholder="root@pam!nimbus"
@@ -420,6 +431,20 @@ function ProxmoxStep({ fields, onChange, onTest, testing, testOk, testError, onN
   )
 }
 
+function AutofillBadge({ message }: { message: string }) {
+  return (
+    <span className="relative group inline-flex items-center">
+      <span className="inline-flex items-center gap-1 text-[10px] font-mono font-medium text-[#2563EB] bg-[rgba(59,130,246,0.08)] border border-[rgba(59,130,246,0.18)] px-1.5 py-0.5 rounded-full cursor-default select-none leading-none">
+        ↳ auto-filled
+      </span>
+      <span className="pointer-events-none absolute bottom-full left-0 mb-2 w-64 px-3 py-2.5 rounded-[8px] bg-[#1b1726] text-white text-[11px] leading-relaxed opacity-0 group-hover:opacity-100 transition-opacity duration-150 z-20 shadow-lg">
+        {message}
+        <span className="absolute top-full left-4 block w-2 h-2 bg-[#1b1726] rotate-45 -mt-1" />
+      </span>
+    </span>
+  )
+}
+
 function GuideStep({
   n,
   children,
@@ -450,11 +475,12 @@ function GuideStep({
 interface NetworkStepProps {
   fields: NetworkFields
   onChange: (key: keyof NetworkFields, value: string) => void
+  gatewayAutofilled: boolean
   onBack: () => void
   onNext: () => void
 }
 
-function NetworkStep({ fields, onChange, onBack, onNext }: NetworkStepProps) {
+function NetworkStep({ fields, onChange, gatewayAutofilled, onBack, onNext }: NetworkStepProps) {
   const canNext = !!fields.ipPoolStart && !!fields.ipPoolEnd && !!fields.gatewayIp
   const missing = !canNext && (fields.ipPoolStart || fields.ipPoolEnd || fields.gatewayIp)
   return (
@@ -493,6 +519,11 @@ function NetworkStep({ fields, onChange, onBack, onNext }: NetworkStepProps) {
         </div>
         <Input
           label="Gateway IP *"
+          labelAddon={
+            gatewayAutofilled ? (
+              <AutofillBadge message="Gateway auto-detected from this host's default route. Verify it matches your LAN router before continuing." />
+            ) : undefined
+          }
           placeholder="192.168.0.1"
           value={fields.gatewayIp}
           onChange={(e) => onChange('gatewayIp', e.target.value)}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-chi/chi/v5 v5.2.5
+	golang.org/x/crypto v0.50.0
 	golang.org/x/time v0.5.0
 	gorm.io/gorm v1.31.1
 )
@@ -17,7 +18,6 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	modernc.org/libc v1.22.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,12 +22,10 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.20.0 h1:gK/Kv2otX8gz+wn7Rmb3vT96ZwuoxnQlY+HlJVj7Qug=
-golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=
+golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=

--- a/internal/api/handlers/setup.go
+++ b/internal/api/handlers/setup.go
@@ -160,39 +160,49 @@ type discoverResult struct {
 }
 
 // Discover handles GET /api/setup/discover.
-// On a Proxmox hypervisor it reads corosync.conf for authoritative cluster
-// member IPs. On other hosts it scans all local subnets for port 8006.
+// It uses two complementary sources and merges the results:
+//   - corosync.conf (authoritative cluster membership, present on PVE nodes)
+//   - TCP port scan of all local subnets (works from any machine)
 func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
 	result := discoverResult{Endpoints: []string{}}
 
 	if _, err := os.Stat("/etc/pve"); err == nil {
 		result.IsHypervisor = true
 		result.SuggestedGateway = defaultGateway()
+	}
 
-		// Use corosync.conf as the authoritative cluster member list —
-		// network scanning is unreliable between Proxmox nodes (iptables).
-		for _, ip := range corosyncNodeIPs() {
-			url := "https://" + ip + ":8006"
-			if !containsStr(result.Endpoints, url) {
-				result.Endpoints = append(result.Endpoints, url)
-			}
-		}
-
-		// Single-node (not yet clustered): fall back to local interface IPs.
-		if len(result.Endpoints) == 0 {
-			for _, ip := range localIPv4s() {
+	// Source 1: corosync cluster membership (instant, authoritative on PVE nodes).
+	// When on a hypervisor, lead with localhost (IP-independent, survives network changes),
+	// then list only remote cluster nodes (skip this machine's own IPs).
+	clusterIPs := corosyncNodeIPs()
+	if result.IsHypervisor {
+		// Always put localhost first on hypervisors
+		result.Endpoints = append(result.Endpoints, "https://localhost:8006")
+		
+		// Add remote cluster nodes, skipping local IPs
+		if len(clusterIPs) > 0 {
+			localIPs := localIPv4s()
+			for _, ip := range clusterIPs {
+				if containsStr(localIPs, ip) {
+					continue // skip—localhost already covers this machine
+				}
 				url := "https://" + ip + ":8006"
 				if !containsStr(result.Endpoints, url) {
 					result.Endpoints = append(result.Endpoints, url)
 				}
 			}
 		}
-
-		response.Success(w, result)
-		return
+	} else {
+		// On non-hypervisor, add cluster nodes as-is
+		for _, ip := range clusterIPs {
+			url := "https://" + ip + ":8006"
+			if !containsStr(result.Endpoints, url) {
+				result.Endpoints = append(result.Endpoints, url)
+			}
+		}
 	}
 
-	// Not a hypervisor — scan all local subnets for anything with 8006 open.
+	// Source 2: subnet scan — supplements corosync and works from any host.
 	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
 	defer cancel()
 

--- a/internal/api/handlers/setup.go
+++ b/internal/api/handlers/setup.go
@@ -160,26 +160,39 @@ type discoverResult struct {
 }
 
 // Discover handles GET /api/setup/discover.
-// It checks whether we're running on a Proxmox host and scans all local
-// subnets for hosts with port 8006 open, so the wizard can suggest the URL.
+// On a Proxmox hypervisor it reads corosync.conf for authoritative cluster
+// member IPs. On other hosts it scans all local subnets for port 8006.
 func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
 	result := discoverResult{Endpoints: []string{}}
 
-	// Running directly on a Proxmox node — seed the list with this node's
-	// own IPs (avoids a localhost entry that duplicates the scanned result).
 	if _, err := os.Stat("/etc/pve"); err == nil {
 		result.IsHypervisor = true
 		result.SuggestedGateway = defaultGateway()
-		for _, ip := range localIPv4s() {
+
+		// Use corosync.conf as the authoritative cluster member list —
+		// network scanning is unreliable between Proxmox nodes (iptables).
+		for _, ip := range corosyncNodeIPs() {
 			url := "https://" + ip + ":8006"
 			if !containsStr(result.Endpoints, url) {
 				result.Endpoints = append(result.Endpoints, url)
 			}
 		}
+
+		// Single-node (not yet clustered): fall back to local interface IPs.
+		if len(result.Endpoints) == 0 {
+			for _, ip := range localIPv4s() {
+				url := "https://" + ip + ":8006"
+				if !containsStr(result.Endpoints, url) {
+					result.Endpoints = append(result.Endpoints, url)
+				}
+			}
+		}
+
+		response.Success(w, result)
+		return
 	}
 
-	// Scan all local subnets for anything with 8006 open.
-	// Use a 6-second budget to give multi-subnet clusters time to respond.
+	// Not a hypervisor — scan all local subnets for anything with 8006 open.
 	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
 	defer cancel()
 
@@ -191,6 +204,27 @@ func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response.Success(w, result)
+}
+
+// corosyncNodeIPs reads Proxmox cluster member IPs from /etc/pve/corosync.conf.
+func corosyncNodeIPs() []string {
+	data, err := os.ReadFile("/etc/pve/corosync.conf")
+	if err != nil {
+		return nil
+	}
+	var ips []string
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "ring0_addr:") {
+			continue
+		}
+		addr := strings.TrimSpace(strings.TrimPrefix(line, "ring0_addr:"))
+		if net.ParseIP(addr) != nil {
+			ips = append(ips, addr)
+		}
+	}
+	return ips
 }
 
 // scanPort8006 returns the IPs across all local subnets that have TCP 8006 open.

--- a/internal/api/handlers/setup.go
+++ b/internal/api/handlers/setup.go
@@ -178,13 +178,13 @@ func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
 	if result.IsHypervisor {
 		// Always put localhost first on hypervisors
 		result.Endpoints = append(result.Endpoints, "https://localhost:8006")
-		
+
 		// Add remote cluster nodes, skipping local IPs
 		if len(clusterIPs) > 0 {
 			localIPs := localIPv4s()
 			for _, ip := range clusterIPs {
 				if containsStr(localIPs, ip) {
-					continue // skip—localhost already covers this machine
+					continue // skip - localhost already covers this machine
 				}
 				url := "https://" + ip + ":8006"
 				if !containsStr(result.Endpoints, url) {

--- a/internal/api/handlers/setup.go
+++ b/internal/api/handlers/setup.go
@@ -1,11 +1,15 @@
 package handlers
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -150,26 +154,33 @@ func (h *Setup) Save(w http.ResponseWriter, r *http.Request) {
 }
 
 type discoverResult struct {
-	IsHypervisor bool     `json:"is_hypervisor"`
-	Endpoints    []string `json:"endpoints"`
+	IsHypervisor     bool     `json:"is_hypervisor"`
+	Endpoints        []string `json:"endpoints"`
+	SuggestedGateway string   `json:"suggested_gateway,omitempty"`
 }
 
 // Discover handles GET /api/setup/discover.
-// It checks whether we're running on a Proxmox host and scans the local
-// subnet for any hosts with port 8006 open, so the wizard can pre-fill
-// or suggest the API URL without the user having to know it.
+// It checks whether we're running on a Proxmox host and scans all local
+// subnets for hosts with port 8006 open, so the wizard can suggest the URL.
 func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
 	result := discoverResult{Endpoints: []string{}}
 
-	// Running directly on a Proxmox node — localhost always works.
+	// Running directly on a Proxmox node — seed the list with this node's
+	// own IPs (avoids a localhost entry that duplicates the scanned result).
 	if _, err := os.Stat("/etc/pve"); err == nil {
 		result.IsHypervisor = true
-		result.Endpoints = append(result.Endpoints, "https://localhost:8006")
+		result.SuggestedGateway = defaultGateway()
+		for _, ip := range localIPv4s() {
+			url := "https://" + ip + ":8006"
+			if !containsStr(result.Endpoints, url) {
+				result.Endpoints = append(result.Endpoints, url)
+			}
+		}
 	}
 
-	// Scan the local subnet for anything with 8006 open.
-	// Use a 4-second budget so the wizard feels responsive.
-	ctx, cancel := context.WithTimeout(r.Context(), 4*time.Second)
+	// Scan all local subnets for anything with 8006 open.
+	// Use a 6-second budget to give multi-subnet clusters time to respond.
+	ctx, cancel := context.WithTimeout(r.Context(), 6*time.Second)
 	defer cancel()
 
 	for _, ip := range scanPort8006(ctx) {
@@ -182,17 +193,24 @@ func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
 	response.Success(w, result)
 }
 
-// scanPort8006 returns the IPs in the local subnet that have TCP 8006 open.
+// scanPort8006 returns the IPs across all local subnets that have TCP 8006 open.
 func scanPort8006(ctx context.Context) []string {
-	subnet := localSubnet()
-	if subnet == nil {
+	seen := map[string]bool{}
+	var allHosts []string
+	for _, subnet := range localSubnets() {
+		for _, h := range subnetHosts(subnet) {
+			if !seen[h] {
+				seen[h] = true
+				allHosts = append(allHosts, h)
+			}
+		}
+	}
+	if len(allHosts) == 0 {
 		return nil
 	}
-
-	hosts := subnetHosts(subnet)
-	// Cap to avoid unreasonably long scans on large subnets.
-	if len(hosts) > 512 {
-		hosts = hosts[:512]
+	// Cap to avoid unreasonably long scans on very large subnets.
+	if len(allHosts) > 1024 {
+		allHosts = allHosts[:1024]
 	}
 
 	var (
@@ -203,18 +221,19 @@ func scanPort8006(ctx context.Context) []string {
 	)
 
 	dialer := &net.Dialer{}
-	for _, ip := range hosts {
+outer:
+	for _, ip := range allHosts {
 		ip := ip
 		select {
 		case <-ctx.Done():
-			break
+			break outer
 		case sem <- struct{}{}:
 		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
-			dialCtx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+			dialCtx, cancel := context.WithTimeout(ctx, 400*time.Millisecond)
 			defer cancel()
 			conn, err := dialer.DialContext(dialCtx, "tcp", ip+":8006")
 			if err == nil {
@@ -229,12 +248,13 @@ func scanPort8006(ctx context.Context) []string {
 	return found
 }
 
-// localSubnet returns the IPv4 subnet of the first non-loopback interface.
-func localSubnet() *net.IPNet {
+// localIPv4s returns all non-loopback IPv4 addresses on this host.
+func localIPv4s() []string {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil
 	}
+	var ips []string
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
@@ -242,11 +262,32 @@ func localSubnet() *net.IPNet {
 		addrs, _ := iface.Addrs()
 		for _, addr := range addrs {
 			if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
-				return ipNet
+				ips = append(ips, ipNet.IP.String())
 			}
 		}
 	}
-	return nil
+	return ips
+}
+
+// localSubnets returns the IPv4 subnets of all non-loopback interfaces.
+func localSubnets() []*net.IPNet {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var subnets []*net.IPNet
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
+				subnets = append(subnets, ipNet)
+			}
+		}
+	}
+	return subnets
 }
 
 // subnetHosts returns all host addresses in subnet (excludes network and broadcast).
@@ -273,6 +314,42 @@ func subnetHosts(subnet *net.IPNet) []string {
 		}
 	}
 	return hosts
+}
+
+// defaultGateway reads the default route from /proc/net/route.
+// The gateway field is a little-endian hex IPv4 address.
+func defaultGateway() string {
+	f, err := os.Open("/proc/net/route")
+	if err != nil {
+		return ""
+	}
+	defer f.Close() //nolint:errcheck
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // skip header line
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[1] != "00000000" { // destination 0.0.0.0 = default route
+			continue
+		}
+		gwHex := fields[2]
+		if len(gwHex) != 8 {
+			continue
+		}
+		b := make([]byte, 4)
+		for i := range 4 {
+			v, err := strconv.ParseUint(gwHex[i*2:i*2+2], 16, 8)
+			if err != nil {
+				return ""
+			}
+			b[3-i] = byte(v) // little-endian → network order
+		}
+		return fmt.Sprintf("%d.%d.%d.%d", b[0], b[1], b[2], b[3])
+	}
+	return ""
 }
 
 func containsStr(ss []string, s string) bool {

--- a/internal/api/handlers/setup.go
+++ b/internal/api/handlers/setup.go
@@ -1,0 +1,285 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"nimbus/internal/api/response"
+	"nimbus/internal/config"
+	"nimbus/internal/proxmox"
+)
+
+// Setup handles the first-run configuration wizard API.
+type Setup struct {
+	cfg     *config.Config
+	restart func()
+}
+
+func NewSetup(cfg *config.Config, restart func()) *Setup {
+	return &Setup{cfg: cfg, restart: restart}
+}
+
+// Status handles GET /api/setup/status.
+func (h *Setup) Status(w http.ResponseWriter, r *http.Request) {
+	response.Success(w, map[string]bool{"configured": h.cfg.IsConfigured()})
+}
+
+type testConnRequest struct {
+	ProxmoxHost        string `json:"proxmox_host"`
+	ProxmoxTokenID     string `json:"proxmox_token_id"`
+	ProxmoxTokenSecret string `json:"proxmox_token_secret"`
+}
+
+// Test handles POST /api/setup/test — probes Proxmox without persisting anything.
+func (h *Setup) Test(w http.ResponseWriter, r *http.Request) {
+	var req testConnRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	if req.ProxmoxHost == "" || req.ProxmoxTokenID == "" || req.ProxmoxTokenSecret == "" {
+		response.BadRequest(w, "proxmox_host, proxmox_token_id, and proxmox_token_secret are required")
+		return
+	}
+
+	client := proxmox.New(req.ProxmoxHost, req.ProxmoxTokenID, req.ProxmoxTokenSecret, 10*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 8*time.Second)
+	defer cancel()
+
+	version, err := client.Version(ctx)
+	if err != nil {
+		response.Error(w, http.StatusBadGateway, "cannot reach Proxmox: "+err.Error())
+		return
+	}
+	response.Success(w, map[string]string{"proxmox_version": version})
+}
+
+type saveConfigRequest struct {
+	ProxmoxHost        string `json:"proxmox_host"`
+	ProxmoxTokenID     string `json:"proxmox_token_id"`
+	ProxmoxTokenSecret string `json:"proxmox_token_secret"`
+	IPPoolStart        string `json:"ip_pool_start"`
+	IPPoolEnd          string `json:"ip_pool_end"`
+	GatewayIP          string `json:"gateway_ip"`
+	Nameserver         string `json:"nameserver"`
+	SearchDomain       string `json:"search_domain"`
+	Port               string `json:"port"`
+}
+
+// Save handles POST /api/setup/save — validates, writes the env file,
+// injects env vars, responds 200, then restarts the process to boot normally.
+func (h *Setup) Save(w http.ResponseWriter, r *http.Request) {
+	var req saveConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+
+	for _, f := range []struct{ name, value string }{
+		{"proxmox_host", req.ProxmoxHost},
+		{"proxmox_token_id", req.ProxmoxTokenID},
+		{"proxmox_token_secret", req.ProxmoxTokenSecret},
+		{"ip_pool_start", req.IPPoolStart},
+		{"ip_pool_end", req.IPPoolEnd},
+		{"gateway_ip", req.GatewayIP},
+	} {
+		if f.value == "" {
+			response.BadRequest(w, f.name+" is required")
+			return
+		}
+	}
+	for _, f := range []struct{ name, value string }{
+		{"ip_pool_start", req.IPPoolStart},
+		{"ip_pool_end", req.IPPoolEnd},
+		{"gateway_ip", req.GatewayIP},
+	} {
+		if net.ParseIP(f.value) == nil {
+			response.BadRequest(w, f.name+": invalid IP address")
+			return
+		}
+	}
+
+	if req.Nameserver == "" {
+		req.Nameserver = "1.1.1.1 8.8.8.8"
+	}
+	if req.SearchDomain == "" {
+		req.SearchDomain = "local"
+	}
+	if req.Port == "" {
+		req.Port = "8080"
+	}
+
+	envPath := config.EnvFilePath()
+	if err := config.WriteEnvFile(envPath, config.EnvValues{
+		ProxmoxHost:        req.ProxmoxHost,
+		ProxmoxTokenID:     req.ProxmoxTokenID,
+		ProxmoxTokenSecret: req.ProxmoxTokenSecret,
+		IPPoolStart:        req.IPPoolStart,
+		IPPoolEnd:          req.IPPoolEnd,
+		GatewayIP:          req.GatewayIP,
+		Nameserver:         req.Nameserver,
+		SearchDomain:       req.SearchDomain,
+		Port:               req.Port,
+	}); err != nil {
+		response.InternalError(w, "failed to write config: "+err.Error())
+		return
+	}
+
+	// Inject into the current process env so syscall.Exec picks them up.
+	_ = os.Setenv("PROXMOX_HOST", req.ProxmoxHost)
+	_ = os.Setenv("PROXMOX_TOKEN_ID", req.ProxmoxTokenID)
+	_ = os.Setenv("PROXMOX_TOKEN_SECRET", req.ProxmoxTokenSecret)
+	_ = os.Setenv("IP_POOL_START", req.IPPoolStart)
+	_ = os.Setenv("IP_POOL_END", req.IPPoolEnd)
+	_ = os.Setenv("GATEWAY_IP", req.GatewayIP)
+	_ = os.Setenv("NAMESERVER", req.Nameserver)
+	_ = os.Setenv("SEARCH_DOMAIN", req.SearchDomain)
+	_ = os.Setenv("PORT", req.Port)
+
+	response.Success(w, map[string]string{"message": "configuration saved"})
+
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		h.restart()
+	}()
+}
+
+type discoverResult struct {
+	IsHypervisor bool     `json:"is_hypervisor"`
+	Endpoints    []string `json:"endpoints"`
+}
+
+// Discover handles GET /api/setup/discover.
+// It checks whether we're running on a Proxmox host and scans the local
+// subnet for any hosts with port 8006 open, so the wizard can pre-fill
+// or suggest the API URL without the user having to know it.
+func (h *Setup) Discover(w http.ResponseWriter, r *http.Request) {
+	result := discoverResult{Endpoints: []string{}}
+
+	// Running directly on a Proxmox node — localhost always works.
+	if _, err := os.Stat("/etc/pve"); err == nil {
+		result.IsHypervisor = true
+		result.Endpoints = append(result.Endpoints, "https://localhost:8006")
+	}
+
+	// Scan the local subnet for anything with 8006 open.
+	// Use a 4-second budget so the wizard feels responsive.
+	ctx, cancel := context.WithTimeout(r.Context(), 4*time.Second)
+	defer cancel()
+
+	for _, ip := range scanPort8006(ctx) {
+		url := "https://" + ip + ":8006"
+		if !containsStr(result.Endpoints, url) {
+			result.Endpoints = append(result.Endpoints, url)
+		}
+	}
+
+	response.Success(w, result)
+}
+
+// scanPort8006 returns the IPs in the local subnet that have TCP 8006 open.
+func scanPort8006(ctx context.Context) []string {
+	subnet := localSubnet()
+	if subnet == nil {
+		return nil
+	}
+
+	hosts := subnetHosts(subnet)
+	// Cap to avoid unreasonably long scans on large subnets.
+	if len(hosts) > 512 {
+		hosts = hosts[:512]
+	}
+
+	var (
+		mu    sync.Mutex
+		found []string
+		sem   = make(chan struct{}, 128)
+		wg    sync.WaitGroup
+	)
+
+	dialer := &net.Dialer{}
+	for _, ip := range hosts {
+		ip := ip
+		select {
+		case <-ctx.Done():
+			break
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			dialCtx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+			defer cancel()
+			conn, err := dialer.DialContext(dialCtx, "tcp", ip+":8006")
+			if err == nil {
+				_ = conn.Close()
+				mu.Lock()
+				found = append(found, ip)
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return found
+}
+
+// localSubnet returns the IPv4 subnet of the first non-loopback interface.
+func localSubnet() *net.IPNet {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			if ipNet, ok := addr.(*net.IPNet); ok && ipNet.IP.To4() != nil {
+				return ipNet
+			}
+		}
+	}
+	return nil
+}
+
+// subnetHosts returns all host addresses in subnet (excludes network and broadcast).
+func subnetHosts(subnet *net.IPNet) []string {
+	var hosts []string
+	// Start from the network base address.
+	base := subnet.IP.To4()
+	if base == nil {
+		return nil
+	}
+	ip := make(net.IP, 4)
+	copy(ip, base)
+	for subnet.Contains(ip) {
+		// Skip network address (.0) and broadcast (.255).
+		if ip[3] != 0 && ip[3] != 255 {
+			hosts = append(hosts, ip.String())
+		}
+		// Increment in place.
+		for i := 3; i >= 0; i-- {
+			ip[i]++
+			if ip[i] != 0 {
+				break
+			}
+		}
+	}
+	return hosts
+}
+
+func containsStr(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"nimbus/internal/api/handlers"
+	"nimbus/internal/config"
 	"nimbus/internal/ippool"
 	"nimbus/internal/provision"
 	"nimbus/internal/proxmox"
@@ -20,9 +21,11 @@ type Deps struct {
 	Provision *provision.Service
 	Pool      *ippool.Pool
 	Proxmox   *proxmox.Client
+	Config    *config.Config
+	Restart   func()
 }
 
-// NewRouter builds and returns the application router.
+// NewRouter builds and returns the application router for normal (configured) mode.
 func NewRouter(d Deps) http.Handler {
 	r := chi.NewRouter()
 
@@ -36,9 +39,11 @@ func NewRouter(d Deps) http.Handler {
 	vms := handlers.NewVMs(d.Provision)
 	nodes := handlers.NewNodes(d.Proxmox)
 	ips := handlers.NewIPs(d.Pool)
+	setup := handlers.NewSetup(d.Config, d.Restart)
 
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/health", health.Check)
+		r.Get("/setup/status", setup.Status)
 
 		r.Get("/nodes", nodes.List)
 		r.Get("/ips", ips.List)
@@ -51,6 +56,32 @@ func NewRouter(d Deps) http.Handler {
 			r.Post("/", vms.Create)
 			r.Get("/{id}", vms.Get)
 		})
+	})
+
+	return r
+}
+
+// NewSetupRouter builds a minimal router for unconfigured (setup) mode.
+// Only setup and health routes are registered; all other API calls 404.
+func NewSetupRouter(cfg *config.Config, restart func()) http.Handler {
+	r := chi.NewRouter()
+
+	r.Use(middleware.RequestID)
+	r.Use(corsMiddleware)
+	r.Use(loggingMiddleware)
+	r.Use(recoveryMiddleware)
+
+	setup := handlers.NewSetup(cfg, restart)
+
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"status":"setup"}}`))
+		})
+		r.Get("/setup/status", setup.Status)
+		r.Get("/setup/discover", setup.Discover)
+		r.Post("/setup/test", setup.Test)
+		r.Post("/setup/save", setup.Save)
 	})
 
 	return r

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,64 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
+// IsConfigured reports whether all required fields are present.
+// Used to decide between setup mode and normal startup.
+func (c *Config) IsConfigured() bool {
+	return c.ProxmoxHost != "" &&
+		c.ProxmoxTokenID != "" &&
+		c.ProxmoxTokenSecret != "" &&
+		c.IPPoolStart != "" &&
+		c.IPPoolEnd != "" &&
+		c.GatewayIP != ""
+}
+
+// EnvValues holds the fields written by the setup wizard.
+type EnvValues struct {
+	ProxmoxHost        string
+	ProxmoxTokenID     string
+	ProxmoxTokenSecret string
+	IPPoolStart        string
+	IPPoolEnd          string
+	GatewayIP          string
+	Nameserver         string
+	SearchDomain       string
+	Port               string
+}
+
+// EnvFilePath returns the path where the runtime config should be written.
+// Uses /etc/nimbus/nimbus.env when that directory exists and is writable
+// (i.e. production after `nimbus install`), otherwise .env in the CWD.
+func EnvFilePath() string {
+	const prod = "/etc/nimbus/nimbus.env"
+	if fi, err := os.Stat("/etc/nimbus"); err == nil && fi.IsDir() {
+		if f, err := os.OpenFile(prod, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600); err == nil {
+			_ = f.Close()
+			return prod
+		}
+	}
+	return ".env"
+}
+
+// WriteEnvFile writes v to path as KEY=VALUE pairs, replacing any existing file.
+func WriteEnvFile(path string, v EnvValues) error {
+	content := fmt.Sprintf(
+		"# Nimbus configuration — written by setup wizard.\n"+
+			"PROXMOX_HOST=%s\n"+
+			"PROXMOX_TOKEN_ID=%s\n"+
+			"PROXMOX_TOKEN_SECRET=%s\n"+
+			"IP_POOL_START=%s\n"+
+			"IP_POOL_END=%s\n"+
+			"GATEWAY_IP=%s\n"+
+			"NAMESERVER=%s\n"+
+			"SEARCH_DOMAIN=%s\n"+
+			"PORT=%s\n",
+		v.ProxmoxHost, v.ProxmoxTokenID, v.ProxmoxTokenSecret,
+		v.IPPoolStart, v.IPPoolEnd, v.GatewayIP,
+		v.Nameserver, v.SearchDomain, v.Port,
+	)
+	return os.WriteFile(path, []byte(content), 0600)
+}
+
 // Validate returns an error listing any missing required fields. Optional
 // integrations (OAuth, Gopher) are not checked.
 func (c *Config) Validate() error {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -94,10 +94,15 @@ func createDirs() error {
 }
 
 func createUser() error {
-	if exec.Command("id", serviceUser).Run() == nil {
-		return nil // already exists
+	if exec.Command("id", serviceUser).Run() != nil {
+		if err := exec.Command("useradd", "-r", "-s", "/usr/sbin/nologin", "-d", dataDir, serviceUser).Run(); err != nil {
+			return err
+		}
 	}
-	return exec.Command("useradd", "-r", "-s", "/usr/sbin/nologin", "-d", dataDir, serviceUser).Run()
+	// www-data group owns /etc/pve (Proxmox cluster filesystem) — membership
+	// lets Nimbus read corosync.conf for cluster node discovery.
+	_ = exec.Command("usermod", "-a", "-G", "www-data", serviceUser).Run()
+	return nil
 }
 
 func installBinary() error {

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -185,6 +185,6 @@ func primaryIP() string {
 	if err != nil {
 		return "localhost"
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck
 	return conn.LocalAddr().(*net.UDPAddr).IP.String()
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -1,0 +1,190 @@
+// Package install implements the `nimbus install` subcommand.
+// It copies the running binary to /opt/nimbus, creates a dedicated service
+// user, writes the systemd unit, enables the service, and writes a sudoers
+// rule so future upgrades don't require a password.
+//
+// Configuration is NOT collected here — the server starts in setup mode and
+// the web wizard at http://<host>:8080 handles configuration.
+package install
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+)
+
+const (
+	installDir  = "/opt/nimbus"
+	dataDir     = "/var/lib/nimbus"
+	envDir      = "/etc/nimbus"
+	envFile     = "/etc/nimbus/nimbus.env"
+	serviceFile = "/etc/systemd/system/nimbus.service"
+	sudoersFile = "/etc/sudoers.d/nimbus"
+	serviceUser = "nimbus"
+	appName     = "nimbus"
+)
+
+// Run executes the install subcommand. If not running as root it re-execs
+// itself via sudo (which may be passwordless after the first install
+// thanks to the sudoers rule written below).
+func Run() {
+	if runtime.GOOS != "linux" {
+		fatalf("nimbus install only supports Linux")
+	}
+
+	if os.Getuid() != 0 {
+		selfExecWithSudo()
+		return
+	}
+
+	fmt.Println("\nNimbus Installer")
+	fmt.Println("────────────────────────────────────────────────")
+	step("Creating directories", createDirs)
+	step("Creating service user", createUser)
+	step("Installing binary", installBinary)
+	step("Writing env file stub", writeEnvStub)
+	step("Writing systemd unit", writeServiceUnit)
+	step("Writing sudoers rule", writeSudoers)
+	step("Enabling & starting service", startService)
+
+	ip := primaryIP()
+	fmt.Printf("\n✅ Nimbus installed.\n")
+	fmt.Printf("   Open http://%s:8080 to complete setup.\n\n", ip)
+}
+
+func selfExecWithSudo() {
+	exe, err := os.Executable()
+	if err != nil {
+		fatalf("cannot determine executable path: %v", err)
+	}
+	if abs, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = abs
+	}
+	args := append([]string{"sudo", exe}, os.Args[1:]...)
+	if err := syscall.Exec("/usr/bin/sudo", args, os.Environ()); err != nil {
+		fatalf("re-exec with sudo failed\nTry: sudo %s install\n%v", exe, err)
+	}
+}
+
+func step(label string, fn func() error) {
+	fmt.Printf("  → %-36s", label+"...")
+	if err := fn(); err != nil {
+		fmt.Printf("✗\n\nError: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("✓")
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func createDirs() error {
+	for _, p := range []string{installDir, dataDir, envDir} {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", p, err)
+		}
+	}
+	return nil
+}
+
+func createUser() error {
+	if exec.Command("id", serviceUser).Run() == nil {
+		return nil // already exists
+	}
+	return exec.Command("useradd", "-r", "-s", "/usr/sbin/nologin", "-d", dataDir, serviceUser).Run()
+}
+
+func installBinary() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate self: %w", err)
+	}
+	if abs, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = abs
+	}
+	data, err := os.ReadFile(exe)
+	if err != nil {
+		return fmt.Errorf("read binary: %w", err)
+	}
+	dest := filepath.Join(installDir, appName)
+	if err := os.WriteFile(dest, data, 0755); err != nil {
+		return fmt.Errorf("write binary: %w", err)
+	}
+	_ = exec.Command("chown", "-R", serviceUser+":"+serviceUser, dataDir).Run()
+	return nil
+}
+
+func writeEnvStub() error {
+	if _, err := os.Stat(envFile); err == nil {
+		return nil // preserve existing config on reinstall/upgrade
+	}
+	stub := "# Nimbus configuration — complete setup at http://<host>:8080\n"
+	if err := os.WriteFile(envFile, []byte(stub), 0600); err != nil {
+		return err
+	}
+	// The nimbus service user must be able to write this file so the web
+	// wizard can save configuration without root.
+	return exec.Command("chown", serviceUser+":"+serviceUser, envDir, envFile).Run()
+}
+
+// serviceUnit is embedded as a constant so the binary carries the unit file
+// without needing any external templates.
+const serviceUnit = `[Unit]
+Description=Nimbus VM provisioning portal
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=nimbus
+WorkingDirectory=/var/lib/nimbus
+EnvironmentFile=-/etc/nimbus/nimbus.env
+ExecStart=/opt/nimbus/nimbus
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/nimbus /etc/nimbus
+
+[Install]
+WantedBy=multi-user.target
+`
+
+func writeServiceUnit() error {
+	if err := os.WriteFile(serviceFile, []byte(serviceUnit), 0644); err != nil {
+		return err
+	}
+	return exec.Command("systemctl", "daemon-reload").Run()
+}
+
+// sudoersRule allows the sudo group to run `nimbus install` without a
+// password prompt so upgrades and reconfigures don't need manual root.
+const sudoersRule = `# Nimbus: passwordless install/upgrade for sudo group members.
+%sudo ALL=(root) NOPASSWD: /opt/nimbus/nimbus install
+`
+
+func writeSudoers() error {
+	return os.WriteFile(sudoersFile, []byte(sudoersRule), 0440)
+}
+
+func startService() error {
+	_ = exec.Command("systemctl", "enable", appName).Run()
+	return exec.Command("systemctl", "restart", appName).Run()
+}
+
+func primaryIP() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return "localhost"
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP.String()
+}

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 # Reinstall: build a new binary and hot-swap the running systemd service.
+# --clean  also wipes config and database (runs uninstall --yes then install)
 set -e
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="nimbus"
 INSTALL_DIR="/opt/$APP_NAME"
+
+CLEAN=0
+for arg in "$@"; do
+  [[ "$arg" == "--clean" ]] && CLEAN=1
+done
 
 # Require root
 if [ "$EUID" -ne 0 ]; then
@@ -15,12 +21,18 @@ fi
 echo "Rebuilding $APP_NAME..."
 "$ROOT/scripts/build.sh"
 
-echo "Swapping binary..."
-systemctl daemon-reload
-systemctl stop "$APP_NAME"
-cp "$ROOT/$APP_NAME" "$INSTALL_DIR/$APP_NAME"
-chown "$APP_NAME:$APP_NAME" "$INSTALL_DIR/$APP_NAME"
-systemctl start "$APP_NAME"
+if [ "$CLEAN" -eq 1 ]; then
+  echo "Clean reinstall — wiping existing install..."
+  "$ROOT/scripts/uninstall.sh" --yes
+  "$ROOT/$APP_NAME" install
+else
+  echo "Swapping binary..."
+  systemctl daemon-reload
+  systemctl stop "$APP_NAME"
+  cp "$ROOT/$APP_NAME" "$INSTALL_DIR/$APP_NAME"
+  chown "$APP_NAME:$APP_NAME" "$INSTALL_DIR/$APP_NAME"
+  systemctl start "$APP_NAME"
+fi
 
 echo "✅ Reinstall complete"
 systemctl status "$APP_NAME" --no-pager

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Removes everything written by `nimbus install`:
+#   systemd unit, binary, service user, env file, sudoers rule, data dir.
+# Prompts before deleting the database and config unless --yes is passed.
+set -euo pipefail
+
+APP_NAME="nimbus"
+INSTALL_DIR="/opt/$APP_NAME"
+DATA_DIR="/var/lib/$APP_NAME"
+ENV_DIR="/etc/$APP_NAME"
+SERVICE_FILE="/etc/systemd/system/${APP_NAME}.service"
+SUDOERS_FILE="/etc/sudoers.d/$APP_NAME"
+
+YES=0
+for arg in "$@"; do
+  [[ "$arg" == "--yes" || "$arg" == "-y" ]] && YES=1
+done
+
+if [ "$EUID" -ne 0 ]; then
+  echo "error: must be run as root (sudo $0)"
+  exit 1
+fi
+
+confirm() {
+  [[ "$YES" -eq 1 ]] && return 0
+  read -rp "  $1 [y/N]: " ans
+  [[ "$ans" =~ ^[Yy]$ ]]
+}
+
+echo ""
+echo "Nimbus Uninstaller"
+echo "──────────────────────────────────────────────"
+
+# Stop and disable service
+if systemctl is-active --quiet "$APP_NAME" 2>/dev/null; then
+  echo "  → Stopping service..."
+  systemctl stop "$APP_NAME"
+fi
+if systemctl is-enabled --quiet "$APP_NAME" 2>/dev/null; then
+  echo "  → Disabling service..."
+  systemctl disable "$APP_NAME"
+fi
+
+# Remove systemd unit
+if [ -f "$SERVICE_FILE" ]; then
+  rm -f "$SERVICE_FILE"
+  systemctl daemon-reload
+  echo "  ✓ Removed $SERVICE_FILE"
+fi
+
+# Remove sudoers rule
+if [ -f "$SUDOERS_FILE" ]; then
+  rm -f "$SUDOERS_FILE"
+  echo "  ✓ Removed $SUDOERS_FILE"
+fi
+
+# Remove binary
+if [ -d "$INSTALL_DIR" ]; then
+  rm -rf "$INSTALL_DIR"
+  echo "  ✓ Removed $INSTALL_DIR"
+fi
+
+# Config + database — ask unless --yes
+if [ -d "$ENV_DIR" ]; then
+  if confirm "Delete config & database in $ENV_DIR and $DATA_DIR? (irreversible)"; then
+    rm -rf "$ENV_DIR" "$DATA_DIR"
+    echo "  ✓ Removed $ENV_DIR and $DATA_DIR"
+  else
+    echo "  ↷ Kept $ENV_DIR and $DATA_DIR"
+  fi
+fi
+
+# Remove service user
+if id "$APP_NAME" &>/dev/null; then
+  userdel "$APP_NAME" 2>/dev/null || true
+  echo "  ✓ Removed user $APP_NAME"
+fi
+
+echo ""
+echo "✅ Nimbus uninstalled."
+echo "   Run ./nimbus install to reinstall."
+echo ""


### PR DESCRIPTION
## Description
Replaces the bash install wizard with a web-based first-run setup wizard and adds a `./nimbus install` CLI subcommand to handle system-level installation (binary, systemd unit, service user, sudoers).

Resolves #__

## Changes Made
- **`./nimbus install` subcommand** — self-elevates via sudo, copies binary to `/opt/nimbus`, creates `nimbus` service user, writes systemd unit with optional `EnvironmentFile` (so service starts in setup mode before config exists), writes `/etc/sudoers.d/nimbus` for passwordless future upgrades
- **Server setup mode** — server starts normally when unconfigured but only exposes setup routes (`/api/setup/status`, `/api/setup/discover`, `/api/setup/test`, `/api/setup/save`); after config is saved it restarts itself via `syscall.Exec` with the new env vars injected
- **Web setup wizard** — 3-step (+ 2 placeholder) first-run wizard: Proxmox connection, network/IP pool, review & save
- **Proxmox discovery** — `GET /api/setup/discover` detects if running on a Proxmox hypervisor and scans the local subnet for port 8006, surfaced in the wizard as clickable endpoint chips
- **Token creation guide** — collapsible step-by-step walkthrough in the wizard for users unfamiliar with Proxmox API tokens; step 5 (uncheck Privilege Separation) highlighted in amber
- **`scripts/uninstall.sh`** — tears down everything written by `nimbus install`; prompts before deleting config/DB, `--yes` to skip
- Removed `scripts/install.sh` (superseded by `./nimbus install`)
- README: renamed project to Nimbus (was NimbusX), removed org-specific references, added mockup link and expanded Phase 2 description

## Testing
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<img width="815" height="904" alt="image" src="https://github.com/user-attachments/assets/e06adc83-be74-4016-947c-2806bb83b1eb" />
<img width="774" height="889" alt="image" src="https://github.com/user-attachments/assets/eb58297c-1395-4363-8fa6-6a90e5ad2556" />
<img width="786" height="565" alt="image" src="https://github.com/user-attachments/assets/b45ba3a2-c9ec-4005-9018-2972f300a06c" />

Step 2:
<img width="835" height="809" alt="image" src="https://github.com/user-attachments/assets/249a671e-b4e9-4305-ae88-3add9d35691c" />
<img width="814" height="653" alt="image" src="https://github.com/user-attachments/assets/00307940-4608-4b37-a5e7-0184c4d6e1d4" />


Step 3:
<img width="778" height="938" alt="image" src="https://github.com/user-attachments/assets/3629a53f-40de-4aef-b05d-c2994b777c40" />

