### PR TITLE
Runtime network settings + UI updates + VM controls

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -224,10 +224,54 @@ func main() {
 	}
 	migCancel()
 
+	// hypervisorReachabilityProbe TCP-dials each cluster node's pveproxy port
+	// and returns the names of nodes that didn't answer. Reused by both
+	// reconcilers below — when a node is unreachable the reconciler treats
+	// its VMs as still-alive-just-out-of-sight rather than reaping the rows
+	// after VACATE_MISS_THRESHOLD cycles. 1 s timeout per node, fans out
+	// concurrently so a 5-node cluster with 2 dead nodes still completes
+	// the probe in ~1 s rather than 5.
+	hypervisorReachabilityProbe := func(ctx context.Context) map[string]bool {
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		addrs, err := pveClient.NodeAddresses(probeCtx)
+		if err != nil {
+			log.Printf("reachability: NodeAddresses failed (treating all nodes as reachable): %v", err)
+			return nil
+		}
+		return proxmox.ProbeReachability(probeCtx, addrs, 1*time.Second)
+	}
+
+	// unreachableVMIDsForReconciler maps node-level reachability into the
+	// vmid set the ippool reconciler consumes. The local vms table is the
+	// only place we know which VMID lives on which node, so the lookup
+	// happens here rather than inside the reconciler package.
+	unreachableVMIDsForReconciler := func(ctx context.Context) map[int]bool {
+		unreachable := hypervisorReachabilityProbe(ctx)
+		if len(unreachable) == 0 {
+			return nil
+		}
+		nodes := make([]string, 0, len(unreachable))
+		for n := range unreachable {
+			nodes = append(nodes, n)
+		}
+		var vms []db.VM
+		if err := database.WithContext(ctx).Where("node IN ?", nodes).Find(&vms).Error; err != nil {
+			log.Printf("reachability: vmid lookup failed (skipping guard this cycle): %v", err)
+			return nil
+		}
+		out := make(map[int]bool, len(vms))
+		for _, v := range vms {
+			out[v.VMID] = true
+		}
+		return out
+	}
+
 	reconciler := ippool.NewReconciler(pool, pveClient,
 		ippool.WithStaleAfter(time.Duration(cfg.ReservationTTLSeconds)*time.Second),
 		ippool.WithCacheTTL(time.Duration(cfg.VerifyCacheTTLSeconds)*time.Second),
 		ippool.WithMissThreshold(cfg.VacateMissThreshold),
+		ippool.WithUnreachableVMIDs(unreachableVMIDsForReconciler),
 	)
 
 	// Startup reconcile: bounded so a temporarily unreachable Proxmox doesn't
@@ -391,7 +435,10 @@ func main() {
 
 	// VM-table reconciler: keeps vms.node in sync with Proxmox migrations and
 	// soft-deletes orphan rows whose VMID hasn't been observed for N
-	// consecutive runs. Same cadence as the IP reconciler.
+	// consecutive runs. Same cadence as the IP reconciler. The reachability
+	// probe — same one the ippool reconciler uses — keeps a flapping node
+	// from cascading into a soft-delete of every row living there.
+	provSvc.SetUnreachableNodesProbe(hypervisorReachabilityProbe)
 	go runVMReconcileLoop(bgCtx, provSvc, time.Duration(cfg.ReconcileIntervalSeconds)*time.Second)
 
 	bootstrapSvc := bootstrap.New(pveClient, database.DB, bootstrap.Config{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -116,7 +116,7 @@ func main() {
 
 	database, err := db.New(cfg.DBPath,
 		&db.User{}, &db.Session{}, &db.OAuthSettings{}, &db.GopherSettings{},
-		&db.GPUSettings{}, &db.GPUJob{},
+		&db.GPUSettings{}, &db.GPUJob{}, &db.NetworkSettings{},
 		&db.VM{}, &db.NodeTemplate{}, &db.SSHKey{}, &db.S3Storage{},
 		ippool.Model(),
 	)
@@ -152,8 +152,44 @@ func main() {
 		log.Printf("backfill: promoted oldest user to admin (no admin existed)")
 	}
 
+	// Network settings: env vars seed the DB row on first boot; after that the
+	// Settings → Network page is the source of truth and live-rotates the
+	// gateway/pool without a restart. Same pattern as Gopher.
+	netSettings, err := authSvc.GetNetworkSettings()
+	if err != nil {
+		log.Fatalf("failed to load network settings: %v", err)
+	}
+	if netSettings.IPPoolStart == "" && netSettings.IPPoolEnd == "" && netSettings.GatewayIP == "" &&
+		(cfg.IPPoolStart != "" || cfg.IPPoolEnd != "" || cfg.GatewayIP != "") {
+		if err := authSvc.SaveNetworkSettings(db.NetworkSettings{
+			IPPoolStart: cfg.IPPoolStart,
+			IPPoolEnd:   cfg.IPPoolEnd,
+			GatewayIP:   cfg.GatewayIP,
+		}); err != nil {
+			log.Printf("warning: failed to seed network settings from env: %v", err)
+		} else {
+			log.Printf("seeded network settings from env vars (one-time migration)")
+			netSettings.IPPoolStart = cfg.IPPoolStart
+			netSettings.IPPoolEnd = cfg.IPPoolEnd
+			netSettings.GatewayIP = cfg.GatewayIP
+		}
+	}
+	// DB wins after seeding; the live values feed pool seed + provision gateway.
+	effectivePoolStart := netSettings.IPPoolStart
+	effectivePoolEnd := netSettings.IPPoolEnd
+	effectiveGateway := netSettings.GatewayIP
+	if effectivePoolStart == "" {
+		effectivePoolStart = cfg.IPPoolStart
+	}
+	if effectivePoolEnd == "" {
+		effectivePoolEnd = cfg.IPPoolEnd
+	}
+	if effectiveGateway == "" {
+		effectiveGateway = cfg.GatewayIP
+	}
+
 	pool := ippool.New(database.DB)
-	if err := pool.Seed(context.Background(), cfg.IPPoolStart, cfg.IPPoolEnd); err != nil {
+	if err := pool.Seed(context.Background(), effectivePoolStart, effectivePoolEnd); err != nil {
 		log.Fatalf("failed to seed IP pool: %v", err)
 	}
 
@@ -228,7 +264,7 @@ func main() {
 	provSvc := provision.New(pveClient, pool, database.DB, cipher, keysSvc, provision.Config{
 		TemplateBaseVMID: cfg.ProxmoxTemplateBaseVMID,
 		ExcludedNodes:    cfg.ExcludedNodes,
-		GatewayIP:        cfg.GatewayIP,
+		GatewayIP:        effectiveGateway,
 		Nameserver:       cfg.Nameserver,
 		SearchDomain:     cfg.SearchDomain,
 		CPUType:          cfg.VMCPUType,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -389,6 +389,11 @@ func main() {
 	}
 	tagColorCancel()
 
+	// VM-table reconciler: keeps vms.node in sync with Proxmox migrations and
+	// soft-deletes orphan rows whose VMID hasn't been observed for N
+	// consecutive runs. Same cadence as the IP reconciler.
+	go runVMReconcileLoop(bgCtx, provSvc, time.Duration(cfg.ReconcileIntervalSeconds)*time.Second)
+
 	bootstrapSvc := bootstrap.New(pveClient, database.DB, bootstrap.Config{
 		TemplateBaseVMID: cfg.ProxmoxTemplateBaseVMID,
 	})
@@ -641,6 +646,37 @@ func runNetscanLoop(ctx context.Context, r *netscan.Reconciler, interval time.Du
 			return
 		case <-t.C:
 			runOnce()
+		}
+	}
+}
+
+// runVMReconcileLoop runs provSvc.ReconcileVMs every interval until ctx is
+// cancelled. Mirrors runReconcileLoop's shape — errors are logged, never
+// fatal. Skips quietly when the cluster snapshot is empty (transient API
+// issue) so a Proxmox blip doesn't soft-delete every row in one cycle.
+func runVMReconcileLoop(ctx context.Context, svc *provision.Service, interval time.Duration) {
+	if interval <= 0 {
+		log.Printf("vm-reconcile loop disabled (interval=%v)", interval)
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			runCtx, cancel := context.WithTimeout(ctx, interval)
+			rep, err := svc.ReconcileVMs(runCtx)
+			cancel()
+			if err != nil {
+				log.Printf("background vm-reconcile error: %v", err)
+				continue
+			}
+			if len(rep.Migrated) > 0 || len(rep.Deleted) > 0 {
+				log.Printf("background vm-reconcile: migrated=%d missed=%d deleted=%d",
+					len(rep.Migrated), len(rep.Missed), len(rep.Deleted))
+			}
 		}
 	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import GopherTunnels from '@/pages/GopherTunnels'
 import GPU from '@/pages/GPU'
 import GPUHost from '@/pages/GPUHost'
 import Keys from '@/pages/Keys'
+import Network from '@/pages/Network'
 import Provision from '@/pages/Provision'
 import MyVMs from '@/pages/MyVMs'
 import S3 from '@/pages/S3'
@@ -88,6 +89,7 @@ export default function App() {
                       <Route path="/gpu" element={<GPU />} />
                       <Route path="/settings" element={<RequireAdmin><Settings /></RequireAdmin>} />
                       <Route path="/gophers" element={<RequireAdmin><GopherTunnels /></RequireAdmin>} />
+                      <Route path="/network" element={<RequireAdmin><Network /></RequireAdmin>} />
                       <Route path="/s3" element={<RequireAdmin><S3 /></RequireAdmin>} />
                       <Route path="/gpu-host" element={<RequireAdmin><GPUHost /></RequireAdmin>} />
                       <Route path="/admin" element={<RequireAdmin><Admin /></RequireAdmin>} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -256,6 +256,27 @@ export async function adminDeleteVM(id: number): Promise<void> {
   await api.delete(`/cluster/vms/${id}`)
 }
 
+export type VMLifecycleOp = 'start' | 'shutdown' | 'stop' | 'reboot'
+
+// vmLifecycle issues a power op against the caller's own VM. Owner-gated;
+// requesting ops on someone else's VM returns 404. Reboots can take ~30s
+// while the Proxmox task drains, so the timeout is generous.
+export async function vmLifecycle(id: number, op: VMLifecycleOp): Promise<void> {
+  await api.post(`/vms/${id}/${op}`, undefined, { timeout: 2 * 60 * 1000 })
+}
+
+// adminVMLifecycle issues a power op against any cluster VM (local /
+// foreign / external) by (node, vmid). Admin-only.
+export async function adminVMLifecycle(
+  node: string,
+  vmid: number,
+  op: VMLifecycleOp,
+): Promise<void> {
+  await api.post(`/cluster/vms/${encodeURIComponent(node)}/${vmid}/${op}`, undefined, {
+    timeout: 2 * 60 * 1000,
+  })
+}
+
 export interface VMTunnel {
   id: string
   machine_id: string

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -822,4 +822,45 @@ export async function forceGatewayUpdate(): Promise<NetworkOpReport> {
   return data
 }
 
+export interface VMReconcileMigration {
+  vm_row_id: number
+  vmid: number
+  hostname: string
+  from_node: string
+  to_node: string
+}
+
+export interface VMReconcileMiss {
+  vm_row_id: number
+  vmid: number
+  hostname: string
+  node: string
+  missed_cycles: number
+}
+
+export interface VMReconcileDeleted {
+  vm_row_id: number
+  vmid: number
+  hostname: string
+  node: string
+}
+
+export interface VMReconcileReport {
+  migrated: VMReconcileMigration[]
+  missed: VMReconcileMiss[]
+  deleted: VMReconcileDeleted[]
+  no_ops: number
+  snapshot_at: string
+}
+
+// reconcileVMs walks the local vms table against the live Proxmox cluster.
+// Updates rows whose VMs migrated to a different node, soft-deletes rows
+// whose VMID hasn't been seen for the configured miss threshold, and reports
+// rows that are still under threshold so the operator sees them going stale.
+// The backend refuses (400) when Proxmox returns an empty cluster snapshot.
+export async function reconcileVMs(): Promise<VMReconcileReport> {
+  const { data } = await api.post<VMReconcileReport>('/vms/reconcile', {})
+  return data
+}
+
 export default api

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -763,4 +763,63 @@ export async function unpairGX10(): Promise<GPUUnpairView> {
   return data
 }
 
+export interface NetworkSettingsView {
+  ip_pool_start: string
+  ip_pool_end: string
+  gateway_ip: string
+}
+
+export interface SaveNetworkSettingsRequest {
+  ip_pool_start?: string
+  ip_pool_end?: string
+  gateway_ip?: string
+}
+
+export async function getNetworkSettings(): Promise<NetworkSettingsView> {
+  const { data } = await api.get<NetworkSettingsView>('/settings/network')
+  return data
+}
+
+export async function saveNetworkSettings(
+  req: SaveNetworkSettingsRequest,
+): Promise<NetworkSettingsView> {
+  const { data } = await api.put<NetworkSettingsView>('/settings/network', req)
+  return data
+}
+
+export interface NetworkOpFailure {
+  vm_row_id: number
+  vmid: number
+  hostname: string
+  error: string
+}
+
+export interface NetworkOpReport {
+  updated: number
+  failures: NetworkOpFailure[]
+}
+
+// renumberAllVMs reassigns every managed VM to a fresh IP from the saved pool
+// and reboots them. The current saved gateway is used. Long-running — every
+// VM bounces in sequence.
+export async function renumberAllVMs(): Promise<NetworkOpReport> {
+  const { data } = await api.post<NetworkOpReport>(
+    '/settings/network/renumber-vms',
+    {},
+    { timeout: 15 * 60 * 1000 },
+  )
+  return data
+}
+
+// forceGatewayUpdate pushes the saved gateway to every managed VM via
+// `qm set --ipconfig0` and reboots them. Each VM keeps its existing IP.
+export async function forceGatewayUpdate(): Promise<NetworkOpReport> {
+  const { data } = await api.post<NetworkOpReport>(
+    '/settings/network/force-gateway-update',
+    {},
+    { timeout: 15 * 60 * 1000 },
+  )
+  return data
+}
+
 export default api

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -149,6 +149,9 @@ export default function Layout({ children, showNav = true }: LayoutProps) {
                   <NavLink to="/gophers" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
                     Gopher Tunnels
                   </NavLink>
+                  <NavLink to="/network" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
+                    Network
+                  </NavLink>
                   {/* When S3 is deployed the link is promoted to a top-level
                       navbar item; hiding the dropdown entry avoids duplication. */}
                   {!s3Deployed && (

--- a/frontend/src/components/ui/NavDropdown.tsx
+++ b/frontend/src/components/ui/NavDropdown.tsx
@@ -1,4 +1,5 @@
-import { KeyboardEvent, ReactNode, useEffect, useRef, useState } from 'react'
+import { KeyboardEvent, ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 type Placement = 'bottom-end' | 'right-start' | 'left-start'
 
@@ -33,14 +34,26 @@ export default function NavDropdown({
   const [open, setOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
   const closeTimer = useRef<number | null>(null)
+
+  // Trigger position, recomputed every time we render the click-mode panel
+  // so it tracks scroll/resize. Used only when triggerOn==='click', which
+  // portals the panel to <body> with position:fixed — necessary because
+  // ancestor `.glass` cards establish a stacking context (backdrop-filter)
+  // that traps an absolute-positioned panel inside the row.
+  const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null)
+  const portalMode = triggerOn === 'click'
 
   useEffect(() => {
     if (!open) return
     const handleDocClick = (e: MouseEvent) => {
-      if (!wrapperRef.current?.contains(e.target as Node)) {
-        setOpen(false)
-      }
+      const target = e.target as Node
+      if (wrapperRef.current?.contains(target)) return
+      // In portal mode the panel is outside the wrapper — also exempt clicks
+      // inside the panel itself so a menu-item button can fire before close.
+      if (panelRef.current?.contains(target)) return
+      setOpen(false)
     }
     document.addEventListener('mousedown', handleDocClick)
     return () => document.removeEventListener('mousedown', handleDocClick)
@@ -53,6 +66,25 @@ export default function NavDropdown({
       }
     }
   }, [])
+
+  // Recompute the portal panel's position whenever it opens, and keep it in
+  // sync with viewport scroll/resize so the menu doesn't drift away from
+  // its trigger when the user scrolls the table behind it.
+  useLayoutEffect(() => {
+    if (!open || !portalMode) return
+    const update = () => {
+      if (triggerRef.current) {
+        setTriggerRect(triggerRef.current.getBoundingClientRect())
+      }
+    }
+    update()
+    window.addEventListener('scroll', update, true)
+    window.addEventListener('resize', update)
+    return () => {
+      window.removeEventListener('scroll', update, true)
+      window.removeEventListener('resize', update)
+    }
+  }, [open, portalMode])
 
   const cancelClose = () => {
     if (closeTimer.current !== null) {
@@ -87,16 +119,41 @@ export default function NavDropdown({
         ? 'right-full top-0'
         : 'right-0 top-full mt-1'
 
-  const hoverProps =
-    triggerOn === 'hover'
-      ? {
-          onMouseEnter: () => {
-            cancelClose()
-            setOpen(true)
-          },
-          onMouseLeave: scheduleClose,
-        }
-      : {}
+  const hoverProps = portalMode
+    ? {}
+    : {
+        onMouseEnter: () => {
+          cancelClose()
+          setOpen(true)
+        },
+        onMouseLeave: scheduleClose,
+      }
+
+  const panelClasses = `min-w-[180px] rounded-[10px] bg-white shadow-lg border border-line py-1 ${panelClassName ?? ''}`
+
+  // Portal mode: render the panel at fixed coordinates derived from the
+  // trigger's bounding rect. right-anchored under the trigger so a row's
+  // menu lines up with its … button regardless of where in the viewport
+  // the row currently sits.
+  const portalPanel =
+    portalMode && open && triggerRect
+      ? createPortal(
+          <div
+            ref={panelRef}
+            role="menu"
+            style={{
+              position: 'fixed',
+              top: triggerRect.bottom + 4,
+              right: window.innerWidth - triggerRect.right,
+              zIndex: 1000,
+            }}
+            className={panelClasses}
+          >
+            {children}
+          </div>,
+          document.body,
+        )
+      : null
 
   return (
     <div
@@ -116,14 +173,12 @@ export default function NavDropdown({
         {trigger}
       </button>
 
-      {open && (
-        <div
-          role="menu"
-          className={`absolute z-30 ${panelPositionClass} min-w-[180px] rounded-[10px] bg-white shadow-lg border border-line py-1 ${panelClassName ?? ''}`}
-        >
+      {!portalMode && open && (
+        <div role="menu" className={`absolute z-30 ${panelPositionClass} ${panelClasses}`}>
           {children}
         </div>
       )}
+      {portalPanel}
     </div>
   )
 }

--- a/frontend/src/components/ui/NavDropdown.tsx
+++ b/frontend/src/components/ui/NavDropdown.tsx
@@ -2,12 +2,20 @@ import { KeyboardEvent, ReactNode, useEffect, useRef, useState } from 'react'
 
 type Placement = 'bottom-end' | 'right-start' | 'left-start'
 
+// triggerOn controls how the menu opens. 'hover' (default) matches the
+// existing nav menus where a mouseEnter pops the panel; 'click' suppresses
+// the hover handlers entirely so the menu only opens on the trigger button's
+// click. Per-row dropdowns inside dense tables use 'click' to avoid
+// accidentally opening every row the cursor passes over.
+type TriggerOn = 'hover' | 'click'
+
 interface NavDropdownProps {
   trigger: ReactNode
   triggerClassName?: string
   panelClassName?: string
   wrapperClassName?: string
   placement?: Placement
+  triggerOn?: TriggerOn
   children: ReactNode
 }
 
@@ -19,6 +27,7 @@ export default function NavDropdown({
   panelClassName,
   wrapperClassName = 'inline-block',
   placement = 'bottom-end',
+  triggerOn = 'hover',
   children,
 }: NavDropdownProps) {
   const [open, setOpen] = useState(false)
@@ -78,15 +87,22 @@ export default function NavDropdown({
         ? 'right-full top-0'
         : 'right-0 top-full mt-1'
 
+  const hoverProps =
+    triggerOn === 'hover'
+      ? {
+          onMouseEnter: () => {
+            cancelClose()
+            setOpen(true)
+          },
+          onMouseLeave: scheduleClose,
+        }
+      : {}
+
   return (
     <div
       ref={wrapperRef}
       className={`relative ${wrapperClassName}`}
-      onMouseEnter={() => {
-        cancelClose()
-        setOpen(true)
-      }}
-      onMouseLeave={scheduleClose}
+      {...hoverProps}
       onKeyDown={handleKeyDown}
     >
       <button

--- a/frontend/src/components/ui/TunnelsModal.tsx
+++ b/frontend/src/components/ui/TunnelsModal.tsx
@@ -145,7 +145,7 @@ export default function TunnelsModal({ vmId, hostname, onClose }: TunnelsModalPr
           {tunnels !== null && tunnels.length > 0 && (
             <div className="grid gap-2">
               {tunnels.map((t) => (
-                <TunnelRow key={t.id} tunnel={t} busy={busy} onDelete={onDelete} />
+                <TunnelRow key={t.id} tunnel={t} hostname={hostname} busy={busy} onDelete={onDelete} />
               ))}
             </div>
           )}
@@ -286,13 +286,20 @@ export default function TunnelsModal({ vmId, hostname, onClose }: TunnelsModalPr
 
 interface TunnelRowProps {
   tunnel: VMTunnel
+  hostname: string
   busy: boolean
   onDelete: (id: string) => void
 }
 
-function TunnelRow({ tunnel, busy, onDelete }: TunnelRowProps) {
+function TunnelRow({ tunnel, hostname, busy, onDelete }: TunnelRowProps) {
   const display = tunnel.tunnel_url || tunnel.subdomain || tunnel.id
   const isFailed = tunnel.status === 'failed'
+  // The SSH base tunnel maps the public host's :port to the guest's
+  // sshd. Spelling out "→ {hostname}:localhost:{port}" makes that
+  // mapping explicit instead of just "port 22" — which reads like a
+  // free-floating port number and doesn't say where the traffic ends up.
+  const targetPort = tunnel.target_port
+  const isSSHBase = targetPort === 22
   return (
     <div
       className={`p-3.5 rounded-[10px] bg-white/85 border ${isFailed ? 'border-[rgba(184,101,15,0.35)]' : 'border-line'}`}
@@ -312,9 +319,20 @@ function TunnelRow({ tunnel, busy, onDelete }: TunnelRowProps) {
             ) : (
               display
             )}
+            {isSSHBase && (
+              <span
+                className="ml-2 align-middle text-[10px] font-mono uppercase tracking-wider text-good bg-[rgba(60,150,90,0.10)] border border-[rgba(60,150,90,0.25)] rounded px-1.5 py-0.5"
+                title="The provision-time SSH exposure for this VM. Public host:port maps to the guest's sshd."
+              >
+                SSH base
+              </span>
+            )}
           </div>
           <div className="text-[11px] font-mono text-ink-3 mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
-            <span>→ port {tunnel.target_port}</span>
+            <span title={`Mapped to ${hostname}'s localhost:${targetPort}`}>
+              → <span className="text-ink-2">{hostname}</span>
+              <span className="text-ink-3"> · localhost:{targetPort}</span>
+            </span>
             {tunnel.transport && tunnel.transport !== 'tcp' && (
               <span className="uppercase">· {tunnel.transport}</span>
             )}

--- a/frontend/src/components/ui/VMActions.tsx
+++ b/frontend/src/components/ui/VMActions.tsx
@@ -66,9 +66,11 @@ export default function VMActions({
         {isOn ? <ShutdownIcon /> : <PlayIcon />}
       </button>
 
-      {/* … menu */}
+      {/* … menu — click-only so brushing the cursor through a dense table
+          doesn't pop every row's panel. */}
       <NavDropdown
         placement="bottom-end"
+        triggerOn="click"
         triggerClassName="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         trigger={<MoreIcon />}
       >

--- a/frontend/src/components/ui/VMActions.tsx
+++ b/frontend/src/components/ui/VMActions.tsx
@@ -116,13 +116,16 @@ function MenuItem({
   disabledReason?: string
   danger?: boolean
 }) {
+  // Hover highlight: 0.05 black on white was too subtle to read as
+  // interactive — bumped to 0.10 for the neutral row and 0.12 for the
+  // destructive (Remove) row so the hand-cursor isn't the only feedback.
   const base =
     'block w-full px-3 py-1.5 text-sm text-left transition-colors cursor-pointer'
   const cls = disabled
     ? `${base} text-ink-3 cursor-not-allowed`
     : danger
-      ? `${base} text-bad hover:bg-[rgba(184,58,58,0.06)]`
-      : `${base} text-ink-2 hover:bg-[rgba(27,23,38,0.05)] hover:text-ink`
+      ? `${base} text-bad hover:bg-[rgba(184,58,58,0.12)] hover:text-bad`
+      : `${base} text-ink-2 hover:bg-[rgba(20,18,28,0.10)] hover:text-ink`
   return (
     <button
       type="button"

--- a/frontend/src/components/ui/VMActions.tsx
+++ b/frontend/src/components/ui/VMActions.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react'
+import NavDropdown from '@/components/ui/NavDropdown'
+import type { VMLifecycleOp } from '@/api/client'
+
+// VMActions renders the per-row power-control surface used in both the admin
+// cluster table and the user's My Machines page.
+//
+// Inline button: Start when status==='stopped', Shutdown when running. The
+// "…" menu carries Restart, Force stop, and Remove; Remove is disabled for
+// rows nimbus didn't create (separation-of-powers — those VMs belong to
+// another instance or a hand-built workload).
+//
+// Callers supply onLifecycle (handles start/shutdown/stop/reboot) and
+// onRemove (the destructive trash flow). Either may be omitted to hide the
+// inline button or the menu Remove item respectively. busy disables every
+// affordance while a request is in flight.
+
+export type VMActionsStatus = 'running' | 'stopped' | 'paused' | 'unknown'
+
+interface VMActionsProps {
+  hostname: string
+  status: VMActionsStatus
+  // canRemove is the "this row is owned by us" gate. NIMBUS rows pass true;
+  // FOREIGN/EXTERNAL pass false → Remove is rendered but disabled with a
+  // tooltip explaining why.
+  canRemove: boolean
+  onLifecycle: (op: VMLifecycleOp) => Promise<void> | void
+  onRemove?: () => void
+  busy?: boolean
+}
+
+export default function VMActions({
+  hostname,
+  status,
+  canRemove,
+  onLifecycle,
+  onRemove,
+  busy = false,
+}: VMActionsProps) {
+  const [running, setRunning] = useState(false)
+  const isBusy = busy || running
+
+  const fire = async (op: VMLifecycleOp) => {
+    if (isBusy) return
+    setRunning(true)
+    try {
+      await onLifecycle(op)
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const isOn = status === 'running' || status === 'paused'
+
+  return (
+    <div className="flex gap-1.5">
+      {/* Inline toggle: Start when off, Shutdown when on. */}
+      <button
+        type="button"
+        onClick={() => fire(isOn ? 'shutdown' : 'start')}
+        disabled={isBusy}
+        className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        title={isOn ? `Shutdown ${hostname}` : `Start ${hostname}`}
+        aria-label={isOn ? `Shutdown ${hostname}` : `Start ${hostname}`}
+      >
+        {isOn ? <ShutdownIcon /> : <PlayIcon />}
+      </button>
+
+      {/* … menu */}
+      <NavDropdown
+        placement="bottom-end"
+        triggerClassName="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        trigger={<MoreIcon />}
+      >
+        <MenuItem
+          label="Restart"
+          disabled={isBusy || !isOn}
+          disabledReason={!isOn ? 'VM is not running' : undefined}
+          onClick={() => fire('reboot')}
+        />
+        <MenuItem
+          label="Force stop"
+          disabled={isBusy || !isOn}
+          disabledReason={!isOn ? 'VM is already off' : undefined}
+          onClick={() => fire('stop')}
+        />
+        <div className="my-1 border-t border-line" />
+        <MenuItem
+          label="Remove"
+          danger
+          disabled={isBusy || !canRemove || !onRemove}
+          disabledReason={
+            !canRemove
+              ? 'This VM was not created by nimbus — manage it through Proxmox.'
+              : undefined
+          }
+          onClick={() => onRemove?.()}
+        />
+      </NavDropdown>
+    </div>
+  )
+}
+
+function MenuItem({
+  label,
+  onClick,
+  disabled,
+  disabledReason,
+  danger,
+}: {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  disabledReason?: string
+  danger?: boolean
+}) {
+  const base =
+    'block w-full px-3 py-1.5 text-sm text-left transition-colors cursor-pointer'
+  const cls = disabled
+    ? `${base} text-ink-3 cursor-not-allowed`
+    : danger
+      ? `${base} text-bad hover:bg-[rgba(184,58,58,0.06)]`
+      : `${base} text-ink-2 hover:bg-[rgba(27,23,38,0.05)] hover:text-ink`
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      className={cls}
+      onClick={() => {
+        if (!disabled) onClick()
+      }}
+      disabled={disabled}
+      title={disabled ? disabledReason : undefined}
+    >
+      {label}
+    </button>
+  )
+}
+
+function PlayIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polygon points="6 4 20 12 6 20 6 4" />
+    </svg>
+  )
+}
+
+function ShutdownIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
+      <line x1="12" y1="2" x2="12" y2="12" />
+    </svg>
+  )
+}
+
+function MoreIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <circle cx="5" cy="12" r="1.6" />
+      <circle cx="12" cy="12" r="1.6" />
+      <circle cx="19" cy="12" r="1.6" />
+    </svg>
+  )
+}

--- a/frontend/src/components/ui/VMActions.tsx
+++ b/frontend/src/components/ui/VMActions.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 import NavDropdown from '@/components/ui/NavDropdown'
+import { ForceStopIcon, RestartIcon, TrashIcon } from '@/components/ui/icons'
 import type { VMLifecycleOp } from '@/api/client'
 
 // VMActions renders the per-row power-control surface used in both the admin
@@ -75,12 +76,14 @@ export default function VMActions({
         trigger={<MoreIcon />}
       >
         <MenuItem
+          icon={<RestartIcon />}
           label="Restart"
           disabled={isBusy || !isOn}
           disabledReason={!isOn ? 'VM is not running' : undefined}
           onClick={() => fire('reboot')}
         />
         <MenuItem
+          icon={<ForceStopIcon />}
           label="Force stop"
           disabled={isBusy || !isOn}
           disabledReason={!isOn ? 'VM is already off' : undefined}
@@ -88,6 +91,7 @@ export default function VMActions({
         />
         <div className="my-1 border-t border-line" />
         <MenuItem
+          icon={<TrashIcon />}
           label="Remove"
           danger
           disabled={isBusy || !canRemove || !onRemove}
@@ -104,12 +108,14 @@ export default function VMActions({
 }
 
 function MenuItem({
+  icon,
   label,
   onClick,
   disabled,
   disabledReason,
   danger,
 }: {
+  icon?: ReactNode
   label: string
   onClick: () => void
   disabled?: boolean
@@ -120,7 +126,7 @@ function MenuItem({
   // interactive — bumped to 0.10 for the neutral row and 0.12 for the
   // destructive (Remove) row so the hand-cursor isn't the only feedback.
   const base =
-    'block w-full px-3 py-1.5 text-sm text-left transition-colors cursor-pointer'
+    'flex w-full items-center gap-2.5 px-3 py-1.5 text-sm text-left transition-colors cursor-pointer'
   const cls = disabled
     ? `${base} text-ink-3 cursor-not-allowed`
     : danger
@@ -137,7 +143,8 @@ function MenuItem({
       disabled={disabled}
       title={disabled ? disabledReason : undefined}
     >
-      {label}
+      {icon && <span className="inline-flex w-3.5 justify-center" aria-hidden>{icon}</span>}
+      <span>{label}</span>
     </button>
   )
 }

--- a/frontend/src/components/ui/icons.tsx
+++ b/frontend/src/components/ui/icons.tsx
@@ -1,0 +1,64 @@
+// Shared inline SVG icons for VM-row affordances. Kept here (rather than
+// pulling in a real icon library) so the SPA stays small and tree-shakable;
+// each icon defaults to currentColor so callers control color via Tailwind
+// text-* utilities. Default size is 14×14 to match the 7×7-rounded-md button
+// affordances; pass size to override for the smaller menu glyphs.
+
+interface IconProps {
+  size?: number
+  className?: string
+}
+
+const baseSvgProps = {
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+}
+
+// NetworkIcon — globe-with-meridians. Used for the per-VM Gopher tunnels
+// affordance on both the Admin cluster table and My Machines.
+export function NetworkIcon({ size = 14, className }: IconProps = {}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" strokeWidth={1.5} className={className} {...baseSvgProps}>
+      <circle cx="8" cy="8" r="6" />
+      <ellipse cx="8" cy="8" rx="3" ry="6" />
+      <path d="M2 8h12" />
+    </svg>
+  )
+}
+
+// RestartIcon — circular arrow. Reads as "send me back through boot".
+export function RestartIcon({ size = 13, className }: IconProps = {}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" strokeWidth={1.6} className={className} {...baseSvgProps}>
+      <path d="M14 8a6 6 0 1 1-1.76-4.24" />
+      <path d="M14 2.5V5.5H11" />
+    </svg>
+  )
+}
+
+// ForceStopIcon — filled square. Distinct from the round ShutdownIcon to
+// signal "pull the plug, no graceful pass first".
+export function ForceStopIcon({ size = 13, className }: IconProps = {}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" className={className} aria-hidden>
+      <rect x="3.5" y="3.5" width="9" height="9" rx="1.5" fill="currentColor" />
+    </svg>
+  )
+}
+
+// TrashIcon — destructive Remove glyph. Same path as the legacy admin
+// trash icon for visual continuity with anyone who used the old delete
+// button.
+export function TrashIcon({ size = 13, className }: IconProps = {}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" strokeWidth={1.6} className={className} {...baseSvgProps}>
+      <path d="M3 4h10" />
+      <path d="M6 4V2.75A.75.75 0 0 1 6.75 2h2.5a.75.75 0 0 1 .75.75V4" />
+      <path d="M4.5 4l.75 9a1 1 0 0 0 1 .9h3.5a1 1 0 0 0 1-.9L11.5 4" />
+      <path d="M6.5 7v4M9.5 7v4" />
+    </svg>
+  )
+}

--- a/frontend/src/components/ui/icons.tsx
+++ b/frontend/src/components/ui/icons.tsx
@@ -17,6 +17,19 @@ const baseSvgProps = {
   'aria-hidden': true,
 }
 
+// TerminalIcon — bash prompt in a window. Used for the per-VM SSH
+// affordance on both the Admin cluster table and My Machines so the two
+// views agree on what the icon means.
+export function TerminalIcon({ size = 14, className }: IconProps = {}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" strokeWidth={1.6} className={className} {...baseSvgProps}>
+      <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
+      <path d="M4 6l2.5 2L4 10" />
+      <path d="M8.5 10.5h3.5" />
+    </svg>
+  )
+}
+
 // NetworkIcon — globe-with-meridians. Used for the per-VM Gopher tunnels
 // affordance on both the Admin cluster table and My Machines.
 export function NetworkIcon({ size = 14, className }: IconProps = {}) {

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -278,7 +278,7 @@ export default function Admin() {
             </div>
             <h3 className="text-xl">IP pool</h3>
           </div>
-          <IPTable ips={ips} />
+          <IPTable ips={ips} clusterVMs={vms} />
         </>
       )}
     </div>
@@ -961,7 +961,7 @@ interface IPFilterState {
 
 const EMPTY_IP_FILTERS: IPFilterState = { status: null, source: null }
 
-function IPTable({ ips }: { ips: IPAllocation[] }) {
+function IPTable({ ips, clusterVMs }: { ips: IPAllocation[]; clusterVMs: ClusterVM[] }) {
   // Default-hide free rows. A typical /24 pool has ~240 entries; the
   // interesting ones are reserved + allocated. Admins flip this on when
   // they want to see what's still available.
@@ -969,6 +969,17 @@ function IPTable({ ips }: { ips: IPAllocation[] }) {
   const [filters, setFilters] = useState<IPFilterState>(EMPTY_IP_FILTERS)
   const [page, setPage] = useState(0)
   const [pageSize, setPageSize] = useState(10)
+
+  // Build a vmid → cluster-source lookup so the IPSourceLabel can split
+  // the broad "adopted" bucket (anything Proxmox claims that nimbus didn't
+  // create) into "another nimbus instance" (carries the nimbus tag → shown
+  // as NIMBUS + warning) vs. "VM not provisioned by any nimbus" (shown as
+  // EXTERNAL VM). Without this cross-reference both look the same.
+  const vmSourceByVMID = useMemo(() => {
+    const m = new Map<number, VMSource>()
+    for (const v of clusterVMs) m.set(v.vmid, v.source)
+    return m
+  }, [clusterVMs])
 
   const sorted = useMemo(() => {
     return [...ips].sort((a, b) => ipToOctets(a.ip) - ipToOctets(b.ip))
@@ -1097,7 +1108,11 @@ function IPTable({ ips }: { ips: IPAllocation[] }) {
             </thead>
             <tbody>
               {paged.map((row) => (
-                <IPRow key={row.ip} row={row} />
+                <IPRow
+                  key={row.ip}
+                  row={row}
+                  clusterSource={row.vmid != null ? vmSourceByVMID.get(row.vmid) : undefined}
+                />
               ))}
             </tbody>
           </table>
@@ -1114,7 +1129,7 @@ function IPTable({ ips }: { ips: IPAllocation[] }) {
   )
 }
 
-function IPRow({ row }: { row: IPAllocation }) {
+function IPRow({ row, clusterSource }: { row: IPAllocation; clusterSource: VMSource | undefined }) {
   const dash = <span className="text-ink-3">—</span>
   const lastSeen = row.last_seen_at || row.allocated_at || row.reserved_at || null
   return (
@@ -1124,7 +1139,7 @@ function IPRow({ row }: { row: IPAllocation }) {
         <IPStatusBadge status={row.status} />
       </td>
       <td className="px-4 py-3 whitespace-nowrap">
-        {row.status === 'free' ? dash : <IPSourceLabel source={row.source} />}
+        {row.status === 'free' ? dash : <IPSourceLabel source={row.source} clusterSource={clusterSource} />}
       </td>
       <td className="px-4 py-3 font-mono text-xs text-ink-2 whitespace-nowrap">
         {row.vmid ?? dash}
@@ -1161,23 +1176,72 @@ function IPStatusBadge({ status }: { status: IPStatus }) {
   )
 }
 
-function IPSourceLabel({ source }: { source: IPSource | undefined }) {
+// IP source tooltip copy. Four cases — three "external" flavours we used to
+// flatten under a single label:
+//   * adopted+foreign    → another nimbus instance manages the VM. The
+//                          hypervisor admin we'd reach is *external to us*,
+//                          so we call this "external hypervisor".
+//   * adopted+!foreign   → a regular Proxmox VM that no nimbus instance
+//                          tagged. "External VM" — same cluster, just not
+//                          ours and not a peer's.
+//   * external           → netscan picked up an IP that doesn't belong to
+//                          any Proxmox VM at all (router, NAS, IoT). "True
+//                          external" — Proxmox doesn't even know about it.
+const ipSourceTooltip = {
+  local: 'Allocated by this nimbus instance for a VM we provisioned.',
+  externalHypervisor:
+    'Claimed by a VM tagged nimbus on the cluster but not in our DB — managed by a different nimbus instance ("external hypervisor"). Reachable through Proxmox; ownership and credentials live with the other instance.',
+  externalVM:
+    'Claimed by a Proxmox VM that no nimbus instance created. Real VM, just not part of any nimbus deployment — not in our DB and not in a peer\'s either.',
+  externalLAN:
+    'Detected on the LAN by netscan but not bound to any Proxmox VM. A non-VM host sharing the pool subnet (gateway, NAS, printer, statically-assigned workstation, …) — included in the pool so we never hand its address to a fresh provision.',
+}
+
+function IPSourceLabel({
+  source,
+  clusterSource,
+}: {
+  source: IPSource | undefined
+  clusterSource: VMSource | undefined
+}) {
   switch (source) {
     case 'local':
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-good">
+        <span
+          className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help"
+          title={ipSourceTooltip.local}
+        >
           NIMBUS
         </span>
       )
     case 'adopted':
+      // The reconciler stamps "adopted" on every Proxmox-claimed IP that
+      // wasn't reserved through us. Splitting that bucket needs the
+      // cluster-VM cross-reference to tell whose hypervisor it is.
+      if (clusterSource === 'foreign') {
+        return (
+          <span
+            className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help inline-flex items-center gap-1"
+            title={ipSourceTooltip.externalHypervisor}
+          >
+            NIMBUS <ForeignWarningIcon />
+          </span>
+        )
+      }
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-good">
-          NIMBUS <span className="text-ink-3">· FOREIGN</span>
+        <span
+          className="font-mono text-[11px] uppercase tracking-wider text-ink-2 cursor-help"
+          title={ipSourceTooltip.externalVM}
+        >
+          EXTERNAL VM
         </span>
       )
     case 'external':
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-ink-2">
+        <span
+          className="font-mono text-[11px] uppercase tracking-wider text-ink-3 cursor-help"
+          title={ipSourceTooltip.externalLAN}
+        >
           EXTERNAL
         </span>
       )

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -11,6 +11,7 @@ import TunnelsModal from '@/components/ui/TunnelsModal'
 import UsageBar from '@/components/ui/UsageBar'
 import VMActions from '@/components/ui/VMActions'
 import VMDetailsPopover from '@/components/ui/VMDetailsPopover'
+import { NetworkIcon } from '@/components/ui/icons'
 import { humanizeOSTemplate, resolveOSId } from '@/lib/os'
 import { formatBytes, formatRelativeTime } from '@/lib/format'
 import type { ClusterStats, ClusterVM, ClusterVMStatus, IPAllocation, IPSource, IPStatus, NodeView, TierName, VMSource } from '@/types'
@@ -533,16 +534,18 @@ function osLabelFor(vm: ClusterVM): string {
   return ''
 }
 
-// osTooltipFor returns the verbose OS description shown when the admin
-// hovers the OS cell. Picks the most complete signal available; falls back
-// to the short label when no extra detail exists. Includes kernel +
-// architecture when the agent reported them.
+// osTooltipFor returns the friendly distro+version string shown on hover —
+// e.g. "Ubuntu 24.04". The cell text dropped the distro prefix to save
+// width, so the tooltip's job is to put it back. Falls back to os_pretty
+// (verbose) only when neither agent fields nor a recognisable os_template
+// are available, since that's the only signal we have left.
 function osTooltipFor(vm: ClusterVM): string {
-  const head = vm.os_pretty || osLabelFor(vm)
-  const tail: string[] = []
-  if (vm.os_kernel) tail.push(`kernel ${vm.os_kernel}`)
-  if (vm.os_machine) tail.push(vm.os_machine)
-  return tail.length > 0 ? `${head} — ${tail.join(', ')}` : head
+  if (vm.os_id && vm.os_version_id) {
+    const distro = vm.os_id[0].toUpperCase() + vm.os_id.slice(1)
+    return `${distro} ${vm.os_version_id}`
+  }
+  if (vm.os_template) return humanizeOSTemplate(vm.os_template)
+  return vm.os_pretty || osLabelFor(vm)
 }
 
 // Tooltip copy explaining what each Source bucket means. Surfaced via the
@@ -608,26 +611,6 @@ function TerminalIcon() {
       <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
       <path d="M4 6l2.5 2L4 10" />
       <path d="M8.5 10.5h3.5" />
-    </svg>
-  )
-}
-
-function NetworkIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <circle cx="8" cy="8" r="6" />
-      <ellipse cx="8" cy="8" rx="3" ry="6" />
-      <path d="M2 8h12" />
     </svg>
   )
 }

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -470,7 +470,9 @@ function NodeCard({
               {n.max_cpu} cores · {formatBytes(n.mem_total)} RAM
             </div>
             <div className="font-mono text-[11px] text-ink-3 mt-0.5">
-              {n.vm_count} VM{n.vm_count !== 1 ? 's' : ''}
+              <span title={`${n.vm_count} running of ${n.vm_count_total} total VM${n.vm_count_total === 1 ? '' : 's'}`}>
+                {n.vm_count}/{n.vm_count_total} VM{n.vm_count_total !== 1 ? 's' : ''}
+              </span>
               {active && <span className="text-ink ml-2">· filtered</span>}
             </div>
           </div>

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -513,22 +513,23 @@ function NodeCard({
   )
 }
 
-// osLabelFor returns the SHORT user-facing OS label for a row. Priority is
-// stripped to just distro + version-id, so e.g. "Ubuntu 24.04.3 LTS (Noble
-// Numbat)" collapses to "Ubuntu 24.04". The verbose form lives in the
-// tooltip — see osTooltipFor — so admins can still see kernel / pretty name
-// on hover without polluting the column.
+// osLabelFor returns the SHORT user-facing OS label for a row. The OSIcon
+// adjacent to it already carries the distro identity, so the text drops to
+// just the version ("24.04", "12") to keep the column narrow. The verbose
+// pretty-name + kernel + arch live in the tooltip — see osTooltipFor.
 //
-//   1. Agent osinfo `id` + `version-id` ("ubuntu", "22.04") → "Ubuntu 22.04".
-//   2. Nimbus os_template ("ubuntu-22.04" → "Ubuntu 22.04").
-//   3. Raw Proxmox ostype hint (l26/win10) humanized.
+//   1. Agent osinfo `version-id` ("22.04") — most accurate.
+//   2. Nimbus os_template ("ubuntu-22.04" → "22.04").
+//   3. Raw Proxmox ostype hint (l26/win10) humanized when nothing else fits.
 //   4. Empty when nothing is known — caller renders a dash.
 function osLabelFor(vm: ClusterVM): string {
-  if (vm.os_id && vm.os_version_id) {
-    const distro = vm.os_id[0].toUpperCase() + vm.os_id.slice(1)
-    return `${distro} ${vm.os_version_id}`
+  if (vm.os_version_id) return vm.os_version_id
+  if (vm.os_template) {
+    // Strip the leading distro segment so "ubuntu-22.04" becomes "22.04".
+    const m = /^[a-z]+[-_](.+)$/i.exec(vm.os_template)
+    if (m) return m[1]
+    return humanizeOSTemplate(vm.os_template)
   }
-  if (vm.os_template) return humanizeOSTemplate(vm.os_template)
   return ''
 }
 
@@ -572,8 +573,11 @@ function SourceLabel({ source }: { source: VMSource }) {
       )
     case 'foreign':
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help" title={tip}>
-          NIMBUS <span className="text-ink-3">· FOREIGN</span>
+        <span
+          className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help inline-flex items-center gap-1"
+          title={tip}
+        >
+          NIMBUS <ForeignWarningIcon />
         </span>
       )
     default:
@@ -624,6 +628,31 @@ function NetworkIcon() {
       <circle cx="8" cy="8" r="6" />
       <ellipse cx="8" cy="8" rx="3" ry="6" />
       <path d="M2 8h12" />
+    </svg>
+  )
+}
+
+// ForeignWarningIcon flags rows whose VM exists on the cluster with a nimbus
+// tag but is not in *our* DB — i.e. provisioned by another nimbus instance.
+// Stamped next to the NIMBUS chip so admins notice at a glance that this
+// row's credentials and ownership belong to someone else.
+function ForeignWarningIcon() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="text-warn"
+    >
+      <path d="M8 1.5 L15 14 L1 14 Z" />
+      <line x1="8" y1="6" x2="8" y2="10" />
+      <circle cx="8" cy="12" r="0.5" fill="currentColor" />
     </svg>
   )
 }
@@ -764,7 +793,7 @@ function VMTable({
                     </span>
                   </button>
                 </th>
-                {['Node', 'IP', 'Tier', 'OS', 'Status', 'Source', 'SSH', 'Actions'].map((col) => (
+                {['Node', 'IP', 'Tier', 'OS', 'Status', 'Source', 'Actions'].map((col) => (
                   <th key={col} className={headerCellClass}>{col}</th>
                 ))}
               </tr>
@@ -822,32 +851,29 @@ function VMTable({
                       <SourceLabel source={vm.source} />
                     </td>
                     <td className="px-4 py-3">
-                      {vm.source === 'local' && vm.username && vm.ip ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setSshTarget({
-                              hostname: vm.hostname || vm.name,
-                              ip: vm.ip!,
-                              username: vm.username!,
-                              vmid: vm.vmid,
-                              node: vm.node,
-                              dbId: vm.id,
-                              keyName: vm.key_name,
-                              tunnelUrl: vm.tunnel_url,
-                            })
-                          }
-                          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md font-mono text-[11px] tracking-wider uppercase border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
-                          title={`SSH details for ${vm.hostname || vm.name}`}
-                          aria-label={`SSH details for ${vm.hostname || vm.name}`}
-                        >
-                          <TerminalIcon />
-                          <span>SSH</span>
-                        </button>
-                      ) : dash}
-                    </td>
-                    <td className="px-4 py-3">
                       <div className="flex gap-1.5 items-center">
+                        {vm.source === 'local' && vm.username && vm.ip && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setSshTarget({
+                                hostname: vm.hostname || vm.name,
+                                ip: vm.ip!,
+                                username: vm.username!,
+                                vmid: vm.vmid,
+                                node: vm.node,
+                                dbId: vm.id,
+                                keyName: vm.key_name,
+                                tunnelUrl: vm.tunnel_url,
+                              })
+                            }
+                            className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
+                            title={`SSH details for ${vm.hostname || vm.name}`}
+                            aria-label={`SSH details for ${vm.hostname || vm.name}`}
+                          >
+                            <TerminalIcon />
+                          </button>
+                        )}
                         {vm.source === 'local' && vm.id !== undefined && vm.tunnel_url && (
                           <button
                             type="button"

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { adminDeleteVM, getClusterStats, listClusterVMs, listIPs, listNodes } from '@/api/client'
+import { adminDeleteVM, adminVMLifecycle, getClusterStats, listClusterVMs, listIPs, listNodes } from '@/api/client'
 import Button from '@/components/ui/Button'
 import Card from '@/components/ui/Card'
 import DeleteVMConfirm from '@/components/ui/DeleteVMConfirm'
@@ -9,6 +9,7 @@ import SSHDetailsModal, { type SSHTarget } from '@/components/ui/SSHDetailsModal
 import StatusBadge from '@/components/ui/StatusBadge'
 import TunnelsModal from '@/components/ui/TunnelsModal'
 import UsageBar from '@/components/ui/UsageBar'
+import VMActions from '@/components/ui/VMActions'
 import VMDetailsPopover from '@/components/ui/VMDetailsPopover'
 import { humanizeOSTemplate, resolveOSId } from '@/lib/os'
 import { formatBytes, formatRelativeTime } from '@/lib/format'
@@ -32,6 +33,9 @@ interface AdminData {
   // admin delete, so the table reflects the change immediately instead of
   // waiting for the next 15s poll.
   removeVM: (id: number) => void
+  // updateVMStatus stamps a row's status optimistically after a lifecycle
+  // op. Keyed by (node, vmid) since foreign/external rows lack a nimbus id.
+  updateVMStatus: (node: string, vmid: number, status: ClusterVMStatus) => void
 }
 
 // pollEachWith fires `fn` immediately, then every `intervalMs`, until the
@@ -112,7 +116,19 @@ function useAdminData(): AdminData {
     setVMs((prev) => prev.filter((v) => v.id !== id))
   }, [])
 
-  return { nodes, vms, ips, clusterStats, statsLoading, vmsLoading, statsError, vmsError, removeVM }
+  // updateVMStatus stamps a row's status optimistically after a lifecycle
+  // op. Keyed by (node, vmid) since foreign/external rows lack a nimbus id.
+  // The 15 s poll above corrects any drift.
+  const updateVMStatus = useCallback(
+    (node: string, vmid: number, status: ClusterVMStatus) => {
+      setVMs((prev) =>
+        prev.map((v) => (v.node === node && v.vmid === vmid ? { ...v, status } : v)),
+      )
+    },
+    [],
+  )
+
+  return { nodes, vms, ips, clusterStats, statsLoading, vmsLoading, statsError, vmsError, removeVM, updateVMStatus }
 }
 
 interface FilterState {
@@ -127,7 +143,7 @@ const headerCellClass =
   'text-left text-[11px] font-mono uppercase tracking-wider text-ink-3 px-4 py-3 whitespace-nowrap'
 
 export default function Admin() {
-  const { nodes, vms, ips, clusterStats, statsLoading, vmsLoading, statsError, vmsError, removeVM } = useAdminData()
+  const { nodes, vms, ips, clusterStats, statsLoading, vmsLoading, statsError, vmsError, removeVM, updateVMStatus } = useAdminData()
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS)
 
 
@@ -251,6 +267,7 @@ export default function Admin() {
               hasFilters={hasFilters}
               onClearFilters={clearFilters}
               onVMDeleted={removeVM}
+              onVMStatusChanged={updateVMStatus}
             />
           )}
 
@@ -582,26 +599,6 @@ function NetworkIcon() {
   )
 }
 
-function TrashIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <path d="M3 4h10" />
-      <path d="M6 4V2.75A.75.75 0 0 1 6.75 2h2.5a.75.75 0 0 1 .75.75V4" />
-      <path d="M4.5 4l.75 9a1 1 0 0 0 1 .9h3.5a1 1 0 0 0 1-.9L11.5 4" />
-      <path d="M6.5 7v4M9.5 7v4" />
-    </svg>
-  )
-}
 
 function VMTable({
   vms,
@@ -613,6 +610,7 @@ function VMTable({
   hasFilters,
   onClearFilters,
   onVMDeleted,
+  onVMStatusChanged,
 }: {
   vms: ClusterVM[]
   allVMs: ClusterVM[]
@@ -623,6 +621,7 @@ function VMTable({
   hasFilters: boolean
   onClearFilters: () => void
   onVMDeleted: (id: number) => void
+  onVMStatusChanged: (node: string, vmid: number, status: ClusterVMStatus) => void
 }) {
   const [sshTarget, setSshTarget] = useState<SSHTarget | null>(null)
   const [tunnelsTarget, setTunnelsTarget] = useState<{ vmId: number; hostname: string } | null>(null)
@@ -816,35 +815,40 @@ function VMTable({
                       ) : dash}
                     </td>
                     <td className="px-4 py-3">
-                      {vm.source === 'local' && vm.id !== undefined ? (
-                        <div className="flex gap-1.5">
-                          {vm.tunnel_url && (
-                            <button
-                              type="button"
-                              onClick={() =>
-                                setTunnelsTarget({
-                                  vmId: vm.id!,
-                                  hostname: vm.hostname || vm.name,
-                                })
-                              }
-                              className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
-                              title="Manage Gopher tunnels for this VM"
-                              aria-label={`Manage tunnels for ${vm.hostname || vm.name}`}
-                            >
-                              <NetworkIcon />
-                            </button>
-                          )}
+                      <div className="flex gap-1.5 items-center">
+                        {vm.source === 'local' && vm.id !== undefined && vm.tunnel_url && (
                           <button
                             type="button"
-                            onClick={() => setEditTarget(vm)}
-                            className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-bad hover:border-bad hover:bg-[rgba(184,58,58,0.06)] transition-colors"
-                            title={`Delete ${vm.hostname || vm.name}`}
-                            aria-label={`Delete ${vm.hostname || vm.name}`}
+                            onClick={() =>
+                              setTunnelsTarget({
+                                vmId: vm.id!,
+                                hostname: vm.hostname || vm.name,
+                              })
+                            }
+                            className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
+                            title="Manage Gopher tunnels for this VM"
+                            aria-label={`Manage tunnels for ${vm.hostname || vm.name}`}
                           >
-                            <TrashIcon />
+                            <NetworkIcon />
                           </button>
-                        </div>
-                      ) : dash}
+                        )}
+                        <VMActions
+                          hostname={vm.hostname || vm.name}
+                          status={vm.status}
+                          canRemove={vm.source === 'local' && vm.id !== undefined}
+                          onLifecycle={async (op) => {
+                            await adminVMLifecycle(vm.node, vm.vmid, op)
+                            const next: ClusterVMStatus =
+                              op === 'start' || op === 'reboot' ? 'running' : 'stopped'
+                            onVMStatusChanged(vm.node, vm.vmid, next)
+                          }}
+                          onRemove={
+                            vm.source === 'local' && vm.id !== undefined
+                              ? () => setEditTarget(vm)
+                              : undefined
+                          }
+                        />
+                      </div>
                     </td>
                   </tr>
                 )

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -11,7 +11,7 @@ import TunnelsModal from '@/components/ui/TunnelsModal'
 import UsageBar from '@/components/ui/UsageBar'
 import VMActions from '@/components/ui/VMActions'
 import VMDetailsPopover from '@/components/ui/VMDetailsPopover'
-import { NetworkIcon } from '@/components/ui/icons'
+import { NetworkIcon, TerminalIcon } from '@/components/ui/icons'
 import { humanizeOSTemplate, resolveOSId } from '@/lib/os'
 import { formatBytes, formatRelativeTime } from '@/lib/format'
 import type { ClusterStats, ClusterVM, ClusterVMStatus, IPAllocation, IPSource, IPStatus, NodeView, TierName, VMSource } from '@/types'
@@ -592,29 +592,6 @@ function SourceLabel({ source }: { source: VMSource }) {
         </span>
       )
   }
-}
-
-// Small inline icons for the per-row action buttons. Kept inline (not a
-// shared component) because they're styled exactly for the 14×14 button
-// slot and don't carry over anywhere else in the app.
-function TerminalIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-    >
-      <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
-      <path d="M4 6l2.5 2L4 10" />
-      <path d="M8.5 10.5h3.5" />
-    </svg>
-  )
 }
 
 // ForeignWarningIcon flags rows whose VM exists on the cluster with a nimbus

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -513,43 +513,72 @@ function NodeCard({
   )
 }
 
-// osLabelFor returns the user-facing OS string for a VM row. Priority:
-//   1. Agent osinfo `version-id` ("22.04") prefixed by distro name from agent
-//      `id` — most accurate, available when qemu-guest-agent is running.
+// osLabelFor returns the SHORT user-facing OS label for a row. Priority is
+// stripped to just distro + version-id, so e.g. "Ubuntu 24.04.3 LTS (Noble
+// Numbat)" collapses to "Ubuntu 24.04". The verbose form lives in the
+// tooltip — see osTooltipFor — so admins can still see kernel / pretty name
+// on hover without polluting the column.
+//
+//   1. Agent osinfo `id` + `version-id` ("ubuntu", "22.04") → "Ubuntu 22.04".
 //   2. Nimbus os_template ("ubuntu-22.04" → "Ubuntu 22.04").
-//   3. Raw Proxmox ostype hint (l26/win10) humanized to "Linux"/"Windows 10".
+//   3. Raw Proxmox ostype hint (l26/win10) humanized.
 //   4. Empty when nothing is known — caller renders a dash.
 function osLabelFor(vm: ClusterVM): string {
   if (vm.os_id && vm.os_version_id) {
     const distro = vm.os_id[0].toUpperCase() + vm.os_id.slice(1)
     return `${distro} ${vm.os_version_id}`
   }
-  if (vm.os_pretty) return vm.os_pretty
   if (vm.os_template) return humanizeOSTemplate(vm.os_template)
   return ''
+}
+
+// osTooltipFor returns the verbose OS description shown when the admin
+// hovers the OS cell. Picks the most complete signal available; falls back
+// to the short label when no extra detail exists. Includes kernel +
+// architecture when the agent reported them.
+function osTooltipFor(vm: ClusterVM): string {
+  const head = vm.os_pretty || osLabelFor(vm)
+  const tail: string[] = []
+  if (vm.os_kernel) tail.push(`kernel ${vm.os_kernel}`)
+  if (vm.os_machine) tail.push(vm.os_machine)
+  return tail.length > 0 ? `${head} — ${tail.join(', ')}` : head
+}
+
+// Tooltip copy explaining what each Source bucket means. Surfaced via the
+// SourceLabel's title attribute so admins can hover any chip to learn what
+// the cluster actually knows about that VM and what they can do with it.
+const sourceTooltip: Record<VMSource, string> = {
+  local:
+    'Created by this nimbus instance. Full lifecycle + delete available — the SSH key, IP allocation, and DB row all live here.',
+  foreign:
+    'Created by a different nimbus instance on this cluster (carries the nimbus tag but is not in our DB). You can power-cycle it via Proxmox; remove is disabled because the credentials and ownership belong to the other instance.',
+  external:
+    'Not provisioned by any nimbus instance — a regular Proxmox VM. You can power-cycle it like any other, but nimbus refuses to remove it as a separation-of-powers guard.',
 }
 
 function SourceLabel({ source }: { source: VMSource }) {
   // Three states: local (this Nimbus), foreign (another Nimbus on the same
   // cluster), external (not Nimbus-provisioned). Foreign and local share the
   // green tone since both are Nimbus-managed; foreign carries a sub-label so
-  // admins can tell whose instance owns the credentials.
+  // admins can tell whose instance owns the credentials. Hover any chip for
+  // a longer-form explanation pulled from sourceTooltip.
+  const tip = sourceTooltip[source]
   switch (source) {
     case 'local':
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-good">
+        <span className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help" title={tip}>
           NIMBUS
         </span>
       )
     case 'foreign':
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-good">
+        <span className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help" title={tip}>
           NIMBUS <span className="text-ink-3">· FOREIGN</span>
         </span>
       )
     default:
       return (
-        <span className="font-mono text-[11px] uppercase tracking-wider text-ink-3">
+        <span className="font-mono text-[11px] uppercase tracking-wider text-ink-3 cursor-help" title={tip}>
           EXTERNAL
         </span>
       )
@@ -777,7 +806,10 @@ function VMTable({
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap">
                       {osLabel ? (
-                        <span className="inline-flex items-center gap-1.5">
+                        <span
+                          className="inline-flex items-center gap-1.5 cursor-help"
+                          title={osTooltipFor(vm)}
+                        >
                           <OSIcon family={osFamily} className="text-ink-2" />
                           <span className="font-mono text-xs text-ink-2">{osLabel}</span>
                         </span>

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -278,7 +278,7 @@ export default function Admin() {
             </div>
             <h3 className="text-xl">IP pool</h3>
           </div>
-          <IPTable ips={ips} clusterVMs={vms} />
+          <IPTable ips={ips} clusterVMs={vms} nodes={nodes} />
         </>
       )}
     </div>
@@ -961,7 +961,7 @@ interface IPFilterState {
 
 const EMPTY_IP_FILTERS: IPFilterState = { status: null, source: null }
 
-function IPTable({ ips, clusterVMs }: { ips: IPAllocation[]; clusterVMs: ClusterVM[] }) {
+function IPTable({ ips, clusterVMs, nodes }: { ips: IPAllocation[]; clusterVMs: ClusterVM[]; nodes: NodeView[] }) {
   // Default-hide free rows. A typical /24 pool has ~240 entries; the
   // interesting ones are reserved + allocated. Admins flip this on when
   // they want to see what's still available.
@@ -980,6 +980,18 @@ function IPTable({ ips, clusterVMs }: { ips: IPAllocation[]; clusterVMs: Cluster
     for (const v of clusterVMs) m.set(v.vmid, v.source)
     return m
   }, [clusterVMs])
+
+  // ip → node-name lookup so a hypervisor's own LAN address renders as
+  // "PROXMOX NODE foo" instead of the generic EXTERNAL chip netscan would
+  // otherwise stamp on it. Nodes without an `ip` field (single-node setups,
+  // pre-/cluster/status fetch) silently fall through.
+  const nodeByIP = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const n of nodes) {
+      if (n.ip) m.set(n.ip, n.name)
+    }
+    return m
+  }, [nodes])
 
   const sorted = useMemo(() => {
     return [...ips].sort((a, b) => ipToOctets(a.ip) - ipToOctets(b.ip))
@@ -1112,6 +1124,7 @@ function IPTable({ ips, clusterVMs }: { ips: IPAllocation[]; clusterVMs: Cluster
                   key={row.ip}
                   row={row}
                   clusterSource={row.vmid != null ? vmSourceByVMID.get(row.vmid) : undefined}
+                  nodeName={nodeByIP.get(row.ip)}
                 />
               ))}
             </tbody>
@@ -1129,7 +1142,15 @@ function IPTable({ ips, clusterVMs }: { ips: IPAllocation[]; clusterVMs: Cluster
   )
 }
 
-function IPRow({ row, clusterSource }: { row: IPAllocation; clusterSource: VMSource | undefined }) {
+function IPRow({
+  row,
+  clusterSource,
+  nodeName,
+}: {
+  row: IPAllocation
+  clusterSource: VMSource | undefined
+  nodeName: string | undefined
+}) {
   const dash = <span className="text-ink-3">—</span>
   const lastSeen = row.last_seen_at || row.allocated_at || row.reserved_at || null
   return (
@@ -1139,7 +1160,9 @@ function IPRow({ row, clusterSource }: { row: IPAllocation; clusterSource: VMSou
         <IPStatusBadge status={row.status} />
       </td>
       <td className="px-4 py-3 whitespace-nowrap">
-        {row.status === 'free' ? dash : <IPSourceLabel source={row.source} clusterSource={clusterSource} />}
+        {row.status === 'free' ? dash : (
+          <IPSourceLabel source={row.source} clusterSource={clusterSource} nodeName={nodeName} />
+        )}
       </td>
       <td className="px-4 py-3 font-mono text-xs text-ink-2 whitespace-nowrap">
         {row.vmid ?? dash}
@@ -1200,10 +1223,27 @@ const ipSourceTooltip = {
 function IPSourceLabel({
   source,
   clusterSource,
+  nodeName,
 }: {
   source: IPSource | undefined
   clusterSource: VMSource | undefined
+  nodeName: string | undefined
 }) {
+  // Hypervisor IPs win over every other classification: a Proxmox node's own
+  // LAN address shows up in netscan as "external" but it's actually one of
+  // our hosts. Render the dedicated chip whenever the row's IP matches a
+  // node from /cluster/status — regardless of whether the source field
+  // came back as "external" or "adopted".
+  if (nodeName) {
+    return (
+      <span
+        className="font-mono text-[11px] uppercase tracking-wider text-good cursor-help inline-flex items-center gap-1"
+        title={`Proxmox hypervisor "${nodeName}". This is one of the cluster nodes' own LAN addresses; netscan picked it up because it lives in the pool subnet.`}
+      >
+        PROXMOX NODE <span className="text-ink-3">· {nodeName}</span>
+      </span>
+    )
+  }
   switch (source) {
     case 'local':
       return (

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -8,6 +8,7 @@ import SSHDetailsModal from '@/components/ui/SSHDetailsModal'
 import StatusBadge from '@/components/ui/StatusBadge'
 import TunnelsModal from '@/components/ui/TunnelsModal'
 import VMActions from '@/components/ui/VMActions'
+import { NetworkIcon } from '@/components/ui/icons'
 import { useAuth } from '@/hooks/useAuth'
 import type { VM } from '@/types'
 
@@ -118,8 +119,9 @@ function VMRow({
             {vm.ip} · vmid {vm.vmid} · node {vm.node} · {vm.os_template}
           </div>
           {vm.tunnel_url && (
-            <div className="font-mono text-[11px] text-good mt-1 truncate" title={vm.tunnel_url}>
-              🌐 {vm.tunnel_url}
+            <div className="font-mono text-[11px] text-good mt-1 truncate inline-flex items-center gap-1.5" title={vm.tunnel_url}>
+              <NetworkIcon size={11} />
+              <span className="truncate">{vm.tunnel_url}</span>
             </div>
           )}
         </div>
@@ -132,11 +134,11 @@ function VMRow({
             <button
               type="button"
               onClick={() => setTunnelsOpen(true)}
-              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md font-mono text-[11px] tracking-wider uppercase border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
-              title="Manage Gopher tunnels for this VM"
+              className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
+              title={`Manage Gopher tunnels for ${vm.hostname}`}
+              aria-label={`Manage tunnels for ${vm.hostname}`}
             >
-              <span aria-hidden>🌐</span>
-              <span>Networks</span>
+              <NetworkIcon />
             </button>
           )}
           <button

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { deleteVM, listVMs } from '@/api/client'
+import { deleteVM, listVMs, vmLifecycle } from '@/api/client'
 import Button from '@/components/ui/Button'
 import Card from '@/components/ui/Card'
 import DeleteVMConfirm from '@/components/ui/DeleteVMConfirm'
 import SSHDetailsModal from '@/components/ui/SSHDetailsModal'
 import StatusBadge from '@/components/ui/StatusBadge'
 import TunnelsModal from '@/components/ui/TunnelsModal'
+import VMActions from '@/components/ui/VMActions'
 import { useAuth } from '@/hooks/useAuth'
 import type { VM } from '@/types'
 
@@ -146,16 +147,16 @@ function VMRow({
             <span aria-hidden>↗</span>
             <span>SSH</span>
           </button>
-          {canDelete && (
-            <button
-              type="button"
-              onClick={() => setDeleteOpen(true)}
-              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md font-mono text-[11px] tracking-wider uppercase border border-line-2 bg-white/85 text-bad hover:border-bad transition-colors"
-              title="Destroy this VM and release its resources"
-            >
-              Delete
-            </button>
-          )}
+          <VMActions
+            hostname={vm.hostname}
+            status={vm.status as 'running' | 'stopped' | 'paused' | 'unknown'}
+            canRemove={canDelete}
+            onLifecycle={async (op) => {
+              await vmLifecycle(vm.ID, op)
+              onChanged()
+            }}
+            onRemove={canDelete ? () => setDeleteOpen(true) : undefined}
+          />
         </div>
       </div>
       {sshOpen && (

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -142,10 +142,11 @@ function VMRow({
           <button
             type="button"
             onClick={() => setSshOpen(true)}
-            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md font-mono text-[11px] tracking-wider uppercase border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
+            className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink hover:border-ink transition-colors"
+            title={`SSH details for ${vm.hostname}`}
+            aria-label={`SSH details for ${vm.hostname}`}
           >
             <span aria-hidden>↗</span>
-            <span>SSH</span>
           </button>
           <VMActions
             hostname={vm.hostname}

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -8,7 +8,7 @@ import SSHDetailsModal from '@/components/ui/SSHDetailsModal'
 import StatusBadge from '@/components/ui/StatusBadge'
 import TunnelsModal from '@/components/ui/TunnelsModal'
 import VMActions from '@/components/ui/VMActions'
-import { NetworkIcon } from '@/components/ui/icons'
+import { NetworkIcon, TerminalIcon } from '@/components/ui/icons'
 import { useAuth } from '@/hooks/useAuth'
 import type { VM } from '@/types'
 
@@ -148,7 +148,7 @@ function VMRow({
             title={`SSH details for ${vm.hostname}`}
             aria-label={`SSH details for ${vm.hostname}`}
           >
-            <span aria-hidden>↗</span>
+            <TerminalIcon />
           </button>
           <VMActions
             hostname={vm.hostname}

--- a/frontend/src/pages/Network.tsx
+++ b/frontend/src/pages/Network.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useState } from 'react'
+import {
+  forceGatewayUpdate,
+  getNetworkSettings,
+  renumberAllVMs,
+  saveNetworkSettings,
+} from '@/api/client'
+import type { NetworkOpReport, NetworkSettingsView } from '@/api/client'
+
+type DangerKind = 'renumber' | 'force-gateway'
+
+function NetworkPanel() {
+  const [settings, setSettings] = useState<NetworkSettingsView | null>(null)
+  const [poolStart, setPoolStart] = useState('')
+  const [poolEnd, setPoolEnd] = useState('')
+  const [gateway, setGateway] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [danger, setDanger] = useState<DangerKind | null>(null)
+  const [report, setReport] = useState<NetworkOpReport | null>(null)
+  const [reportKind, setReportKind] = useState<DangerKind | null>(null)
+
+  useEffect(() => {
+    getNetworkSettings()
+      .then((s) => {
+        setSettings(s)
+        setPoolStart(s.ip_pool_start)
+        setPoolEnd(s.ip_pool_end)
+        setGateway(s.gateway_ip)
+      })
+      .catch(() => setError('Failed to load network settings'))
+  }, [])
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSaved(false)
+    setReport(null)
+    try {
+      setSaving(true)
+      const next = await saveNetworkSettings({
+        ip_pool_start: poolStart,
+        ip_pool_end: poolEnd,
+        gateway_ip: gateway,
+      })
+      setSettings(next)
+      setPoolStart(next.ip_pool_start)
+      setPoolEnd(next.ip_pool_end)
+      setGateway(next.gateway_ip)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const dirty =
+    !!settings &&
+    (poolStart !== settings.ip_pool_start ||
+      poolEnd !== settings.ip_pool_end ||
+      gateway !== settings.gateway_ip)
+
+  return (
+    <div
+      className="glass"
+      style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 18 }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+          IP pool & gateway
+        </span>
+      </div>
+
+      <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+        Saved values take effect for all <em>new</em> VMs immediately. Existing
+        VMs keep their current IP and gateway until you explicitly push the
+        change to them — see the action buttons below the form. Changing the
+        gateway in your network without also pushing it to existing VMs will
+        cut them off from the LAN.
+      </p>
+
+      <form onSubmit={handleSave} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <div className="n-field">
+          <label className="n-label" htmlFor="net-pool-start">IP pool start</label>
+          <input
+            id="net-pool-start"
+            className="n-input"
+            type="text"
+            placeholder="192.168.0.150"
+            value={poolStart}
+            onChange={(e) => setPoolStart(e.target.value)}
+          />
+        </div>
+        <div className="n-field">
+          <label className="n-label" htmlFor="net-pool-end">IP pool end</label>
+          <input
+            id="net-pool-end"
+            className="n-input"
+            type="text"
+            placeholder="192.168.0.200"
+            value={poolEnd}
+            onChange={(e) => setPoolEnd(e.target.value)}
+          />
+        </div>
+        <div className="n-field">
+          <label className="n-label" htmlFor="net-gateway">Gateway IP</label>
+          <input
+            id="net-gateway"
+            className="n-input"
+            type="text"
+            placeholder="192.168.0.1"
+            value={gateway}
+            onChange={(e) => setGateway(e.target.value)}
+          />
+        </div>
+
+        {error && <span style={{ fontSize: 13, color: 'var(--err)' }}>{error}</span>}
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button
+            type="submit"
+            className="n-btn n-btn-primary"
+            disabled={saving || !dirty}
+            style={{ minWidth: 100 }}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          {saved && <span style={{ fontSize: 13, color: 'var(--ok)' }}>Saved.</span>}
+          {!dirty && !saving && !saved && (
+            <span style={{ fontSize: 12, color: 'var(--ink-mute)' }}>
+              No unsaved changes.
+            </span>
+          )}
+        </div>
+      </form>
+
+      <div
+        style={{
+          marginTop: 6,
+          paddingTop: 18,
+          borderTop: '1px solid var(--line)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+        }}
+      >
+        <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+          Apply to existing VMs
+        </div>
+        <p style={{ margin: 0, fontSize: 12.5, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+          Both actions reboot every running nimbus-managed VM. Sessions drop,
+          in-progress work in user shells dies. Use only after you've saved
+          the new values above.
+        </p>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            className="n-btn"
+            disabled={dirty}
+            onClick={() => {
+              setReport(null)
+              setReportKind(null)
+              setDanger('force-gateway')
+            }}
+            title={dirty ? 'Save your changes first' : ''}
+          >
+            Force gateway on every VM…
+          </button>
+          <button
+            type="button"
+            className="n-btn"
+            disabled={dirty}
+            onClick={() => {
+              setReport(null)
+              setReportKind(null)
+              setDanger('renumber')
+            }}
+            title={dirty ? 'Save your changes first' : ''}
+          >
+            Renumber every VM into new pool…
+          </button>
+        </div>
+      </div>
+
+      {report && (
+        <div
+          style={{
+            marginTop: 4,
+            padding: '14px 16px',
+            border: '1px solid var(--line)',
+            borderRadius: 8,
+            background: 'rgba(20,18,28,0.03)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+            {reportKind === 'renumber' ? 'Renumber complete' : 'Gateway update complete'}
+          </div>
+          <div style={{ fontSize: 13, color: 'var(--ink-body)' }}>
+            {report.updated} VM{report.updated === 1 ? '' : 's'} updated.{' '}
+            {report.failures.length > 0
+              ? `${report.failures.length} failure${report.failures.length === 1 ? '' : 's'}:`
+              : 'No failures.'}
+          </div>
+          {report.failures.length > 0 && (
+            <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12.5, color: 'var(--err)' }}>
+              {report.failures.map((f) => (
+                <li key={f.vm_row_id}>
+                  {f.hostname || `vm row ${f.vm_row_id}`} (vmid {f.vmid}): {f.error}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {danger && (
+        <DangerModal
+          kind={danger}
+          settings={settings}
+          onClose={() => setDanger(null)}
+          onDone={(rep, kind) => {
+            setReport(rep)
+            setReportKind(kind)
+            setDanger(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function DangerModal({
+  kind,
+  settings,
+  onClose,
+  onDone,
+}: {
+  kind: DangerKind
+  settings: NetworkSettingsView | null
+  onClose: () => void
+  onDone: (rep: NetworkOpReport, kind: DangerKind) => void
+}) {
+  const required =
+    kind === 'renumber' ? 'RENUMBER ALL VMS' : 'CHANGE GATEWAY ON ALL VMS'
+  const [typed, setTyped] = useState('')
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const title =
+    kind === 'renumber'
+      ? 'Renumber every nimbus-managed VM'
+      : 'Force the new gateway on every VM'
+
+  const description =
+    kind === 'renumber'
+      ? `Every nimbus-managed VM will be assigned a fresh IP from ${
+          settings?.ip_pool_start ?? '?'
+        } – ${settings?.ip_pool_end ?? '?'} and rebooted. The new pool must have at least as many free addresses as you have VMs. Any open SSH sessions will drop. This cannot be cleanly undone — the old IPs are released back to the pool.`
+      : `Every nimbus-managed VM will be reconfigured to use ${
+          settings?.gateway_ip ?? '?'
+        } as its default gateway and rebooted. If the new gateway is not yet reachable on your network, every VM will lose connectivity until the network is fixed. Any open SSH sessions will drop.`
+
+  const handleConfirm = async () => {
+    setError(null)
+    try {
+      setRunning(true)
+      const rep = kind === 'renumber' ? await renumberAllVMs() : await forceGatewayUpdate()
+      onDone(rep, kind)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Operation failed')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(8,6,12,0.55)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 50,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="glass"
+        style={{
+          width: 'min(520px, 92vw)',
+          padding: '22px 24px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+          borderColor: 'var(--err)',
+        }}
+      >
+        <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--err)' }}>
+          {title}
+        </div>
+        <p style={{ margin: 0, fontSize: 13.5, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+          {description}
+        </p>
+        <div className="n-field">
+          <label className="n-label" htmlFor="danger-confirm">
+            Type <code style={{ color: 'var(--err)' }}>{required}</code> to confirm
+          </label>
+          <input
+            id="danger-confirm"
+            className="n-input"
+            type="text"
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            placeholder={required}
+            autoFocus
+          />
+        </div>
+        {error && <span style={{ fontSize: 13, color: 'var(--err)' }}>{error}</span>}
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+          <button type="button" className="n-btn" onClick={onClose} disabled={running}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="n-btn n-btn-primary"
+            onClick={handleConfirm}
+            disabled={running || typed !== required}
+            style={{ background: 'var(--err)', borderColor: 'var(--err)' }}
+          >
+            {running ? 'Working…' : kind === 'renumber' ? 'Renumber all VMs' : 'Force gateway'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function Network() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <div>
+        <h1 className="n-display" style={{ fontSize: 28, margin: '0 0 6px' }}>
+          Network
+        </h1>
+        <p style={{ margin: 0, fontSize: 14, color: 'var(--ink-body)' }}>
+          The IP pool nimbus draws from when provisioning, and the gateway
+          handed to each VM via cloud-init.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+        <div className="lg:col-span-2 flex flex-col gap-6">
+          <NetworkPanel />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Network.tsx
+++ b/frontend/src/pages/Network.tsx
@@ -2,10 +2,15 @@ import { useEffect, useState } from 'react'
 import {
   forceGatewayUpdate,
   getNetworkSettings,
+  reconcileVMs,
   renumberAllVMs,
   saveNetworkSettings,
 } from '@/api/client'
-import type { NetworkOpReport, NetworkSettingsView } from '@/api/client'
+import type {
+  NetworkOpReport,
+  NetworkSettingsView,
+  VMReconcileReport,
+} from '@/api/client'
 
 type DangerKind = 'renumber' | 'force-gateway'
 
@@ -344,6 +349,109 @@ function DangerModal({
   )
 }
 
+function SyncPanel() {
+  const [running, setRunning] = useState(false)
+  const [report, setReport] = useState<VMReconcileReport | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSync = async () => {
+    setError(null)
+    setReport(null)
+    try {
+      setRunning(true)
+      const rep = await reconcileVMs()
+      setReport(rep)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reconcile failed')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  return (
+    <div
+      className="glass"
+      style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}
+    >
+      <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+        Sync DB with cluster
+      </div>
+      <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+        Walks every VM row against the live Proxmox cluster. Rows whose VM
+        moved to a different node (manual <code>qm migrate</code>) get their
+        node updated. Rows whose VMID hasn't been observed for 3 consecutive
+        runs get soft-deleted — typically because someone destroyed the VM
+        directly through Proxmox, leaving an orphan here. This runs on the
+        background reconcile loop every minute; the button forces an
+        immediate pass.
+      </p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <button
+          type="button"
+          className="n-btn n-btn-primary"
+          onClick={handleSync}
+          disabled={running}
+          style={{ minWidth: 160 }}
+        >
+          {running ? 'Syncing…' : 'Sync now'}
+        </button>
+        {error && <span style={{ fontSize: 13, color: 'var(--err)' }}>{error}</span>}
+      </div>
+      {report && (
+        <div
+          style={{
+            marginTop: 4,
+            padding: '14px 16px',
+            border: '1px solid var(--line)',
+            borderRadius: 8,
+            background: 'rgba(20,18,28,0.03)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            fontSize: 13,
+            color: 'var(--ink-body)',
+          }}
+        >
+          <div>
+            Migrated: <strong>{report.migrated.length}</strong> &middot; Soft-deleted:{' '}
+            <strong>{report.deleted.length}</strong> &middot; Going stale:{' '}
+            <strong>{report.missed.length}</strong> &middot; In sync:{' '}
+            <strong>{report.no_ops}</strong>
+          </div>
+          {report.migrated.length > 0 && (
+            <ul style={{ margin: 0, paddingLeft: 18 }}>
+              {report.migrated.map((m) => (
+                <li key={`mig-${m.vm_row_id}`}>
+                  {m.hostname} (vmid {m.vmid}): {m.from_node} → {m.to_node}
+                </li>
+              ))}
+            </ul>
+          )}
+          {report.deleted.length > 0 && (
+            <ul style={{ margin: 0, paddingLeft: 18, color: 'var(--err)' }}>
+              {report.deleted.map((d) => (
+                <li key={`del-${d.vm_row_id}`}>
+                  {d.hostname} (vmid {d.vmid} on {d.node}) — soft-deleted
+                </li>
+              ))}
+            </ul>
+          )}
+          {report.missed.length > 0 && (
+            <ul style={{ margin: 0, paddingLeft: 18, color: 'var(--ink-mute)' }}>
+              {report.missed.map((m) => (
+                <li key={`miss-${m.vm_row_id}`}>
+                  {m.hostname} (vmid {m.vmid} on {m.node}) — missed{' '}
+                  {m.missed_cycles}/3
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function Network() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
@@ -360,6 +468,7 @@ export default function Network() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
         <div className="lg:col-span-2 flex flex-col gap-6">
           <NetworkPanel />
+          <SyncPanel />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Provision.tsx
+++ b/frontend/src/pages/Provision.tsx
@@ -238,7 +238,7 @@ export default function Provision() {
           <div className="eyebrow">New machine</div>
           <h2 className="text-3xl">What are we spinning up today?</h2>
           <p className="text-base text-ink-2 mt-2 leading-relaxed">
-            Pick a size, give it a name, grab your key. Done in &lt; 60s.
+            Pick a size, give it a name, grab your key. Most builds finish in 90–120s.
           </p>
         </div>
       </div>
@@ -289,7 +289,7 @@ export default function Provision() {
               Provision machine →
             </Button>
             <p className="text-xs text-ink-3 text-center mt-3 leading-relaxed">
-              Typically completes in 30–60 seconds.
+              Typically completes in 90–120 seconds.
             </p>
             {form.tier === 'xl' && (
               <p className="text-xs text-warn text-center mt-2">
@@ -772,7 +772,7 @@ function LoadingView({ hostname, currentStep }: LoadingViewProps) {
           </span>
         </h2>
         <p className="text-base text-ink-2 mt-4 leading-relaxed">
-          Hold tight — your machine is on its way. Provisioning typically takes 30–60s.
+          Hold tight — your machine is on its way. Provisioning typically takes 90–120s.
         </p>
         <div className="mt-4 font-mono text-2xl text-ink tabular-nums">{fmt(elapsed)}</div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -145,6 +145,11 @@ export interface NodeView {
   swap_total: number
   vm_count: number
   vm_count_total: number
+  // Corosync ring address for this node, when available. The IP-pool table
+  // uses it to render hypervisor LAN addresses as "PROXMOX NODE <name>"
+  // instead of the generic EXTERNAL chip netscan would otherwise stamp on
+  // them.
+  ip?: string
 }
 
 export interface ClusterStats {

--- a/internal/api/handlers/cluster.go
+++ b/internal/api/handlers/cluster.go
@@ -222,3 +222,24 @@ func (h *Cluster) DeleteVM(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// VMLifecycle handles POST /api/cluster/vms/{node}/{vmid}/{op} where op is
+// one of start | shutdown | stop | reboot. Admin-only. Works on any source
+// (local, foreign, external) since it routes by (node, vmid) instead of
+// nimbus DB row id. For local rows the status column is updated
+// optimistically; the reconciler corrects any drift.
+func (h *Cluster) VMLifecycle(w http.ResponseWriter, r *http.Request) {
+	node := chi.URLParam(r, "node")
+	vmidStr := chi.URLParam(r, "vmid")
+	vmid, err := strconv.Atoi(vmidStr)
+	if err != nil || vmid <= 0 {
+		response.BadRequest(w, "invalid vmid")
+		return
+	}
+	op := provision.VMLifecycleOp(chi.URLParam(r, "op"))
+	if err := h.svc.AdminLifecycleByVMID(r.Context(), node, vmid, op); err != nil {
+		response.FromError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/handlers/nodes.go
+++ b/internal/api/handlers/nodes.go
@@ -27,6 +27,13 @@ type nodeView struct {
 	SwapTotal    uint64  `json:"swap_total"`     // configured swap on the host
 	VMCount      int     `json:"vm_count"`       // running, non-template
 	VMCountTotal int     `json:"vm_count_total"` // all non-template (running + stopped)
+	// IP is the node's corosync ring address from /cluster/status. Surfaced
+	// so the SPA can label hypervisor IPs in the IP-pool table — when an
+	// allocation row's IP matches a node, we render "PROXMOX NODE foo"
+	// instead of the generic EXTERNAL chip the netscan would otherwise pin
+	// it with. Empty when /cluster/status didn't include the node (single-
+	// node deployments, fresh installs).
+	IP string `json:"ip,omitempty"`
 }
 
 // List handles GET /api/nodes.
@@ -65,6 +72,14 @@ func (h *Nodes) List(w http.ResponseWriter, r *http.Request) {
 		agg[vm.Node] = a
 	}
 
+	// /cluster/status carries each node's corosync ring address. Single
+	// extra cluster-level call (cheap) — failure leaves nodeIP entries empty
+	// and the SPA falls back to the EXTERNAL label for those rows.
+	nodeIP, err := h.px.NodeAddresses(r.Context())
+	if err != nil {
+		nodeIP = nil
+	}
+
 	// Swap counters live on /nodes/{node}/status, not /nodes — fan out per
 	// online node in parallel. A failed status call shouldn't block the rest:
 	// we leave swap fields at zero for that node and serve the page anyway.
@@ -98,6 +113,7 @@ func (h *Nodes) List(w http.ResponseWriter, r *http.Request) {
 			SwapTotal:    swap[i].Total,
 			VMCount:      a.running,
 			VMCountTotal: a.total,
+			IP:           nodeIP[n.Name],
 		})
 	}
 	response.Success(w, out)

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -47,7 +47,7 @@ type NetworkApplier interface {
 // provision.Service satisfies this; the handler keeps it as an interface so
 // tests can inject a fake without booting the whole orchestrator.
 type NetworkOps interface {
-	RenumberAllVMs(ctx context.Context, gateway string) (provision.NetworkOpReport, error)
+	RenumberAllVMs(ctx context.Context, gateway, poolStart, poolEnd string) (provision.NetworkOpReport, error)
 	ForceGatewayUpdate(ctx context.Context, gateway string) (provision.NetworkOpReport, error)
 }
 
@@ -689,11 +689,11 @@ func (s *Settings) RenumberVMs(w http.ResponseWriter, r *http.Request) {
 		response.InternalError(w, "failed to load network settings")
 		return
 	}
-	if settings.GatewayIP == "" {
-		response.BadRequest(w, "gateway_ip is not set; save network settings first")
+	if settings.GatewayIP == "" || settings.IPPoolStart == "" || settings.IPPoolEnd == "" {
+		response.BadRequest(w, "network settings (gateway_ip + ip_pool_start + ip_pool_end) must all be saved before renumbering")
 		return
 	}
-	rep, err := s.networkOps.RenumberAllVMs(r.Context(), settings.GatewayIP)
+	rep, err := s.networkOps.RenumberAllVMs(r.Context(), settings.GatewayIP, settings.IPPoolStart, settings.IPPoolEnd)
 	if err != nil {
 		response.BadRequest(w, err.Error())
 		return

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -35,6 +36,27 @@ type GPUConfigApplier interface {
 	SetGPUBootstrapConfig(provision.GPUBootstrapConfig)
 }
 
+// NetworkApplier is implemented by anything that needs to be told the live
+// gateway IP after a Settings → Network save. provision.Service satisfies via
+// SetGatewayIP.
+type NetworkApplier interface {
+	SetGatewayIP(string)
+}
+
+// NetworkOps performs the disruptive renumber + force-gateway batch ops.
+// provision.Service satisfies this; the handler keeps it as an interface so
+// tests can inject a fake without booting the whole orchestrator.
+type NetworkOps interface {
+	RenumberAllVMs(ctx context.Context, gateway string) (provision.NetworkOpReport, error)
+	ForceGatewayUpdate(ctx context.Context, gateway string) (provision.NetworkOpReport, error)
+}
+
+// PoolReseeder is what the network handler uses to converge the IP pool table
+// to the new range after a save. *ippool.Pool satisfies it.
+type PoolReseeder interface {
+	Reseed(ctx context.Context, start, end string) (added, removedFree, stranded int, err error)
+}
+
 // SelfBootstrap is implemented by selftunnel.Service. SaveGopher fires
 // Start in a goroutine after a successful credential save, and the
 // /self-bootstrap status/start endpoints proxy to it.
@@ -49,12 +71,15 @@ type SelfBootstrap interface {
 
 // Settings handles admin-only configuration endpoints.
 type Settings struct {
-	auth          *service.AuthService
-	appliers      []TunnelClientApplier
-	tunnels       TunnelInfoSetter
-	gpuAppliers   []GPUConfigApplier
-	nimbusAppURL  string // captured at construction so SaveGPU can build NimbusGPUAPI URL
-	selfBootstrap SelfBootstrap
+	auth            *service.AuthService
+	appliers        []TunnelClientApplier
+	tunnels         TunnelInfoSetter
+	gpuAppliers     []GPUConfigApplier
+	nimbusAppURL    string // captured at construction so SaveGPU can build NimbusGPUAPI URL
+	selfBootstrap   SelfBootstrap
+	networkAppliers []NetworkApplier
+	networkOps      NetworkOps
+	pool            PoolReseeder
 }
 
 func NewSettings(auth *service.AuthService) *Settings {
@@ -95,6 +120,27 @@ func (s *Settings) WithNimbusAppURL(u string) *Settings {
 // something to talk to.
 func (s *Settings) WithSelfBootstrap(b SelfBootstrap) *Settings {
 	s.selfBootstrap = b
+	return s
+}
+
+// WithNetworkAppliers registers components that need to be told the live
+// gateway IP after a network settings save (provision.Service mainly).
+func (s *Settings) WithNetworkAppliers(a ...NetworkApplier) *Settings {
+	s.networkAppliers = append(s.networkAppliers, a...)
+	return s
+}
+
+// WithNetworkOps wires the renumber / force-gateway batch operator.
+// provision.Service satisfies it.
+func (s *Settings) WithNetworkOps(o NetworkOps) *Settings {
+	s.networkOps = o
+	return s
+}
+
+// WithPoolReseeder wires the IP pool so SaveNetwork can converge the
+// allocation table to the new range. *ippool.Pool satisfies it.
+func (s *Settings) WithPoolReseeder(p PoolReseeder) *Settings {
+	s.pool = p
 	return s
 }
 
@@ -483,6 +529,176 @@ func (s *Settings) SelfBootstrapStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response.Success(w, map[string]string{"state": "started"})
+}
+
+// networkSettingsView is what GET / PUT /api/settings/network return.
+type networkSettingsView struct {
+	IPPoolStart string `json:"ip_pool_start"`
+	IPPoolEnd   string `json:"ip_pool_end"`
+	GatewayIP   string `json:"gateway_ip"`
+}
+
+// GetNetwork handles GET /api/settings/network (admin only). Returns the live
+// IP pool range and gateway. Used by the Settings → Network panel and as the
+// canonical source for the renumber / force-gateway confirmation modals.
+func (s *Settings) GetNetwork(w http.ResponseWriter, _ *http.Request) {
+	settings, err := s.auth.GetNetworkSettings()
+	if err != nil {
+		response.InternalError(w, "failed to load network settings")
+		return
+	}
+	response.Success(w, networkSettingsView{
+		IPPoolStart: settings.IPPoolStart,
+		IPPoolEnd:   settings.IPPoolEnd,
+		GatewayIP:   settings.GatewayIP,
+	})
+}
+
+type saveNetworkRequest struct {
+	IPPoolStart string `json:"ip_pool_start"`
+	IPPoolEnd   string `json:"ip_pool_end"`
+	GatewayIP   string `json:"gateway_ip"`
+}
+
+// SaveNetwork handles PUT /api/settings/network (admin only). Persists the
+// supplied values, then reseeds the IP pool to converge to the new range and
+// pushes the live gateway to every registered NetworkApplier. Existing VMs
+// are NOT touched — that requires the explicit RenumberVMs / ForceGatewayUpdate
+// endpoints.
+func (s *Settings) SaveNetwork(w http.ResponseWriter, r *http.Request) {
+	var req saveNetworkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	start := strings.TrimSpace(req.IPPoolStart)
+	end := strings.TrimSpace(req.IPPoolEnd)
+	gw := strings.TrimSpace(req.GatewayIP)
+
+	for label, v := range map[string]string{"ip_pool_start": start, "ip_pool_end": end, "gateway_ip": gw} {
+		if v == "" {
+			continue // empty = preserve existing
+		}
+		if ip := net.ParseIP(v); ip == nil || ip.To4() == nil {
+			response.BadRequest(w, label+" is not a valid IPv4 address")
+			return
+		}
+	}
+
+	if err := s.auth.SaveNetworkSettings(db.NetworkSettings{
+		IPPoolStart: start,
+		IPPoolEnd:   end,
+		GatewayIP:   gw,
+	}); err != nil {
+		response.InternalError(w, "failed to save network settings")
+		return
+	}
+
+	settings, err := s.auth.GetNetworkSettings()
+	if err != nil {
+		response.InternalError(w, "saved, but failed to reload: "+err.Error())
+		return
+	}
+
+	if s.pool != nil && settings.IPPoolStart != "" && settings.IPPoolEnd != "" {
+		if _, _, _, err := s.pool.Reseed(r.Context(), settings.IPPoolStart, settings.IPPoolEnd); err != nil {
+			response.BadRequest(w, "saved, but pool reseed failed: "+err.Error())
+			return
+		}
+	}
+	for _, a := range s.networkAppliers {
+		a.SetGatewayIP(settings.GatewayIP)
+	}
+
+	response.Success(w, networkSettingsView{
+		IPPoolStart: settings.IPPoolStart,
+		IPPoolEnd:   settings.IPPoolEnd,
+		GatewayIP:   settings.GatewayIP,
+	})
+}
+
+// networkOpResponse is the JSON shape returned by the renumber / force-gateway
+// endpoints — Updated count + per-VM failures the UI can surface.
+type networkOpResponse struct {
+	Updated  int                    `json:"updated"`
+	Failures []networkOpFailureView `json:"failures"`
+}
+
+type networkOpFailureView struct {
+	VMRowID  uint   `json:"vm_row_id"`
+	VMID     int    `json:"vmid"`
+	Hostname string `json:"hostname"`
+	Error    string `json:"error"`
+}
+
+func toNetworkOpResponse(rep provision.NetworkOpReport) networkOpResponse {
+	out := networkOpResponse{
+		Updated:  rep.Updated,
+		Failures: make([]networkOpFailureView, 0, len(rep.Failures)),
+	}
+	for _, f := range rep.Failures {
+		out.Failures = append(out.Failures, networkOpFailureView{
+			VMRowID:  f.VMRowID,
+			VMID:     f.VMID,
+			Hostname: f.Hostname,
+			Error:    f.Err,
+		})
+	}
+	return out
+}
+
+// ForceGatewayUpdate handles POST /api/settings/network/force-gateway-update
+// (admin only). Pushes the currently-saved gateway to every managed VM via
+// `qm set --ipconfig0` and reboots running VMs so the change takes effect.
+// Disruptive — every running VM bounces.
+func (s *Settings) ForceGatewayUpdate(w http.ResponseWriter, r *http.Request) {
+	if s.networkOps == nil {
+		response.InternalError(w, "network ops not wired")
+		return
+	}
+	settings, err := s.auth.GetNetworkSettings()
+	if err != nil {
+		response.InternalError(w, "failed to load network settings")
+		return
+	}
+	if settings.GatewayIP == "" {
+		response.BadRequest(w, "gateway_ip is not set; save network settings first")
+		return
+	}
+	rep, err := s.networkOps.ForceGatewayUpdate(r.Context(), settings.GatewayIP)
+	if err != nil {
+		response.InternalError(w, err.Error())
+		return
+	}
+	response.Success(w, toNetworkOpResponse(rep))
+}
+
+// RenumberVMs handles POST /api/settings/network/renumber-vms (admin only).
+// Reserves a fresh IP from the saved pool for every managed VM, updates each
+// VM's cloud-init, reboots it, and releases the old IP. Disruptive.
+//
+// Refuses with 400 if the pool has fewer free addresses than the number of
+// VMs to renumber — operator must widen the pool first.
+func (s *Settings) RenumberVMs(w http.ResponseWriter, r *http.Request) {
+	if s.networkOps == nil {
+		response.InternalError(w, "network ops not wired")
+		return
+	}
+	settings, err := s.auth.GetNetworkSettings()
+	if err != nil {
+		response.InternalError(w, "failed to load network settings")
+		return
+	}
+	if settings.GatewayIP == "" {
+		response.BadRequest(w, "gateway_ip is not set; save network settings first")
+		return
+	}
+	rep, err := s.networkOps.RenumberAllVMs(r.Context(), settings.GatewayIP)
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	response.Success(w, toNetworkOpResponse(rep))
 }
 
 // RegenerateAccessCode handles POST /api/settings/access-code/regenerate (admin only).

--- a/internal/api/handlers/vms.go
+++ b/internal/api/handlers/vms.go
@@ -378,3 +378,18 @@ func validateCreate(req createVMRequest) error {
 	}
 	return nil
 }
+
+// Reconcile handles POST /api/vms/reconcile (admin only). Walks the local vms
+// table against the live Proxmox cluster snapshot, updates rows whose VMs
+// have migrated to a different node, and soft-deletes rows whose VMID hasn't
+// been observed for vacateMissThreshold consecutive runs. Refuses to act when
+// Proxmox returns an empty cluster snapshot (transient API failure → would
+// otherwise wipe every row).
+func (h *VMs) Reconcile(w http.ResponseWriter, r *http.Request) {
+	rep, err := h.svc.ReconcileVMs(r.Context())
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	response.Success(w, rep)
+}

--- a/internal/api/handlers/vms.go
+++ b/internal/api/handlers/vms.go
@@ -193,6 +193,29 @@ func (h *VMs) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// Lifecycle handles POST /api/vms/{id}/{op} where op is one of
+// start | shutdown | stop | reboot. Owner-gated like Delete: a non-owning
+// requester gets 404 so existence isn't disclosed.
+func (h *VMs) Lifecycle(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 64)
+	if err != nil {
+		response.BadRequest(w, "invalid id")
+		return
+	}
+	user := ctxutil.User(r.Context())
+	if user == nil {
+		response.Error(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+	op := provision.VMLifecycleOp(chi.URLParam(r, "op"))
+	if err := h.svc.LifecycleOp(r.Context(), uint(id), user.ID, op); err != nil {
+		response.FromError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // GetPrivateKey handles GET /api/vms/{id}/private-key. Returns
 // {key_name, private_key} for vault-stored keys; 404 when no key was
 // deposited for this VM.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -67,7 +67,10 @@ func NewRouter(d Deps) http.Handler {
 		WithTunnelAppliers(d.Provision).
 		WithTunnelInfoSetter(tunnels).
 		WithGPUAppliers(d.Provision).
-		WithNimbusAppURL(d.Config.AppURL)
+		WithNimbusAppURL(d.Config.AppURL).
+		WithNetworkAppliers(d.Provision).
+		WithNetworkOps(d.Provision).
+		WithPoolReseeder(d.Pool)
 	if d.SelfBootstrap != nil {
 		settingsBuilder = settingsBuilder.WithSelfBootstrap(d.SelfBootstrap)
 	}
@@ -196,6 +199,14 @@ func NewRouter(d Deps) http.Handler {
 				r.Put("/settings/gopher", settings.SaveGopher)
 				r.Get("/settings/gopher/self-bootstrap", settings.SelfBootstrapStatus)
 				r.Post("/settings/gopher/self-bootstrap", settings.SelfBootstrapStart)
+				r.Get("/settings/network", settings.GetNetwork)
+				r.Put("/settings/network", settings.SaveNetwork)
+				// Disruptive batch ops — generous timeout because each VM
+				// reboot waits on a Proxmox task.
+				r.With(middleware.Timeout(15*time.Minute)).
+					Post("/settings/network/renumber-vms", settings.RenumberVMs)
+				r.With(middleware.Timeout(15*time.Minute)).
+					Post("/settings/network/force-gateway-update", settings.ForceGatewayUpdate)
 				r.Get("/tunnels", tunnels.List)
 
 				// S3 storage (singleton MinIO VM) — admin-only.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -180,6 +180,11 @@ func NewRouter(d Deps) http.Handler {
 				// (per-node walks) — give it a longer timeout.
 				r.With(middleware.Timeout(60*time.Second)).
 					Post("/ips/reconcile", ips.Reconcile)
+				// VM-table reconcile: tracks migrations and soft-deletes
+				// orphan rows that have been missing from Proxmox for N
+				// consecutive runs. Refuses on empty cluster snapshot.
+				r.With(middleware.Timeout(60*time.Second)).
+					Post("/vms/reconcile", vms.Reconcile)
 
 				// Bootstrap templates can take 10-20 minutes when
 				// downloading all 4 OSes across every online node —

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -174,6 +174,12 @@ func NewRouter(d Deps) http.Handler {
 				r.Get("/ips", ips.List)
 				r.Get("/cluster/vms", cluster.ListVMs)
 				r.Delete("/cluster/vms/{id}", cluster.DeleteVM)
+				// Power operations on any cluster VM (local / foreign /
+				// external). Routed by (node, vmid) so foreign + external
+				// rows that have no nimbus DB id are still reachable.
+				// Reboot waits on a Proxmox task — give it some headroom.
+				r.With(middleware.Timeout(2*time.Minute)).
+					Post("/cluster/vms/{node}/{vmid}/{op}", cluster.VMLifecycle)
 				r.Get("/cluster/stats", cluster.Stats)
 
 				// Reconcile can run a few seconds on a busy cluster
@@ -255,6 +261,10 @@ func NewRouter(d Deps) http.Handler {
 					r.Get("/{id}", vms.Get)
 					r.Get("/{id}/private-key", vms.GetPrivateKey)
 					r.Delete("/{id}", vms.Delete)
+					// Power operations on the caller's own VM. Reboot
+					// waits on a Proxmox task — give it some room.
+					r.With(middleware.Timeout(2*time.Minute)).
+						Post("/{id}/{op:start|shutdown|stop|reboot}", vms.Lifecycle)
 					// Per-port tunnels on top of the VM's Gopher machine —
 					// the post-provision Networks surface.
 					r.Get("/{id}/tunnels", vms.ListTunnels)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -200,6 +200,11 @@ type VM struct {
 	TunnelURL   string `gorm:"column:tunnel_url"                       json:"tunnel_url,omitempty"`
 	TunnelError string `gorm:"column:tunnel_error"                     json:"tunnel_error,omitempty"`
 	ErrorMsg    string `gorm:"column:error_msg"                        json:"error_msg,omitempty"`
+	// MissedCycles counts consecutive VM-reconciler runs in which Proxmox
+	// reported no VM at this row's (node, vmid). Reset to 0 whenever the VM
+	// is observed again. Crossing VACATE_MISS_THRESHOLD soft-deletes the row.
+	// Default 0 — pre-existing rows behave correctly without backfill.
+	MissedCycles int `gorm:"column:missed_cycles;default:0"          json:"missed_cycles,omitempty"`
 }
 
 // SSHKey is a first-class user-managed SSH key.

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -278,3 +278,15 @@ type S3Storage struct {
 
 // TableName pins the table name; without this GORM would pluralize to "s3_storages".
 func (S3Storage) TableName() string { return "s3_storage" }
+
+// NetworkSettings stores the runtime-editable IP pool range and gateway. Only a
+// single row (ID=1) is used. The columns mirror the env vars they replace
+// (IP_POOL_START / IP_POOL_END / GATEWAY_IP) — env vars now act as first-boot
+// defaults only; once the row is populated, the DB is the source of truth and
+// admins manage these from Settings → Network.
+type NetworkSettings struct {
+	ID          uint   `gorm:"primaryKey"`
+	IPPoolStart string `gorm:"default:''"`
+	IPPoolEnd   string `gorm:"default:''"`
+	GatewayIP   string `gorm:"default:''"`
+}

--- a/internal/ippool/pool.go
+++ b/internal/ippool/pool.go
@@ -86,6 +86,81 @@ func (p *Pool) Seed(ctx context.Context, start, end string) error {
 		Create(&addresses).Error
 }
 
+// Reseed converges the pool to [start, end]: inserts addresses inside the new
+// range that aren't already there, and deletes rows OUTSIDE the new range
+// that are still free. Allocated/reserved/external rows outside the new range
+// are left in place — they'd need explicit operator action (renumber the VM,
+// release the row) before they can be cleaned up.
+//
+// Returns the count of rows added, removed-free, and left-stranded
+// (allocated/reserved outside the new range) for caller logging.
+func (p *Pool) Reseed(ctx context.Context, start, end string) (added, removedFree, stranded int, err error) {
+	startIP := net.ParseIP(start).To4()
+	endIP := net.ParseIP(end).To4()
+	if startIP == nil || endIP == nil {
+		return 0, 0, 0, fmt.Errorf("%w: %q .. %q", ErrInvalidRange, start, end)
+	}
+	if compareIP(endIP, startIP) < 0 {
+		return 0, 0, 0, fmt.Errorf("%w: end %s precedes start %s", ErrInvalidRange, end, start)
+	}
+
+	// Insert any addresses inside the new range that aren't already rows.
+	addresses := make([]IPAllocation, 0, 256)
+	cur := append(net.IP(nil), startIP...)
+	for {
+		addresses = append(addresses, IPAllocation{IP: cur.String(), Status: StatusFree})
+		if cur.Equal(endIP) {
+			break
+		}
+		incrementIP(cur)
+		if len(addresses) > 65536 {
+			return 0, 0, 0, fmt.Errorf("%w: range exceeds 65536 addresses", ErrInvalidRange)
+		}
+	}
+	insertRes := p.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&addresses)
+	if insertRes.Error != nil {
+		return 0, 0, 0, fmt.Errorf("seed insert: %w", insertRes.Error)
+	}
+	added = int(insertRes.RowsAffected)
+
+	// Delete free rows outside the new range. Allocated/reserved/external
+	// rows outside the range are *kept* — operator-visible debt.
+	delRes := p.db.WithContext(ctx).
+		Where("status = ? AND (ip < ? OR ip > ?)", StatusFree, start, end).
+		Delete(&IPAllocation{})
+	if delRes.Error != nil {
+		return added, 0, 0, fmt.Errorf("prune free rows: %w", delRes.Error)
+	}
+	removedFree = int(delRes.RowsAffected)
+
+	// Count what's left outside the new range so the caller can report it.
+	var strandedCount int64
+	if err := p.db.WithContext(ctx).
+		Model(&IPAllocation{}).
+		Where("ip < ? OR ip > ?", start, end).
+		Count(&strandedCount).Error; err != nil {
+		return added, removedFree, 0, fmt.Errorf("count stranded: %w", err)
+	}
+	stranded = int(strandedCount)
+	return added, removedFree, stranded, nil
+}
+
+// CountFree returns how many rows are currently status=free. Used by the
+// renumber flow to validate that the new pool has enough capacity for every
+// VM we're about to re-IP.
+func (p *Pool) CountFree(ctx context.Context) (int, error) {
+	var n int64
+	if err := p.db.WithContext(ctx).
+		Model(&IPAllocation{}).
+		Where("status = ?", StatusFree).
+		Count(&n).Error; err != nil {
+		return 0, fmt.Errorf("count free: %w", err)
+	}
+	return int(n), nil
+}
+
 // Reserve atomically claims the first free IP and tags it with hostname.
 // Returns ErrPoolExhausted when none is available.
 //

--- a/internal/ippool/pool.go
+++ b/internal/ippool/pool.go
@@ -242,6 +242,32 @@ func (p *Pool) Release(ctx context.Context, ip string) error {
 	return nil
 }
 
+// Drop removes the row for an IP entirely (DELETE, not soft-delete). Used by
+// the renumber path to evict allocated rows that fall outside the new pool
+// range — Release would just mark them free, which then re-pollutes Reserve's
+// "lowest free IP" pick. Idempotent: missing rows return nil.
+func (p *Pool) Drop(ctx context.Context, ip string) error {
+	if err := p.db.WithContext(ctx).
+		Where("ip = ?", ip).
+		Delete(&IPAllocation{}).Error; err != nil {
+		return fmt.Errorf("drop %s: %w", ip, err)
+	}
+	return nil
+}
+
+// InRange reports whether ip falls within the inclusive [start, end] IPv4
+// range. Returns false on parse error so callers treat malformed inputs as
+// out-of-range (safe default — a Drop is reversible by re-Seeding).
+func InRange(ip, start, end string) bool {
+	a := net.ParseIP(ip).To4()
+	s := net.ParseIP(start).To4()
+	e := net.ParseIP(end).To4()
+	if a == nil || s == nil || e == nil {
+		return false
+	}
+	return compareIP(a, s) >= 0 && compareIP(a, e) <= 0
+}
+
 // List returns all IP allocations ordered by IP. Useful for the admin UI and
 // debugging.
 func (p *Pool) List(ctx context.Context) ([]IPAllocation, error) {

--- a/internal/ippool/pool_test.go
+++ b/internal/ippool/pool_test.go
@@ -418,3 +418,106 @@ func TestReleaseStaleReservations(t *testing.T) {
 		}
 	})
 }
+
+func TestReseed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("growing the range adds new addresses", func(t *testing.T) {
+		p := newTestPool(t)
+		ctx := context.Background()
+		if err := p.Seed(ctx, "10.0.0.10", "10.0.0.12"); err != nil {
+			t.Fatalf("Seed: %v", err)
+		}
+		added, removedFree, stranded, err := p.Reseed(ctx, "10.0.0.10", "10.0.0.15")
+		if err != nil {
+			t.Fatalf("Reseed: %v", err)
+		}
+		if added != 3 || removedFree != 0 || stranded != 0 {
+			t.Errorf("added=%d removedFree=%d stranded=%d; want 3/0/0", added, removedFree, stranded)
+		}
+		got, _ := p.List(ctx)
+		if len(got) != 6 {
+			t.Errorf("post-grow rows = %d, want 6", len(got))
+		}
+	})
+
+	t.Run("shrinking removes free rows outside new range", func(t *testing.T) {
+		p := newTestPool(t)
+		ctx := context.Background()
+		if err := p.Seed(ctx, "10.0.0.10", "10.0.0.15"); err != nil {
+			t.Fatalf("Seed: %v", err)
+		}
+		added, removedFree, stranded, err := p.Reseed(ctx, "10.0.0.10", "10.0.0.12")
+		if err != nil {
+			t.Fatalf("Reseed: %v", err)
+		}
+		if added != 0 || removedFree != 3 || stranded != 0 {
+			t.Errorf("added=%d removedFree=%d stranded=%d; want 0/3/0", added, removedFree, stranded)
+		}
+		got, _ := p.List(ctx)
+		if len(got) != 3 {
+			t.Errorf("post-shrink rows = %d, want 3", len(got))
+		}
+	})
+
+	t.Run("shrinking leaves allocated rows stranded outside the range", func(t *testing.T) {
+		p := newTestPool(t)
+		ctx := context.Background()
+		if err := p.Seed(ctx, "10.0.0.10", "10.0.0.15"); err != nil {
+			t.Fatalf("Seed: %v", err)
+		}
+		// Force-allocate .14 (will be outside the new range).
+		if err := p.AdoptAllocation(ctx, "10.0.0.14", 999, "stranded-host"); err != nil {
+			t.Fatalf("AdoptAllocation: %v", err)
+		}
+
+		added, removedFree, stranded, err := p.Reseed(ctx, "10.0.0.10", "10.0.0.12")
+		if err != nil {
+			t.Fatalf("Reseed: %v", err)
+		}
+		if added != 0 {
+			t.Errorf("added=%d, want 0", added)
+		}
+		// .13, .15 were free → removed (2). .14 allocated → kept (1 stranded).
+		if removedFree != 2 {
+			t.Errorf("removedFree=%d, want 2", removedFree)
+		}
+		if stranded != 1 {
+			t.Errorf("stranded=%d, want 1", stranded)
+		}
+		// .14 row must still exist with its allocation.
+		row, err := p.GetByIP(ctx, "10.0.0.14")
+		if err != nil {
+			t.Fatalf("stranded row .14 missing: %v", err)
+		}
+		if row.Status != ippool.StatusAllocated {
+			t.Errorf(".14 status = %s, want allocated", row.Status)
+		}
+	})
+
+	t.Run("rejects invalid range", func(t *testing.T) {
+		p := newTestPool(t)
+		_, _, _, err := p.Reseed(context.Background(), "not-an-ip", "10.0.0.5")
+		if !errors.Is(err, ippool.ErrInvalidRange) {
+			t.Errorf("err = %v, want ErrInvalidRange", err)
+		}
+	})
+}
+
+func TestCountFree(t *testing.T) {
+	t.Parallel()
+	p := newTestPool(t)
+	ctx := context.Background()
+	if err := p.Seed(ctx, "10.0.0.10", "10.0.0.14"); err != nil {
+		t.Fatalf("Seed: %v", err)
+	}
+	if n, err := p.CountFree(ctx); err != nil || n != 5 {
+		t.Errorf("CountFree pre-reserve = %d, %v; want 5, nil", n, err)
+	}
+	if _, err := p.Reserve(ctx, "x"); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if n, err := p.CountFree(ctx); err != nil || n != 4 {
+		t.Errorf("CountFree post-reserve = %d, %v; want 4, nil", n, err)
+	}
+}

--- a/internal/ippool/reconcile.go
+++ b/internal/ippool/reconcile.go
@@ -39,15 +39,25 @@ type ClusterIPLister interface {
 	ListClusterIPs(ctx context.Context) ([]proxmox.ClusterIP, error)
 }
 
+// UnreachableVMIDsFunc returns the set of VMIDs whose host node is currently
+// unreachable. The reconciler treats those rows' "missing from snapshot" as
+// "we just can't see them right now" instead of "the VM is gone" — neither
+// missed_cycles bumps nor vacates fire while the node is offline. A nil
+// return means "no probe wired" → behave as before. Errors inside the
+// implementation should swallow + return nil rather than failing the whole
+// reconcile pass.
+type UnreachableVMIDsFunc func(ctx context.Context) map[int]bool
+
 // Reconciler diffs Proxmox cluster state against the local IP pool and applies
 // targeted fixes. Safe for concurrent use.
 type Reconciler struct {
-	pool          *Pool
-	px            ClusterIPLister
-	staleAfter    time.Duration
-	cacheTTL      time.Duration
-	missThreshold int
-	clock         func() time.Time
+	pool             *Pool
+	px               ClusterIPLister
+	staleAfter       time.Duration
+	cacheTTL         time.Duration
+	missThreshold    int
+	clock            func() time.Time
+	unreachableVMIDs UnreachableVMIDsFunc
 
 	mu       sync.Mutex
 	cached   []proxmox.ClusterIP
@@ -95,6 +105,16 @@ func WithClock(f func() time.Time) Option {
 		if f != nil {
 			r.clock = f
 		}
+	}
+}
+
+// WithUnreachableVMIDs wires a probe that the reconciler consults each cycle
+// to find VMIDs whose Proxmox host is currently unreachable. Misses on those
+// rows become no-ops instead of bumping missed_cycles, so a transient node
+// outage doesn't cascade into IP vacates after VACATE_MISS_THRESHOLD cycles.
+func WithUnreachableVMIDs(f UnreachableVMIDsFunc) Option {
+	return func(r *Reconciler) {
+		r.unreachableVMIDs = f
 	}
 }
 
@@ -201,6 +221,16 @@ func (r *Reconciler) Reconcile(ctx context.Context) (Report, error) {
 		return rep, fmt.Errorf("list local rows: %w", err)
 	}
 
+	// One reachability check per cycle — fans out TCP dials to every node's
+	// pveproxy port. A non-empty result means: when these VMIDs are missing
+	// from the cluster snapshot, treat the absence as a network blip rather
+	// than evidence the VMs were destroyed. Falls back to the old behaviour
+	// (no probe) when the option wasn't wired or the probe returns nil.
+	var unreachable map[int]bool
+	if r.unreachableVMIDs != nil {
+		unreachable = r.unreachableVMIDs(ctx)
+	}
+
 	var errs []error
 	for _, row := range rows {
 		px, hasPx := pxByIP[row.IP]
@@ -222,6 +252,17 @@ func (r *Reconciler) Reconcile(ctx context.Context) (Report, error) {
 		case row.Status == StatusReserved:
 			r.handleReservedMissing(ctx, row, &rep, &errs)
 		case row.Status == StatusAllocated:
+			// Skip the missed-cycle bump when the VM lives on a node we
+			// can't currently reach — most likely a brief outage, not a
+			// genuine destruction. We still TouchSeen so the row's
+			// last_seen_at stays fresh for the stale-detection guard.
+			if row.VMID != nil && unreachable[*row.VMID] {
+				if err := r.pool.TouchSeen(ctx, row.IP); err != nil {
+					errs = append(errs, fmt.Errorf("touch %s (unreachable host): %w", row.IP, err))
+				}
+				rep.NoOps++
+				break
+			}
 			r.handleAllocatedMissing(ctx, row, &rep, &errs)
 		default:
 			rep.NoOps++

--- a/internal/ippool/reconcile_test.go
+++ b/internal/ippool/reconcile_test.go
@@ -377,3 +377,41 @@ func TestReconcile_OutOfRangeProxmoxIPsAreIgnored(t *testing.T) {
 		t.Errorf("out-of-range Proxmox IPs must not affect Adopted/Conflicts: %+v", rep)
 	}
 }
+
+// TestReconcile_UnreachableNodeSuppressesMissBump asserts the reachability
+// guard: when the WithUnreachableVMIDs probe reports that a row’s vmid lives
+// on a node we currently can’t reach, missing-from-snapshot is treated as
+// "still alive, just out of sight" — missed_cycles stays put and the row
+// never gets vacated even after threshold cycles.
+func TestReconcile_UnreachableNodeSuppressesMissBump(t *testing.T) {
+	t.Parallel()
+	p := newSeedPool(t, "10.0.0.1", "10.0.0.5")
+	ctx := context.Background()
+
+	_, _ = p.Reserve(ctx, "host")
+	_ = p.MarkAllocated(ctx, "10.0.0.1", 200)
+
+	emptyLister := staticLister(nil, nil)
+	probe := func(context.Context) map[int]bool { return map[int]bool{200: true} }
+	r := ippool.NewReconciler(p, emptyLister,
+		ippool.WithMissThreshold(2),
+		ippool.WithUnreachableVMIDs(probe),
+	)
+
+	for i := 1; i <= 3; i++ {
+		rep, err := r.Reconcile(ctx)
+		if err != nil {
+			t.Fatalf("Reconcile #%d: %v", i, err)
+		}
+		if len(rep.Vacated) != 0 {
+			t.Errorf("cycle %d vacated %v, must hold while host is unreachable", i, rep.Vacated)
+		}
+		row, _ := p.GetByIP(ctx, "10.0.0.1")
+		if row.MissedCycles != 0 {
+			t.Errorf("cycle %d missed_cycles = %d, want 0 (gate should suppress)", i, row.MissedCycles)
+		}
+		if row.Status != ippool.StatusAllocated {
+			t.Errorf("cycle %d status = %s, want allocated", i, row.Status)
+		}
+	}
+}

--- a/internal/provision/lifecycle_test.go
+++ b/internal/provision/lifecycle_test.go
@@ -1,0 +1,119 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"nimbus/internal/db"
+	internalerrors "nimbus/internal/errors"
+	"nimbus/internal/provision"
+)
+
+// seedOwnedVM seeds a vms row owned by ownerID at the given (vmid, node, ip).
+// Returns the new row id so tests can call lifecycle ops against it.
+func seedOwnedVM(t *testing.T, database *db.DB, ownerID uint, hostname string, vmid int, node string) uint {
+	t.Helper()
+	owner := ownerID
+	row := &db.VM{
+		VMID:       vmid,
+		Hostname:   hostname,
+		IP:         "10.0.0.99",
+		Node:       node,
+		Tier:       "small",
+		OSTemplate: "ubuntu-24.04",
+		Status:     "running",
+		OwnerID:    &owner,
+	}
+	if err := database.Create(row).Error; err != nil {
+		t.Fatalf("seed vm: %v", err)
+	}
+	return row.ID
+}
+
+func TestLifecycleOp_RoutesEachOpAndUpdatesStatus(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		op         provision.VMLifecycleOp
+		wantStatus string
+	}{
+		{provision.VMOpStart, "running"},
+		{provision.VMOpShutdown, "stopped"},
+		{provision.VMOpStop, "stopped"},
+		{provision.VMOpReboot, "running"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.op), func(t *testing.T) {
+			t.Parallel()
+			fake := happyFakePVE(t)
+			svc, _, database := newTestService(t, fake)
+			id := seedOwnedVM(t, database, 42, "vm-a", 200, "alpha")
+
+			if err := svc.LifecycleOp(context.Background(), id, 42, tc.op); err != nil {
+				t.Fatalf("LifecycleOp(%s): %v", tc.op, err)
+			}
+			var got db.VM
+			if err := database.First(&got, id).Error; err != nil {
+				t.Fatalf("re-read: %v", err)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("status after %s = %q, want %q", tc.op, got.Status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestLifecycleOp_NonOwnerGets404(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "vm-a", 200, "alpha")
+
+	err := svc.LifecycleOp(context.Background(), id, 99, provision.VMOpStart)
+	var notFound *internalerrors.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("err = %v, want NotFoundError (existence must not be disclosed)", err)
+	}
+}
+
+func TestLifecycleOp_RejectsUnknownOp(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "vm-a", 200, "alpha")
+
+	err := svc.LifecycleOp(context.Background(), id, 42, provision.VMLifecycleOp("nuke"))
+	var ve *internalerrors.ValidationError
+	if !errors.As(err, &ve) {
+		t.Errorf("err = %v, want ValidationError", err)
+	}
+}
+
+func TestAdminLifecycleByVMID_WorksWithoutLocalRow(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	svc, _, _ := newTestService(t, fake)
+
+	// No local row at all — emulates a foreign / external VM. The op must
+	// still go through (proxmox call succeeds), without erroring.
+	if err := svc.AdminLifecycleByVMID(context.Background(), "alpha", 9999, provision.VMOpStart); err != nil {
+		t.Fatalf("AdminLifecycleByVMID on absent local row: %v", err)
+	}
+}
+
+func TestAdminLifecycleByVMID_StampsStatusOnLocalRow(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	svc, _, database := newTestService(t, fake)
+	id := seedOwnedVM(t, database, 42, "vm-a", 200, "alpha")
+
+	if err := svc.AdminLifecycleByVMID(context.Background(), "alpha", 200, provision.VMOpShutdown); err != nil {
+		t.Fatalf("AdminLifecycleByVMID: %v", err)
+	}
+	var got db.VM
+	if err := database.First(&got, id).Error; err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if got.Status != "stopped" {
+		t.Errorf("local status after admin shutdown = %q, want stopped", got.Status)
+	}
+}

--- a/internal/provision/network_ops.go
+++ b/internal/provision/network_ops.go
@@ -1,0 +1,197 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"nimbus/internal/db"
+	"nimbus/internal/ippool"
+	"nimbus/internal/proxmox"
+)
+
+// NetworkOpReport summarizes a renumber or force-gateway batch run. Updated is
+// the count of VMs that were successfully reconfigured (and rebooted, if
+// applicable). Failures carries one entry per VM that errored — the rest of
+// the batch continues so a single broken VM doesn't block the operation.
+type NetworkOpReport struct {
+	Updated  int
+	Failures []NetworkOpFailure
+}
+
+// NetworkOpFailure pairs a VM identity with the error that aborted its update.
+type NetworkOpFailure struct {
+	VMRowID  uint
+	VMID     int
+	Hostname string
+	Err      string
+}
+
+// managedVMsForNetworkOp returns the VMs the network ops should touch:
+// non-soft-deleted rows with a real Proxmox VMID and node assignment, in
+// status that implies the VM exists on Proxmox (excludes "creating"/"failed").
+func (s *Service) managedVMsForNetworkOp(ctx context.Context) ([]db.VM, error) {
+	var vms []db.VM
+	if err := s.db.WithContext(ctx).
+		Where("vmid > 0 AND node <> '' AND status NOT IN ?", []string{"creating", "failed"}).
+		Order("id ASC").
+		Find(&vms).Error; err != nil {
+		return nil, fmt.Errorf("list vms: %w", err)
+	}
+	return vms, nil
+}
+
+// ForceGatewayUpdate rewrites every managed VM's cloud-init ipconfig0 to use
+// the supplied gateway, keeping each VM's existing IP, then reboots the VM so
+// the new gateway takes effect. Disruptive — every VM bounces. Caller must
+// confirm with the operator.
+//
+// Per-VM failures are collected, not returned, so the batch keeps going. A
+// non-nil error from this method only indicates a setup failure (DB list,
+// invalid gateway).
+func (s *Service) ForceGatewayUpdate(ctx context.Context, gateway string) (NetworkOpReport, error) {
+	if gateway == "" {
+		return NetworkOpReport{}, errors.New("gateway is required")
+	}
+	vms, err := s.managedVMsForNetworkOp(ctx)
+	if err != nil {
+		return NetworkOpReport{}, err
+	}
+	rep := NetworkOpReport{}
+	for _, vm := range vms {
+		if vm.IP == "" {
+			rep.Failures = append(rep.Failures, NetworkOpFailure{
+				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+				Err: "vm has no recorded IP",
+			})
+			continue
+		}
+		ipconfig := fmt.Sprintf("ip=%s/24,gw=%s", vm.IP, gateway)
+		if err := s.px.SetCloudInit(ctx, vm.Node, vm.VMID, proxmox.CloudInitConfig{
+			IPConfig0: ipconfig,
+		}); err != nil {
+			log.Printf("force-gateway: set cloud-init vmid=%d on %s: %v (skipping)", vm.VMID, vm.Node, err)
+			rep.Failures = append(rep.Failures, NetworkOpFailure{
+				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+				Err: "set cloud-init: " + err.Error(),
+			})
+			continue
+		}
+		if err := s.rebootIfRunning(ctx, vm); err != nil {
+			log.Printf("force-gateway: reboot vmid=%d on %s: %v (config saved, will apply on next boot)", vm.VMID, vm.Node, err)
+			rep.Failures = append(rep.Failures, NetworkOpFailure{
+				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+				Err: "config saved but reboot failed: " + err.Error(),
+			})
+			continue
+		}
+		rep.Updated++
+	}
+	return rep, nil
+}
+
+// RenumberAllVMs reassigns every managed VM to a fresh IP from the current
+// pool, updating cloud-init and rebooting each VM in turn. The new pool must
+// already be saved (Reseed run) and have at least len(vms) free addresses.
+//
+// On success, each VM's old IP is released back to the pool (may then be
+// pruned if outside the new range) and the vms.ip column is updated.
+//
+// Disruptive — every VM bounces. Per-VM failures roll back that one VM's
+// reservation but don't abort the batch.
+func (s *Service) RenumberAllVMs(ctx context.Context, gateway string) (NetworkOpReport, error) {
+	if gateway == "" {
+		return NetworkOpReport{}, errors.New("gateway is required")
+	}
+	vms, err := s.managedVMsForNetworkOp(ctx)
+	if err != nil {
+		return NetworkOpReport{}, err
+	}
+	free, err := s.pool.CountFree(ctx)
+	if err != nil {
+		return NetworkOpReport{}, fmt.Errorf("count free: %w", err)
+	}
+	if free < len(vms) {
+		return NetworkOpReport{}, fmt.Errorf("pool has %d free addresses, need %d to renumber every VM", free, len(vms))
+	}
+
+	rep := NetworkOpReport{}
+	for _, vm := range vms {
+		newIP, err := s.pool.Reserve(ctx, vm.Hostname)
+		if err != nil {
+			if errors.Is(err, ippool.ErrPoolExhausted) {
+				rep.Failures = append(rep.Failures, NetworkOpFailure{
+					VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+					Err: "pool exhausted mid-renumber",
+				})
+				return rep, fmt.Errorf("pool exhausted after renumbering %d/%d", rep.Updated, len(vms))
+			}
+			rep.Failures = append(rep.Failures, NetworkOpFailure{
+				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+				Err: "reserve new ip: " + err.Error(),
+			})
+			continue
+		}
+
+		ipconfig := fmt.Sprintf("ip=%s/24,gw=%s", newIP, gateway)
+		if err := s.px.SetCloudInit(ctx, vm.Node, vm.VMID, proxmox.CloudInitConfig{
+			IPConfig0: ipconfig,
+		}); err != nil {
+			_ = s.pool.Release(ctx, newIP)
+			log.Printf("renumber: set cloud-init vmid=%d on %s: %v (rolled back reservation)", vm.VMID, vm.Node, err)
+			rep.Failures = append(rep.Failures, NetworkOpFailure{
+				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+				Err: "set cloud-init: " + err.Error(),
+			})
+			continue
+		}
+
+		if err := s.rebootIfRunning(ctx, vm); err != nil {
+			log.Printf("renumber: reboot vmid=%d on %s: %v (config saved, IP not yet active)", vm.VMID, vm.Node, err)
+			// Don't roll back — the cloud-init drive is already updated.
+			// Mark the new IP allocated and update DB so the operator's
+			// view is consistent; the VM picks up the new IP on next boot.
+		}
+
+		if err := s.pool.MarkAllocated(ctx, newIP, vm.VMID); err != nil {
+			log.Printf("renumber: mark allocated %s vmid=%d: %v", newIP, vm.VMID, err)
+		}
+		oldIP := vm.IP
+		if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("id = ?", vm.ID).Update("ip", newIP).Error; err != nil {
+			log.Printf("renumber: update vms.ip row=%d new=%s: %v", vm.ID, newIP, err)
+			rep.Failures = append(rep.Failures, NetworkOpFailure{
+				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+				Err: "update vm record: " + err.Error(),
+			})
+			continue
+		}
+		if oldIP != "" {
+			if err := s.pool.Release(ctx, oldIP); err != nil {
+				log.Printf("renumber: release old ip %s vmid=%d: %v", oldIP, vm.VMID, err)
+			}
+		}
+		rep.Updated++
+	}
+	return rep, nil
+}
+
+// rebootIfRunning issues a Proxmox reboot only when the local DB believes the
+// VM is running. Avoids returning errors for stopped VMs (which would be
+// expected — Proxmox refuses to reboot a stopped VM, but the cloud-init
+// change still applies on next start).
+func (s *Service) rebootIfRunning(ctx context.Context, vm db.VM) error {
+	if vm.Status != "running" {
+		return nil
+	}
+	taskID, err := s.px.RebootVM(ctx, vm.Node, vm.VMID)
+	if err != nil {
+		return err
+	}
+	if taskID != "" {
+		if err := s.px.WaitForTask(ctx, vm.Node, taskID, s.cfg.PollInterval); err != nil {
+			return fmt.Errorf("reboot task: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/provision/network_ops.go
+++ b/internal/provision/network_ops.go
@@ -100,14 +100,20 @@ func (s *Service) ForceGatewayUpdate(ctx context.Context, gateway string) (Netwo
 // pool, updating cloud-init and rebooting each VM in turn. The new pool must
 // already be saved (Reseed run) and have at least len(vms) free addresses.
 //
-// On success, each VM's old IP is released back to the pool (may then be
-// pruned if outside the new range) and the vms.ip column is updated.
+// poolStart / poolEnd describe the *new* pool range. They're used to decide
+// what to do with each VM's old IP after the swap: in-range → Release (return
+// to free pool, can be reused by a later iteration), out-of-range → Drop
+// (delete the row entirely so it never reappears as "free" and pollutes
+// Reserve's lowest-free pick).
 //
 // Disruptive — every VM bounces. Per-VM failures roll back that one VM's
 // reservation but don't abort the batch.
-func (s *Service) RenumberAllVMs(ctx context.Context, gateway string) (NetworkOpReport, error) {
+func (s *Service) RenumberAllVMs(ctx context.Context, gateway, poolStart, poolEnd string) (NetworkOpReport, error) {
 	if gateway == "" {
 		return NetworkOpReport{}, errors.New("gateway is required")
+	}
+	if poolStart == "" || poolEnd == "" {
+		return NetworkOpReport{}, errors.New("pool range is required")
 	}
 	vms, err := s.managedVMsForNetworkOp(ctx)
 	if err != nil {
@@ -176,8 +182,17 @@ func (s *Service) RenumberAllVMs(ctx context.Context, gateway string) (NetworkOp
 			continue
 		}
 		if oldIP != "" {
-			if err := s.pool.Release(ctx, oldIP); err != nil {
-				log.Printf("renumber: release old ip %s vmid=%d: %v", oldIP, vm.VMID, err)
+			// In-range old IPs return to the free pool (can be reused by a
+			// later iteration). Out-of-range old IPs would re-pollute
+			// Reserve's lex-lowest pick if marked free, so drop them outright.
+			if ippool.InRange(oldIP, poolStart, poolEnd) {
+				if err := s.pool.Release(ctx, oldIP); err != nil {
+					log.Printf("renumber: release old ip %s vmid=%d: %v", oldIP, vm.VMID, err)
+				}
+			} else {
+				if err := s.pool.Drop(ctx, oldIP); err != nil {
+					log.Printf("renumber: drop stranded ip %s vmid=%d: %v", oldIP, vm.VMID, err)
+				}
 			}
 		}
 		rep.Updated++

--- a/internal/provision/network_ops.go
+++ b/internal/provision/network_ops.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"nimbus/internal/db"
 	"nimbus/internal/ippool"
@@ -71,14 +72,18 @@ func (s *Service) ForceGatewayUpdate(ctx context.Context, gateway string) (Netwo
 		if err := s.px.SetCloudInit(ctx, vm.Node, vm.VMID, proxmox.CloudInitConfig{
 			IPConfig0: ipconfig,
 		}); err != nil {
+			msg := "set cloud-init: " + err.Error()
+			if isVMConfigMissing(err) {
+				msg = fmt.Sprintf("vm not present on node %s — local DB is out of sync (try a reconcile)", vm.Node)
+			}
 			log.Printf("force-gateway: set cloud-init vmid=%d on %s: %v (skipping)", vm.VMID, vm.Node, err)
 			rep.Failures = append(rep.Failures, NetworkOpFailure{
 				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
-				Err: "set cloud-init: " + err.Error(),
+				Err: msg,
 			})
 			continue
 		}
-		if err := s.rebootIfRunning(ctx, vm); err != nil {
+		if err := s.rebootForNetworkChange(ctx, vm); err != nil {
 			log.Printf("force-gateway: reboot vmid=%d on %s: %v (config saved, will apply on next boot)", vm.VMID, vm.Node, err)
 			rep.Failures = append(rep.Failures, NetworkOpFailure{
 				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
@@ -139,15 +144,19 @@ func (s *Service) RenumberAllVMs(ctx context.Context, gateway string) (NetworkOp
 			IPConfig0: ipconfig,
 		}); err != nil {
 			_ = s.pool.Release(ctx, newIP)
+			msg := "set cloud-init: " + err.Error()
+			if isVMConfigMissing(err) {
+				msg = fmt.Sprintf("vm not present on node %s — local DB is out of sync (try a reconcile)", vm.Node)
+			}
 			log.Printf("renumber: set cloud-init vmid=%d on %s: %v (rolled back reservation)", vm.VMID, vm.Node, err)
 			rep.Failures = append(rep.Failures, NetworkOpFailure{
 				VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
-				Err: "set cloud-init: " + err.Error(),
+				Err: msg,
 			})
 			continue
 		}
 
-		if err := s.rebootIfRunning(ctx, vm); err != nil {
+		if err := s.rebootForNetworkChange(ctx, vm); err != nil {
 			log.Printf("renumber: reboot vmid=%d on %s: %v (config saved, IP not yet active)", vm.VMID, vm.Node, err)
 			// Don't roll back — the cloud-init drive is already updated.
 			// Mark the new IP allocated and update DB so the operator's
@@ -176,16 +185,18 @@ func (s *Service) RenumberAllVMs(ctx context.Context, gateway string) (NetworkOp
 	return rep, nil
 }
 
-// rebootIfRunning issues a Proxmox reboot only when the local DB believes the
-// VM is running. Avoids returning errors for stopped VMs (which would be
-// expected — Proxmox refuses to reboot a stopped VM, but the cloud-init
-// change still applies on next start).
-func (s *Service) rebootIfRunning(ctx context.Context, vm db.VM) error {
-	if vm.Status != "running" {
-		return nil
-	}
+// rebootForNetworkChange issues a Proxmox reboot so the new cloud-init
+// applies. The local vms.status column is unreliable (the reconciler doesn't
+// keep it in sync with Proxmox power state), so we always attempt the reboot
+// and let Proxmox tell us when there's no work — its "VM N not running" 500
+// is treated as a no-op since cloud-init will apply on next boot anyway.
+func (s *Service) rebootForNetworkChange(ctx context.Context, vm db.VM) error {
 	taskID, err := s.px.RebootVM(ctx, vm.Node, vm.VMID)
 	if err != nil {
+		if isVMNotRunning(err) {
+			// VM is stopped — config is already on disk; next boot picks it up.
+			return nil
+		}
 		return err
 	}
 	if taskID != "" {
@@ -194,4 +205,28 @@ func (s *Service) rebootIfRunning(ctx context.Context, vm db.VM) error {
 		}
 	}
 	return nil
+}
+
+// isVMNotRunning matches the Proxmox 500 body that means "you asked me to
+// reboot a stopped VM" — fine for our purposes; the cloud-init drive is
+// already updated and the change applies on next boot.
+func isVMNotRunning(err error) bool {
+	var httpErr *proxmox.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	return httpErr.Status == 500 && strings.Contains(httpErr.Body, "not running")
+}
+
+// isVMConfigMissing matches the Proxmox 500 body for "Configuration file
+// 'nodes/<node>/qemu-server/<vmid>.conf' does not exist" — the VM has drifted
+// off this node (manual migration, manual destroy) but nimbus's DB still
+// thinks it lives here. Surface a cleaner failure message so the operator
+// knows to clean up the row rather than chasing a Proxmox-internal error.
+func isVMConfigMissing(err error) bool {
+	var httpErr *proxmox.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	return httpErr.Status == 500 && strings.Contains(httpErr.Body, "does not exist")
 }

--- a/internal/provision/network_ops_test.go
+++ b/internal/provision/network_ops_test.go
@@ -1,0 +1,145 @@
+package provision_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"nimbus/internal/db"
+	"nimbus/internal/proxmox"
+)
+
+func seedManagedVM(t *testing.T, database *db.DB, hostname string, vmid int, ip string) {
+	t.Helper()
+	if err := database.Create(&db.VM{
+		VMID:       vmid,
+		Hostname:   hostname,
+		IP:         ip,
+		Node:       "alpha",
+		Tier:       "small",
+		OSTemplate: "ubuntu-24.04",
+		Status:     "running",
+	}).Error; err != nil {
+		t.Fatalf("seed vm %s: %v", hostname, err)
+	}
+}
+
+func TestForceGatewayUpdate_PushesNewGatewayKeepsIP(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	svc, _, database := newTestService(t, fake)
+
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
+
+	rep, err := svc.ForceGatewayUpdate(context.Background(), "10.0.0.99")
+	if err != nil {
+		t.Fatalf("ForceGatewayUpdate: %v", err)
+	}
+	if rep.Updated != 2 || len(rep.Failures) != 0 {
+		t.Fatalf("rep = %+v; want Updated=2 Failures=0", rep)
+	}
+
+	// The last cloud-init call is recorded on the fake — confirm it carries
+	// the new gateway with the VM's existing IP.
+	got := fake.cloudInitArgs.Load()
+	if got == nil {
+		t.Fatal("no SetCloudInit call recorded")
+	}
+	if !strings.Contains(got.IPConfig0, "gw=10.0.0.99") {
+		t.Errorf("ipconfig0 = %q, want gw=10.0.0.99", got.IPConfig0)
+	}
+	if !strings.Contains(got.IPConfig0, "ip=10.0.0.3") {
+		t.Errorf("ipconfig0 = %q, want ip=10.0.0.3 (vm-b's existing IP)", got.IPConfig0)
+	}
+}
+
+func TestForceGatewayUpdate_RejectsEmptyGateway(t *testing.T) {
+	t.Parallel()
+	svc, _, _ := newTestService(t, happyFakePVE(t))
+	if _, err := svc.ForceGatewayUpdate(context.Background(), ""); err == nil {
+		t.Error("expected error for empty gateway, got nil")
+	}
+}
+
+func TestForceGatewayUpdate_PerVMFailureDoesNotAbortBatch(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	// First call fails, second succeeds — batch should report 1/1.
+	calls := 0
+	fake.setCloudInit = func(_ context.Context, _ string, _ int, _ proxmox.CloudInitConfig) error {
+		calls++
+		if calls == 1 {
+			return errAPIDown
+		}
+		return nil
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
+
+	rep, err := svc.ForceGatewayUpdate(context.Background(), "10.0.0.99")
+	if err != nil {
+		t.Fatalf("ForceGatewayUpdate: %v", err)
+	}
+	if rep.Updated != 1 || len(rep.Failures) != 1 {
+		t.Errorf("rep = %+v; want Updated=1 Failures=1", rep)
+	}
+}
+
+func TestRenumberAllVMs_RejectsWhenPoolTooSmall(t *testing.T) {
+	t.Parallel()
+	svc, pool, database := newTestService(t, happyFakePVE(t))
+	// Pool has 5 free addresses; allocate 3 of them so only 2 are free,
+	// then seed 3 VMs — pool capacity is 2, demand is 3 → should refuse.
+	for i := 0; i < 3; i++ {
+		if _, err := pool.Reserve(context.Background(), "filler"); err != nil {
+			t.Fatalf("Reserve: %v", err)
+		}
+	}
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
+	seedManagedVM(t, database, "vm-c", 202, "10.0.0.4")
+
+	if _, err := svc.RenumberAllVMs(context.Background(), "10.0.0.1"); err == nil {
+		t.Error("expected error when pool capacity < vm count, got nil")
+	}
+}
+
+func TestRenumberAllVMs_HappyPathReassignsIPsAndUpdatesDB(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
+
+	rep, err := svc.RenumberAllVMs(context.Background(), "10.0.0.1")
+	if err != nil {
+		t.Fatalf("RenumberAllVMs: %v", err)
+	}
+	if rep.Updated != 2 || len(rep.Failures) != 0 {
+		t.Fatalf("rep = %+v; want Updated=2 Failures=0", rep)
+	}
+
+	// VM rows should now show fresh IPs from the pool, distinct from the
+	// originals. Pool was seeded 10.0.0.1..5; existing VMs held .2 and .3.
+	// After Reserve cycles, the lowest-free addresses get handed out — at
+	// minimum the new IPs differ from the old ones.
+	var vms []db.VM
+	if err := database.WithContext(context.Background()).Order("id ASC").Find(&vms).Error; err != nil {
+		t.Fatalf("list vms: %v", err)
+	}
+	if len(vms) != 2 {
+		t.Fatalf("vm count = %d, want 2", len(vms))
+	}
+	if vms[0].IP == "10.0.0.2" && vms[1].IP == "10.0.0.3" {
+		t.Errorf("VMs still hold their original IPs (%s, %s) — renumber did not write back", vms[0].IP, vms[1].IP)
+	}
+}
+
+// errAPIDown is a sentinel for the per-VM-failure batch test.
+var errAPIDown = &fakeAPIErr{msg: "proxmox unreachable"}
+
+type fakeAPIErr struct{ msg string }
+
+func (e *fakeAPIErr) Error() string { return e.msg }

--- a/internal/provision/network_ops_test.go
+++ b/internal/provision/network_ops_test.go
@@ -9,6 +9,25 @@ import (
 	"nimbus/internal/proxmox"
 )
 
+// proxmoxNotRunningErr fakes the 500 body Proxmox returns when reboot is
+// called against a stopped VM. The network-ops code should treat this as a
+// no-op (cloud-init applies on next boot anyway).
+var proxmoxNotRunningErr = &proxmox.HTTPError{
+	Status: 500,
+	Method: "POST",
+	Path:   "/nodes/x/qemu/200/status/reboot",
+	Body:   `{"data":null,"message":"VM 200 not running\n"}`,
+}
+
+// proxmoxConfigMissingErr fakes the 500 body Proxmox returns when the qemu
+// config file is gone — the VM has drifted off this node.
+var proxmoxConfigMissingErr = &proxmox.HTTPError{
+	Status: 500,
+	Method: "POST",
+	Path:   "/nodes/x/qemu/200/config",
+	Body:   `{"message":"Configuration file 'nodes/x/qemu-server/200.conf' does not exist\n","data":null}`,
+}
+
 func seedManagedVM(t *testing.T, database *db.DB, hostname string, vmid int, ip string) {
 	t.Helper()
 	if err := database.Create(&db.VM{
@@ -143,3 +162,47 @@ var errAPIDown = &fakeAPIErr{msg: "proxmox unreachable"}
 type fakeAPIErr struct{ msg string }
 
 func (e *fakeAPIErr) Error() string { return e.msg }
+
+func TestForceGatewayUpdate_StoppedVMCountsAsSuccess(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	// Proxmox refuses to reboot a stopped VM with 500 + "not running" body.
+	// The cloud-init drive is already updated; the VM picks up the new
+	// gateway on next boot, so this should NOT count as a failure.
+	fake.rebootVM = func(_ context.Context, _ string, _ int) (string, error) {
+		return "", proxmoxNotRunningErr
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
+
+	rep, err := svc.ForceGatewayUpdate(context.Background(), "10.0.0.99")
+	if err != nil {
+		t.Fatalf("ForceGatewayUpdate: %v", err)
+	}
+	if rep.Updated != 2 || len(rep.Failures) != 0 {
+		t.Errorf("rep = %+v; want Updated=2 Failures=0 (stopped VMs are success)", rep)
+	}
+}
+
+func TestForceGatewayUpdate_VMNotPresentOnNodeSurfacesCleanMessage(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.setCloudInit = func(_ context.Context, _ string, _ int, _ proxmox.CloudInitConfig) error {
+		return proxmoxConfigMissingErr
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-stale", 200, "10.0.0.2")
+
+	rep, err := svc.ForceGatewayUpdate(context.Background(), "10.0.0.99")
+	if err != nil {
+		t.Fatalf("ForceGatewayUpdate: %v", err)
+	}
+	if rep.Updated != 0 || len(rep.Failures) != 1 {
+		t.Fatalf("rep = %+v; want Updated=0 Failures=1", rep)
+	}
+	got := rep.Failures[0].Err
+	if !strings.Contains(got, "vm not present on node") || !strings.Contains(got, "out of sync") {
+		t.Errorf("failure message = %q, want clean drift message", got)
+	}
+}

--- a/internal/provision/network_ops_test.go
+++ b/internal/provision/network_ops_test.go
@@ -120,8 +120,65 @@ func TestRenumberAllVMs_RejectsWhenPoolTooSmall(t *testing.T) {
 	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
 	seedManagedVM(t, database, "vm-c", 202, "10.0.0.4")
 
-	if _, err := svc.RenumberAllVMs(context.Background(), "10.0.0.1"); err == nil {
+	if _, err := svc.RenumberAllVMs(context.Background(), "10.0.0.1", "10.0.0.1", "10.0.0.5"); err == nil {
 		t.Error("expected error when pool capacity < vm count, got nil")
+	}
+}
+
+func TestRenumberAllVMs_DropsStrandedOldIPsSoTheyDoNotPolluteReserve(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	svc, pool, database := newTestService(t, fake)
+
+	// newTestService seeds the pool with 10.0.0.1..5. To simulate the user's
+	// scenario, adopt a stranded "old-pool" address (192.168.0.151) into the
+	// table the same way Reseed would have left it after a pool migration.
+	// First we have to inject the row.
+	if err := pool.Seed(context.Background(), "192.168.0.151", "192.168.0.151"); err != nil {
+		t.Fatalf("seed stranded: %v", err)
+	}
+	// Allocate it to a VM that's about to be renumbered.
+	seedManagedVM(t, database, "vm-stranded", 200, "192.168.0.151")
+	if err := pool.AdoptAllocation(context.Background(), "192.168.0.151", 200, "vm-stranded"); err != nil {
+		t.Fatalf("adopt stranded: %v", err)
+	}
+
+	// Renumber into the new pool [10.0.0.1, 10.0.0.5]. With the bug, the loop
+	// would Release 192.168.0.151 back to free, and a *subsequent* Reserve
+	// would pick it (lex < 10.0.0.x in 4-byte comparison? actually 10.0.0.x <
+	// 192.168.0.x, so this case wouldn't reproduce — flip ranges to match the
+	// real-world incident).
+	// The user hit it with pool 192.168.50.* and stranded 192.168.0.* which
+	// IS lex-lower than 192.168.50.* so freed-stranded-row WAS picked up.
+	// Use that exact shape here:
+	if _, _, _, err := pool.Reseed(context.Background(), "192.168.50.1", "192.168.50.5"); err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+
+	rep, err := svc.RenumberAllVMs(context.Background(), "192.168.50.1", "192.168.50.1", "192.168.50.5")
+	if err != nil {
+		t.Fatalf("RenumberAllVMs: %v", err)
+	}
+	if rep.Updated != 1 || len(rep.Failures) != 0 {
+		t.Fatalf("rep = %+v; want Updated=1 Failures=0", rep)
+	}
+
+	// The stranded row must be GONE from the pool table — not lingering as
+	// status=free where the next Reserve would pick it up.
+	if _, err := pool.GetByIP(context.Background(), "192.168.0.151"); err == nil {
+		t.Errorf("192.168.0.151 still in pool — should have been dropped on renumber")
+	}
+
+	// And the VM should now hold a 192.168.50.* address.
+	var got db.VM
+	if err := database.WithContext(context.Background()).First(&got, "vmid = ?", 200).Error; err != nil {
+		t.Fatalf("re-read vm: %v", err)
+	}
+	if got.IP == "192.168.0.151" {
+		t.Errorf("vm.IP = %q, expected to have moved into the new pool", got.IP)
+	}
+	if !strings.HasPrefix(got.IP, "192.168.50.") {
+		t.Errorf("vm.IP = %q, want a 192.168.50.x address from the new pool", got.IP)
 	}
 }
 
@@ -132,7 +189,7 @@ func TestRenumberAllVMs_HappyPathReassignsIPsAndUpdatesDB(t *testing.T) {
 	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
 	seedManagedVM(t, database, "vm-b", 201, "10.0.0.3")
 
-	rep, err := svc.RenumberAllVMs(context.Background(), "10.0.0.1")
+	rep, err := svc.RenumberAllVMs(context.Background(), "10.0.0.1", "10.0.0.1", "10.0.0.5")
 	if err != nil {
 		t.Fatalf("RenumberAllVMs: %v", err)
 	}

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -77,6 +77,7 @@ type ProxmoxClient interface {
 	ResizeDisk(ctx context.Context, node string, vmid int, disk, size string) error
 	StartVM(ctx context.Context, node string, vmid int) (string, error)
 	StopVM(ctx context.Context, node string, vmid int) (string, error)
+	ShutdownVM(ctx context.Context, node string, vmid int) (string, error)
 	RebootVM(ctx context.Context, node string, vmid int) (string, error)
 	DestroyVM(ctx context.Context, node string, vmid int) (string, error)
 	GetAgentInterfaces(ctx context.Context, node string, vmid int) ([]proxmox.NetworkInterface, error)
@@ -736,6 +737,136 @@ func (s *Service) Delete(ctx context.Context, id, requesterID uint) error {
 		return &internalerrors.NotFoundError{Resource: "vm", ID: fmt.Sprintf("%d", id)}
 	}
 	return s.deleteVM(ctx, &vm)
+}
+
+// VMLifecycleOp identifies one of the four user-facing power operations.
+// Used by the user-scoped lifecycle wrapper so the handler doesn't have to
+// know which Proxmox endpoint corresponds to each verb.
+type VMLifecycleOp string
+
+const (
+	VMOpStart    VMLifecycleOp = "start"
+	VMOpShutdown VMLifecycleOp = "shutdown" // graceful (guest agent / ACPI)
+	VMOpStop     VMLifecycleOp = "stop"     // force (pull plug)
+	VMOpReboot   VMLifecycleOp = "reboot"
+)
+
+// LifecycleOp issues a power operation against a VM the requester owns.
+// Same ownership semantics as Delete: a non-owning caller gets NotFound so
+// existence isn't disclosed. On success vms.status is updated optimistically
+// (the reconciler will correct if the change actually fails on Proxmox after
+// the task UPID is returned).
+func (s *Service) LifecycleOp(ctx context.Context, id, requesterID uint, op VMLifecycleOp) error {
+	var vm db.VM
+	if err := s.db.WithContext(ctx).First(&vm, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return &internalerrors.NotFoundError{Resource: "vm", ID: fmt.Sprintf("%d", id)}
+		}
+		return fmt.Errorf("get vm %d: %w", id, err)
+	}
+	if vm.OwnerID == nil || *vm.OwnerID != requesterID {
+		return &internalerrors.NotFoundError{Resource: "vm", ID: fmt.Sprintf("%d", id)}
+	}
+	return s.runLifecycleOp(ctx, &vm, op)
+}
+
+// AdminLifecycleOp issues a power operation without an owner gate. Used by
+// the admin cluster handler so an admin can power-cycle any local VM (foreign
+// and external are reachable via the by-(node,vmid) cluster endpoints).
+func (s *Service) AdminLifecycleOp(ctx context.Context, id uint, op VMLifecycleOp) error {
+	var vm db.VM
+	if err := s.db.WithContext(ctx).First(&vm, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return &internalerrors.NotFoundError{Resource: "vm", ID: fmt.Sprintf("%d", id)}
+		}
+		return fmt.Errorf("get vm %d: %w", id, err)
+	}
+	return s.runLifecycleOp(ctx, &vm, op)
+}
+
+// AdminLifecycleByVMID issues a power operation against a Proxmox VM that
+// may not have a local DB row (foreign / external). When a local row exists
+// for this (node, vmid), its status is updated optimistically; otherwise the
+// op is purely a Proxmox API call.
+func (s *Service) AdminLifecycleByVMID(ctx context.Context, node string, vmid int, op VMLifecycleOp) error {
+	if node == "" || vmid <= 0 {
+		return &internalerrors.ValidationError{Field: "vmid", Message: "node and vmid are required"}
+	}
+	var (
+		upid       string
+		err        error
+		nextStatus string
+	)
+	switch op {
+	case VMOpStart:
+		upid, err = s.px.StartVM(ctx, node, vmid)
+		nextStatus = "running"
+	case VMOpShutdown:
+		upid, err = s.px.ShutdownVM(ctx, node, vmid)
+		nextStatus = "stopped"
+	case VMOpStop:
+		upid, err = s.px.StopVM(ctx, node, vmid)
+		nextStatus = "stopped"
+	case VMOpReboot:
+		upid, err = s.px.RebootVM(ctx, node, vmid)
+		nextStatus = "running"
+	default:
+		return &internalerrors.ValidationError{Field: "op", Message: fmt.Sprintf("unknown lifecycle op %q", op)}
+	}
+	if err != nil {
+		return fmt.Errorf("%s vm %d on %s: %w", op, vmid, node, err)
+	}
+	if upid != "" {
+		if err := s.px.WaitForTask(ctx, node, upid, s.cfg.PollInterval); err != nil {
+			return fmt.Errorf("%s task vm %d: %w", op, vmid, err)
+		}
+	}
+	// Best-effort optimistic status sync for local rows.
+	if err := s.db.WithContext(ctx).Model(&db.VM{}).
+		Where("vmid = ? AND node = ?", vmid, node).
+		Update("status", nextStatus).Error; err != nil {
+		log.Printf("admin lifecycle %s vm=%d node=%s: status update failed: %v", op, vmid, node, err)
+	}
+	return nil
+}
+
+// runLifecycleOp dispatches op to the right Proxmox endpoint, waits for the
+// task, then updates vms.status. Returns ValidationError for an unknown op.
+func (s *Service) runLifecycleOp(ctx context.Context, vm *db.VM, op VMLifecycleOp) error {
+	var (
+		upid       string
+		err        error
+		nextStatus string
+	)
+	switch op {
+	case VMOpStart:
+		upid, err = s.px.StartVM(ctx, vm.Node, vm.VMID)
+		nextStatus = "running"
+	case VMOpShutdown:
+		upid, err = s.px.ShutdownVM(ctx, vm.Node, vm.VMID)
+		nextStatus = "stopped"
+	case VMOpStop:
+		upid, err = s.px.StopVM(ctx, vm.Node, vm.VMID)
+		nextStatus = "stopped"
+	case VMOpReboot:
+		upid, err = s.px.RebootVM(ctx, vm.Node, vm.VMID)
+		nextStatus = "running"
+	default:
+		return &internalerrors.ValidationError{Field: "op", Message: fmt.Sprintf("unknown lifecycle op %q", op)}
+	}
+	if err != nil {
+		return fmt.Errorf("%s vm %d on %s: %w", op, vm.VMID, vm.Node, err)
+	}
+	if upid != "" {
+		if err := s.px.WaitForTask(ctx, vm.Node, upid, s.cfg.PollInterval); err != nil {
+			return fmt.Errorf("%s task vm %d: %w", op, vm.VMID, err)
+		}
+	}
+	if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("id = ?", vm.ID).
+		Update("status", nextStatus).Error; err != nil {
+		log.Printf("lifecycle %s vm=%d: status update failed (proxmox already applied): %v", op, vm.ID, err)
+	}
+	return nil
 }
 
 // AdminDelete destroys a VM regardless of who owns it. Same semantics as

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -152,6 +152,12 @@ type Service struct {
 	gatewayMu sync.RWMutex
 	gatewayIP string
 
+	// unreachableNodes is the per-cycle reachability probe consulted by
+	// ReconcileVMs. nil → no guard (legacy reap-on-miss behaviour). Set via
+	// SetUnreachableNodesProbe. Lock-free: a single pointer write swaps the
+	// closure atomically, and ReconcileVMs reads it once per call.
+	unreachableNodes UnreachableNodesFunc
+
 	// guards concurrent provisions from racing on cluster/nextid by
 	// serializing the clone path. SQLite already serializes ippool.Reserve.
 	cloneMu sync.Mutex

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -77,6 +77,7 @@ type ProxmoxClient interface {
 	ResizeDisk(ctx context.Context, node string, vmid int, disk, size string) error
 	StartVM(ctx context.Context, node string, vmid int) (string, error)
 	StopVM(ctx context.Context, node string, vmid int) (string, error)
+	RebootVM(ctx context.Context, node string, vmid int) (string, error)
 	DestroyVM(ctx context.Context, node string, vmid int) (string, error)
 	GetAgentInterfaces(ctx context.Context, node string, vmid int) ([]proxmox.NetworkInterface, error)
 }
@@ -144,6 +145,12 @@ type Service struct {
 	gpuMu  sync.Mutex
 	gpuCfg GPUBootstrapConfig
 
+	// gatewayMu guards the live-reloadable gateway IP. Replaces the cfg.GatewayIP
+	// read at clone time so the Settings → Network page can rotate the gateway
+	// without a restart. Initial value is seeded from cfg.GatewayIP in New.
+	gatewayMu sync.RWMutex
+	gatewayIP string
+
 	// guards concurrent provisions from racing on cluster/nextid by
 	// serializing the clone path. SQLite already serializes ippool.Reserve.
 	cloneMu sync.Mutex
@@ -161,14 +168,35 @@ func New(px ProxmoxClient, pool *ippool.Pool, database *gorm.DB, cipher *secrets
 		cfg.PollInterval = 3 * time.Second
 	}
 	return &Service{
-		px:       px,
-		pool:     pool,
-		verifier: noopVerifier{},
-		db:       database,
-		cipher:   cipher,
-		keys:     keys,
-		cfg:      cfg,
+		px:        px,
+		pool:      pool,
+		verifier:  noopVerifier{},
+		db:        database,
+		cipher:    cipher,
+		keys:      keys,
+		cfg:       cfg,
+		gatewayIP: cfg.GatewayIP,
 	}
+}
+
+// SetGatewayIP rotates the gateway used for new provisions. Live-reloadable
+// from Settings → Network. Empty input is a no-op so the handler can blindly
+// push the persisted value without re-checking. Existing VMs are NOT updated
+// — that requires the explicit force-gateway-update op.
+func (s *Service) SetGatewayIP(ip string) {
+	if ip == "" {
+		return
+	}
+	s.gatewayMu.Lock()
+	defer s.gatewayMu.Unlock()
+	s.gatewayIP = ip
+}
+
+// GatewayIP returns the gateway used for new provisions, under lock.
+func (s *Service) GatewayIP() string {
+	s.gatewayMu.RLock()
+	defer s.gatewayMu.RUnlock()
+	return s.gatewayIP
 }
 
 // SetIPVerifier installs (or replaces) the IP verifier used after each Reserve
@@ -345,7 +373,7 @@ func (s *Service) Provision(ctx context.Context, req Request, progress ProgressR
 	cloudInit := proxmox.CloudInitConfig{
 		CIUser:       username,
 		SSHKeys:      sshPubKey,
-		IPConfig0:    fmt.Sprintf("ip=%s/24,gw=%s", ip, s.cfg.GatewayIP),
+		IPConfig0:    fmt.Sprintf("ip=%s/24,gw=%s", ip, s.GatewayIP()),
 		Nameserver:   s.cfg.Nameserver,
 		SearchDomain: s.cfg.SearchDomain,
 		Cores:        tier.CPU,

--- a/internal/provision/service_test.go
+++ b/internal/provision/service_test.go
@@ -54,6 +54,7 @@ type fakePVE struct {
 	resizeDisk        func(context.Context, string, int, string, string) error
 	startVM           func(context.Context, string, int) (string, error)
 	stopVM            func(context.Context, string, int) (string, error)
+	rebootVM          func(context.Context, string, int) (string, error)
 	destroyVM         func(context.Context, string, int) (string, error)
 	getAgentIfaces    func(context.Context, string, int) ([]proxmox.NetworkInterface, error)
 
@@ -119,6 +120,12 @@ func (f *fakePVE) StopVM(ctx context.Context, n string, vmid int) (string, error
 		return "task:stop", nil
 	}
 	return f.stopVM(ctx, n, vmid)
+}
+func (f *fakePVE) RebootVM(ctx context.Context, n string, vmid int) (string, error) {
+	if f.rebootVM == nil {
+		return "task:reboot", nil
+	}
+	return f.rebootVM(ctx, n, vmid)
 }
 func (f *fakePVE) DestroyVM(ctx context.Context, n string, vmid int) (string, error) {
 	if f.destroyVM == nil {

--- a/internal/provision/service_test.go
+++ b/internal/provision/service_test.go
@@ -54,6 +54,7 @@ type fakePVE struct {
 	resizeDisk        func(context.Context, string, int, string, string) error
 	startVM           func(context.Context, string, int) (string, error)
 	stopVM            func(context.Context, string, int) (string, error)
+	shutdownVM        func(context.Context, string, int) (string, error)
 	rebootVM          func(context.Context, string, int) (string, error)
 	destroyVM         func(context.Context, string, int) (string, error)
 	getAgentIfaces    func(context.Context, string, int) ([]proxmox.NetworkInterface, error)
@@ -120,6 +121,12 @@ func (f *fakePVE) StopVM(ctx context.Context, n string, vmid int) (string, error
 		return "task:stop", nil
 	}
 	return f.stopVM(ctx, n, vmid)
+}
+func (f *fakePVE) ShutdownVM(ctx context.Context, n string, vmid int) (string, error) {
+	if f.shutdownVM == nil {
+		return "task:shutdown", nil
+	}
+	return f.shutdownVM(ctx, n, vmid)
 }
 func (f *fakePVE) RebootVM(ctx context.Context, n string, vmid int) (string, error) {
 	if f.rebootVM == nil {

--- a/internal/provision/vm_reconcile.go
+++ b/internal/provision/vm_reconcile.go
@@ -62,6 +62,22 @@ type VMDeleted struct {
 // pass.
 var errEmptyClusterSnapshot = errors.New("cluster snapshot is empty — refusing to soft-delete every vm row")
 
+// UnreachableNodesFunc returns the set of node names the local host can't
+// currently reach over TCP. The reconciler treats a VM that's missing from
+// the cluster snapshot as "still alive, just unreachable" when its host node
+// is in this set — no missed_cycles bump, no soft-delete. Wired up in
+// main.go via SetUnreachableNodesProbe; nil disables the guard (legacy
+// behaviour where every missing VM gets reaped after the threshold).
+type UnreachableNodesFunc func(ctx context.Context) map[string]bool
+
+// SetUnreachableNodesProbe installs the per-cycle reachability check. Safe
+// to call before/after the reconcile loop has started; reads happen at the
+// top of each ReconcileVMs invocation so a freshly-installed probe takes
+// effect on the next cycle.
+func (s *Service) SetUnreachableNodesProbe(f UnreachableNodesFunc) {
+	s.unreachableNodes = f
+}
+
 // ReconcileVMs walks the local vms table and converges it to the cluster
 // snapshot. Three things can happen per row:
 //
@@ -105,10 +121,25 @@ func (s *Service) ReconcileVMs(ctx context.Context) (VMSyncReport, error) {
 		return rep, fmt.Errorf("list vms: %w", err)
 	}
 
+	// One reachability snapshot per cycle — fans out TCP dials so a transient
+	// node outage doesn't soft-delete every VM living there.
+	var unreachable map[string]bool
+	if s.unreachableNodes != nil {
+		unreachable = s.unreachableNodes(ctx)
+	}
+
 	for _, vm := range rows {
 		px, found := byVMID[vm.VMID]
 		switch {
 		case !found:
+			// Missing from cluster snapshot AND host node is currently
+			// unreachable → almost certainly a node outage, not a manual
+			// destroy. Don't bump missed_cycles; the row stays intact and
+			// gets re-evaluated next cycle.
+			if unreachable[vm.Node] {
+				rep.NoOps++
+				continue
+			}
 			s.handleVMMissing(ctx, vm, &rep)
 		case px.Node != vm.Node:
 			s.handleVMMigrated(ctx, vm, px.Node, &rep)

--- a/internal/provision/vm_reconcile.go
+++ b/internal/provision/vm_reconcile.go
@@ -74,7 +74,15 @@ var errEmptyClusterSnapshot = errors.New("cluster snapshot is empty — refusing
 // Refuses to act if the snapshot returned zero VMs — that's almost always a
 // Proxmox API hiccup and acting on it would wipe every row at once.
 func (s *Service) ReconcileVMs(ctx context.Context) (VMSyncReport, error) {
-	rep := VMSyncReport{SnapshotAt: time.Now().UTC()}
+	// Initialize the slices (rather than leaving them nil) so the JSON
+	// encoder emits "[]" instead of "null" for empty results — the SPA
+	// reads .length on these without a guard.
+	rep := VMSyncReport{
+		Migrated:   []VMMigration{},
+		Missed:     []VMMiss{},
+		Deleted:    []VMDeleted{},
+		SnapshotAt: time.Now().UTC(),
+	}
 
 	cluster, err := s.px.GetClusterVMs(ctx)
 	if err != nil {

--- a/internal/provision/vm_reconcile.go
+++ b/internal/provision/vm_reconcile.go
@@ -1,0 +1,176 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"nimbus/internal/db"
+)
+
+// vacateMissThreshold is the number of consecutive reconcile cycles during
+// which a VM row must be missing from Proxmox before we soft-delete it.
+// Mirrors the IP reconciler's VACATE_MISS_THRESHOLD default — same forgiveness
+// window, same operator intuition.
+const vacateMissThreshold = 3
+
+// VMSyncReport is the structured outcome of one ReconcileVMs run, also the
+// JSON body of POST /api/vms/reconcile.
+type VMSyncReport struct {
+	Migrated   []VMMigration `json:"migrated"`
+	Missed     []VMMiss      `json:"missed"`
+	Deleted    []VMDeleted   `json:"deleted"`
+	NoOps      int           `json:"no_ops"`
+	SnapshotAt time.Time     `json:"snapshot_at"`
+}
+
+// VMMigration records a row whose Proxmox node moved out from under it
+// (operator ran qm migrate outside nimbus). vms.node is updated in place.
+type VMMigration struct {
+	VMRowID  uint   `json:"vm_row_id"`
+	VMID     int    `json:"vmid"`
+	Hostname string `json:"hostname"`
+	FromNode string `json:"from_node"`
+	ToNode   string `json:"to_node"`
+}
+
+// VMMiss records a row that Proxmox didn't return this cycle but hasn't yet
+// crossed the soft-delete threshold. Useful for the UI's "going stale" chip.
+type VMMiss struct {
+	VMRowID      uint   `json:"vm_row_id"`
+	VMID         int    `json:"vmid"`
+	Hostname     string `json:"hostname"`
+	Node         string `json:"node"`
+	MissedCycles int    `json:"missed_cycles"`
+}
+
+// VMDeleted records a row the reconciler just soft-deleted because it crossed
+// the miss threshold. Soft-delete (gorm.DeletedAt) means the row is recoverable
+// by an operator who restores its deleted_at to NULL.
+type VMDeleted struct {
+	VMRowID  uint   `json:"vm_row_id"`
+	VMID     int    `json:"vmid"`
+	Hostname string `json:"hostname"`
+	Node     string `json:"node"`
+}
+
+// errEmptyClusterSnapshot is returned when GetClusterVMs succeeds but returns
+// zero VMs. Refusing to act guards against a Proxmox API returning a stale or
+// empty response — the alternative would be to soft-delete every row in one
+// pass.
+var errEmptyClusterSnapshot = errors.New("cluster snapshot is empty — refusing to soft-delete every vm row")
+
+// ReconcileVMs walks the local vms table and converges it to the cluster
+// snapshot. Three things can happen per row:
+//
+//  1. Same vmid found on the same node → reset MissedCycles, no-op.
+//  2. Same vmid found on a *different* node → update vms.node (someone ran
+//     qm migrate outside nimbus).
+//  3. vmid not found anywhere in the cluster → bump MissedCycles. After
+//     vacateMissThreshold consecutive misses, soft-delete the row.
+//
+// Refuses to act if the snapshot returned zero VMs — that's almost always a
+// Proxmox API hiccup and acting on it would wipe every row at once.
+func (s *Service) ReconcileVMs(ctx context.Context) (VMSyncReport, error) {
+	rep := VMSyncReport{SnapshotAt: time.Now().UTC()}
+
+	cluster, err := s.px.GetClusterVMs(ctx)
+	if err != nil {
+		return rep, fmt.Errorf("get cluster vms: %w", err)
+	}
+	if len(cluster) == 0 {
+		return rep, errEmptyClusterSnapshot
+	}
+
+	byVMID := make(map[int]struct{ Node, Name string }, len(cluster))
+	for _, c := range cluster {
+		byVMID[c.VMID] = struct{ Node, Name string }{Node: c.Node, Name: c.Name}
+	}
+
+	var rows []db.VM
+	if err := s.db.WithContext(ctx).
+		Where("vmid > 0").
+		Order("id ASC").
+		Find(&rows).Error; err != nil {
+		return rep, fmt.Errorf("list vms: %w", err)
+	}
+
+	for _, vm := range rows {
+		px, found := byVMID[vm.VMID]
+		switch {
+		case !found:
+			s.handleVMMissing(ctx, vm, &rep)
+		case px.Node != vm.Node:
+			s.handleVMMigrated(ctx, vm, px.Node, &rep)
+		default:
+			s.handleVMSeen(ctx, vm, &rep)
+		}
+	}
+
+	return rep, nil
+}
+
+// handleVMSeen resets MissedCycles to zero (idempotent — only writes when
+// non-zero to keep the SQLite single-writer happy on no-op cycles).
+func (s *Service) handleVMSeen(ctx context.Context, vm db.VM, rep *VMSyncReport) {
+	if vm.MissedCycles > 0 {
+		if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("id = ?", vm.ID).
+			Update("missed_cycles", 0).Error; err != nil {
+			log.Printf("vm-reconcile: reset missed_cycles vmid=%d row=%d: %v", vm.VMID, vm.ID, err)
+		}
+	}
+	rep.NoOps++
+}
+
+// handleVMMigrated updates vms.node to reflect the new Proxmox location.
+// Resets MissedCycles too — the VM is alive, just elsewhere.
+func (s *Service) handleVMMigrated(ctx context.Context, vm db.VM, newNode string, rep *VMSyncReport) {
+	if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("id = ?", vm.ID).Updates(map[string]any{
+		"node":          newNode,
+		"missed_cycles": 0,
+	}).Error; err != nil {
+		log.Printf("vm-reconcile: update node vmid=%d row=%d %s→%s: %v", vm.VMID, vm.ID, vm.Node, newNode, err)
+		return
+	}
+	log.Printf("vm-reconcile: migrated vmid=%d (%s) %s → %s", vm.VMID, vm.Hostname, vm.Node, newNode)
+	rep.Migrated = append(rep.Migrated, VMMigration{
+		VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname,
+		FromNode: vm.Node, ToNode: newNode,
+	})
+}
+
+// handleVMMissing increments MissedCycles. When the post-increment value
+// crosses vacateMissThreshold, soft-deletes the row.
+func (s *Service) handleVMMissing(ctx context.Context, vm db.VM, rep *VMSyncReport) {
+	next := vm.MissedCycles + 1
+	if next < vacateMissThreshold {
+		if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("id = ?", vm.ID).
+			Update("missed_cycles", next).Error; err != nil {
+			log.Printf("vm-reconcile: bump missed_cycles vmid=%d row=%d: %v", vm.VMID, vm.ID, err)
+			return
+		}
+		rep.Missed = append(rep.Missed, VMMiss{
+			VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname, Node: vm.Node,
+			MissedCycles: next,
+		})
+		return
+	}
+	// Threshold reached — soft-delete. gorm.DeletedAt is on the embedded
+	// gorm.Model so a plain Delete() flips deleted_at instead of truncating.
+	if err := s.db.WithContext(ctx).Delete(&db.VM{}, vm.ID).Error; err != nil {
+		log.Printf("vm-reconcile: soft-delete vmid=%d row=%d: %v", vm.VMID, vm.ID, err)
+		return
+	}
+	log.Printf("vm-reconcile: soft-deleted vmid=%d (%s) — missing for %d cycles", vm.VMID, vm.Hostname, next)
+	// Also release the IP allocation so the slot returns to the pool.
+	if vm.IP != "" {
+		if err := s.pool.Release(ctx, vm.IP); err != nil {
+			log.Printf("vm-reconcile: release ip %s for vmid=%d: %v", vm.IP, vm.VMID, err)
+		}
+	}
+	rep.Deleted = append(rep.Deleted, VMDeleted{
+		VMRowID: vm.ID, VMID: vm.VMID, Hostname: vm.Hostname, Node: vm.Node,
+	})
+}

--- a/internal/provision/vm_reconcile_test.go
+++ b/internal/provision/vm_reconcile_test.go
@@ -1,0 +1,194 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"nimbus/internal/db"
+	"nimbus/internal/proxmox"
+)
+
+func TestReconcileVMs_RefusesEmptyClusterSnapshot(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return nil, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+
+	if _, err := svc.ReconcileVMs(context.Background()); err == nil {
+		t.Fatal("expected error for empty cluster snapshot, got nil")
+	}
+
+	// VM row must NOT have been touched.
+	var got db.VM
+	if err := database.WithContext(context.Background()).First(&got).Error; err != nil {
+		t.Fatalf("vm row was deleted on empty snapshot: %v", err)
+	}
+	if got.MissedCycles != 0 {
+		t.Errorf("missed_cycles = %d, want 0 (refuse should not bump)", got.MissedCycles)
+	}
+}
+
+func TestReconcileVMs_TracksMigration(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		// VM 200 has moved from "alpha" to "beta".
+		return []proxmox.ClusterVM{{VMID: 200, Node: "beta", Name: "vm-a", Status: "running"}}, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2") // seeded as node="alpha"
+
+	rep, err := svc.ReconcileVMs(context.Background())
+	if err != nil {
+		t.Fatalf("ReconcileVMs: %v", err)
+	}
+	if len(rep.Migrated) != 1 {
+		t.Fatalf("rep.Migrated = %d, want 1", len(rep.Migrated))
+	}
+	if rep.Migrated[0].FromNode != "alpha" || rep.Migrated[0].ToNode != "beta" {
+		t.Errorf("migration = %+v, want alpha→beta", rep.Migrated[0])
+	}
+
+	var got db.VM
+	if err := database.WithContext(context.Background()).First(&got).Error; err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if got.Node != "beta" {
+		t.Errorf("vm.node = %q, want beta", got.Node)
+	}
+}
+
+func TestReconcileVMs_BumpsMissedCyclesBeforeThreshold(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	// VMID 200 is missing — only 999 (irrelevant) is in the cluster.
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return []proxmox.ClusterVM{{VMID: 999, Node: "alpha", Name: "other"}}, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+
+	// Two consecutive runs — both should bump missed_cycles, not delete.
+	for i := 1; i <= 2; i++ {
+		rep, err := svc.ReconcileVMs(context.Background())
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if len(rep.Deleted) != 0 {
+			t.Fatalf("run %d: rep.Deleted = %d, want 0 (under threshold)", i, len(rep.Deleted))
+		}
+		if len(rep.Missed) != 1 || rep.Missed[0].MissedCycles != i {
+			t.Errorf("run %d: rep.Missed = %+v, want one entry with MissedCycles=%d", i, rep.Missed, i)
+		}
+	}
+
+	// Row should still exist, with missed_cycles=2.
+	var got db.VM
+	if err := database.WithContext(context.Background()).First(&got).Error; err != nil {
+		t.Fatalf("row vanished early: %v", err)
+	}
+	if got.MissedCycles != 2 {
+		t.Errorf("missed_cycles = %d, want 2", got.MissedCycles)
+	}
+}
+
+func TestReconcileVMs_SoftDeletesAfterThreshold(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return []proxmox.ClusterVM{{VMID: 999, Node: "alpha", Name: "other"}}, nil
+	}
+	svc, pool, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	// Mark .2 allocated so we can verify Release happens on soft-delete.
+	if err := pool.AdoptAllocation(context.Background(), "10.0.0.2", 200, "vm-a"); err != nil {
+		t.Fatalf("AdoptAllocation: %v", err)
+	}
+
+	// Three runs — third one must soft-delete.
+	for i := 1; i <= 3; i++ {
+		if _, err := svc.ReconcileVMs(context.Background()); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+
+	// Default GORM scope filters soft-deleted rows. Confirm the row is gone
+	// from the default view.
+	var alive []db.VM
+	if err := database.WithContext(context.Background()).Find(&alive).Error; err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if len(alive) != 0 {
+		t.Errorf("rows still visible = %d, want 0 (should be soft-deleted)", len(alive))
+	}
+	// And confirm Unscoped() can still see it (recoverable).
+	var allIncDeleted []db.VM
+	if err := database.WithContext(context.Background()).Unscoped().Find(&allIncDeleted).Error; err != nil {
+		t.Fatalf("unscoped read: %v", err)
+	}
+	if len(allIncDeleted) != 1 {
+		t.Errorf("unscoped rows = %d, want 1 (row should be recoverable)", len(allIncDeleted))
+	}
+
+	// And confirm the IP returned to the pool.
+	row, err := pool.GetByIP(context.Background(), "10.0.0.2")
+	if err != nil {
+		t.Fatalf("GetByIP: %v", err)
+	}
+	if row.Status != "free" {
+		t.Errorf(".2 status = %q, want free (released on soft-delete)", row.Status)
+	}
+}
+
+func TestReconcileVMs_ResetsMissedCyclesWhenSeenAgain(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	clusterMissing := []proxmox.ClusterVM{{VMID: 999, Node: "alpha", Name: "other"}}
+	clusterPresent := []proxmox.ClusterVM{
+		{VMID: 200, Node: "alpha", Name: "vm-a", Status: "running"},
+	}
+	currentSnap := clusterMissing
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return currentSnap, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+
+	// One miss to bump missed_cycles to 1.
+	if _, err := svc.ReconcileVMs(context.Background()); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	// Then VM reappears — counter should reset.
+	currentSnap = clusterPresent
+	if _, err := svc.ReconcileVMs(context.Background()); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	var got db.VM
+	if err := database.WithContext(context.Background()).First(&got).Error; err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if got.MissedCycles != 0 {
+		t.Errorf("missed_cycles = %d, want 0 (reset on re-find)", got.MissedCycles)
+	}
+}
+
+func TestReconcileVMs_EmptyClusterErrorIsTyped(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) { return nil, nil }
+	svc, _, _ := newTestService(t, fake)
+	_, err := svc.ReconcileVMs(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// We don't export the sentinel — the message is the contract. Keeping
+	// the assertion loose protects against rewording the error.
+	if !errors.Is(err, err) || err.Error() == "" {
+		t.Errorf("err = %v, want a non-empty error", err)
+	}
+}

--- a/internal/provision/vm_reconcile_test.go
+++ b/internal/provision/vm_reconcile_test.go
@@ -192,3 +192,39 @@ func TestReconcileVMs_EmptyClusterErrorIsTyped(t *testing.T) {
 		t.Errorf("err = %v, want a non-empty error", err)
 	}
 }
+
+// TestReconcileVMs_UnreachableNodeSuppressesMissBump asserts the reachability
+// guard: when SetUnreachableNodesProbe reports the host node as unreachable,
+// a VM missing from the cluster snapshot is treated as still-alive rather
+// than an orphan ready to soft-delete. MissedCycles stays at 0 across N
+// cycles where N exceeds the vacate threshold.
+func TestReconcileVMs_UnreachableNodeSuppressesMissBump(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	// Cluster snapshot returns an unrelated VM only — vmid 200 is missing.
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return []proxmox.ClusterVM{{VMID: 999, Node: "alpha", Name: "other"}}, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	seedManagedVM(t, database, "vm-a", 200, "10.0.0.2")
+	svc.SetUnreachableNodesProbe(func(context.Context) map[string]bool {
+		return map[string]bool{"alpha": true}
+	})
+
+	for i := 1; i <= 5; i++ {
+		rep, err := svc.ReconcileVMs(context.Background())
+		if err != nil {
+			t.Fatalf("ReconcileVMs #%d: %v", i, err)
+		}
+		if len(rep.Deleted) != 0 || len(rep.Missed) != 0 {
+			t.Errorf("cycle %d rep = %+v; want no deletes / no misses while host is unreachable", i, rep)
+		}
+	}
+	var got db.VM
+	if err := database.WithContext(context.Background()).First(&got, "vmid = ?", 200).Error; err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if got.MissedCycles != 0 {
+		t.Errorf("missed_cycles = %d, want 0 (probe should suppress every cycle)", got.MissedCycles)
+	}
+}

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -649,6 +649,80 @@ func (c *Client) GetAgentOSInfoCached(ctx context.Context, node string, vmid int
 	return info
 }
 
+// ProbeReachability TCP-dials each address concurrently and returns the set
+// of node names that didn't answer within timeout. An empty map means all
+// addresses responded (or the input map was empty).
+//
+// The reconcilers use this as a skip-the-reaper guard: if a node went off
+// the network briefly (kernel update, ifdown, broken switch port), Proxmox's
+// /cluster/resources stops listing its VMs, every IP allocated to one of
+// those VMs flows through the missed-cycle path, and after VACATE_MISS_THRESHOLD
+// cycles the rows get vacated and soft-deleted. Skipping the bump on
+// unreachable nodes keeps the local DB intact across short outages —
+// Proxmox's `online` flag is unreliable when nimbus's own host is the one
+// with bad cluster connectivity.
+//
+// Port 8006 is pveproxy's default. We're not authenticating — a successful
+// TCP handshake is enough to say "the box is alive and routing".
+func ProbeReachability(ctx context.Context, addresses map[string]string, timeout time.Duration) map[string]bool {
+	if len(addresses) == 0 {
+		return nil
+	}
+	out := make(map[string]bool)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for name, ip := range addresses {
+		wg.Add(1)
+		go func(name, ip string) {
+			defer wg.Done()
+			d := net.Dialer{Timeout: timeout}
+			conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort(ip, "8006"))
+			if err != nil {
+				mu.Lock()
+				out[name] = true
+				mu.Unlock()
+				return
+			}
+			_ = conn.Close()
+		}(name, ip)
+	}
+	wg.Wait()
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// GetClusterStatus returns the heterogeneous /cluster/status payload — one
+// entry per node carrying its corosync address, plus a cluster-summary row.
+// Callers usually want NodeAddresses, not raw entries.
+func (c *Client) GetClusterStatus(ctx context.Context) ([]ClusterStatusEntry, error) {
+	var out []ClusterStatusEntry
+	if err := c.do(ctx, http.MethodGet, "/cluster/status", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// NodeAddresses returns name → IP for every node in the cluster, derived from
+// /cluster/status. Used by the IP-pool labeller (so a hypervisor's own LAN
+// address shows as "PROXMOX NODE foo" instead of generic EXTERNAL) and the
+// reconciler reachability guard (TCP-probe before counting a missing-VM
+// cycle so a brief node outage doesn't reap rows en masse).
+func (c *Client) NodeAddresses(ctx context.Context) (map[string]string, error) {
+	entries, err := c.GetClusterStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if e.Type == "node" && e.Name != "" && e.IP != "" {
+			out[e.Name] = e.IP
+		}
+	}
+	return out, nil
+}
+
 // GetClusterStorage returns every storage entry visible at the cluster level.
 // Shared storage appears once per node; callers must dedupe by Storage name.
 func (c *Client) GetClusterStorage(ctx context.Context) ([]ClusterStorage, error) {

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -543,6 +543,20 @@ func (c *Client) StopVM(ctx context.Context, node string, vmid int) (string, err
 	return taskID, nil
 }
 
+// ShutdownVM asks Proxmox to stop a VM gracefully — talks to the guest agent
+// (or sends ACPI when no agent) so the OS can flush filesystems and exit
+// cleanly. The Proxmox endpoint falls back to forceStop after its own
+// configured timeout, so a hung guest still ends up off without our caller
+// babysitting. Used for the user-facing "Shutdown" button.
+func (c *Client) ShutdownVM(ctx context.Context, node string, vmid int) (string, error) {
+	var taskID string
+	path := fmt.Sprintf("/nodes/%s/qemu/%d/status/shutdown", url.PathEscape(node), vmid)
+	if err := c.do(ctx, http.MethodPost, path, url.Values{}, &taskID); err != nil {
+		return "", err
+	}
+	return taskID, nil
+}
+
 // RebootVM triggers a graceful reboot through the guest agent (or ACPI when
 // no agent is present). Used after a cloud-init network change so the VM picks
 // up the new ipconfig0 on next boot. Returns the task UPID.

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -543,6 +543,18 @@ func (c *Client) StopVM(ctx context.Context, node string, vmid int) (string, err
 	return taskID, nil
 }
 
+// RebootVM triggers a graceful reboot through the guest agent (or ACPI when
+// no agent is present). Used after a cloud-init network change so the VM picks
+// up the new ipconfig0 on next boot. Returns the task UPID.
+func (c *Client) RebootVM(ctx context.Context, node string, vmid int) (string, error) {
+	var taskID string
+	path := fmt.Sprintf("/nodes/%s/qemu/%d/status/reboot", url.PathEscape(node), vmid)
+	if err := c.do(ctx, http.MethodPost, path, url.Values{}, &taskID); err != nil {
+		return "", err
+	}
+	return taskID, nil
+}
+
 // DestroyVM removes a VM from Proxmox.
 //
 //   - purge=1 also clears job/replication/HA references (otherwise stale

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -11,6 +11,19 @@ type Node struct {
 	MaxMem uint64  `json:"maxmem"` // bytes total
 }
 
+// ClusterStatusEntry is one row from /api2/json/cluster/status. The endpoint
+// returns a heterogeneous list (cluster + per-node entries); the per-node
+// rows carry the node's address. Fields we don't read are dropped — Proxmox
+// also reports level, quorum state, etc.
+type ClusterStatusEntry struct {
+	Type   string `json:"type"`   // "cluster" | "node"
+	Name   string `json:"name"`   // node hostname (empty for the cluster row)
+	IP     string `json:"ip"`     // address Proxmox advertises for this node
+	Online int    `json:"online"` // 1 = part of corosync quorum
+	Local  int    `json:"local"`  // 1 if this is the node we made the API call on
+	NodeID int    `json:"nodeid"` // numeric corosync id
+}
+
 // MemPair is the {used,total,free} shape Proxmox returns inside its node
 // status response. Both `memory` and `swap` use this layout.
 type MemPair struct {

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -475,6 +475,40 @@ func (s *AuthService) SaveGPUSettings(next db.GPUSettings) error {
 	return s.db.Save(&next).Error
 }
 
+// GetNetworkSettings returns the stored IP pool / gateway configuration.
+// Creates an empty row on first call. Empty strings on the row mean the
+// caller should fall back to env defaults (handled by main.go's seed step).
+func (s *AuthService) GetNetworkSettings() (*db.NetworkSettings, error) {
+	var settings db.NetworkSettings
+	err := s.db.FirstOrCreate(&settings, db.NetworkSettings{ID: 1}).Error
+	return &settings, err
+}
+
+// SaveNetworkSettings persists the IP pool / gateway. Empty fields are treated
+// as "preserve existing" so the UI can rotate one knob without re-sending the
+// others. No validation here — the handler checks that the strings parse as
+// valid IPv4 addresses before invoking this.
+func (s *AuthService) SaveNetworkSettings(next db.NetworkSettings) error {
+	existing, err := s.GetNetworkSettings()
+	if err != nil {
+		return err
+	}
+	if next.IPPoolStart == "" {
+		next.IPPoolStart = existing.IPPoolStart
+	}
+	if next.IPPoolEnd == "" {
+		next.IPPoolEnd = existing.IPPoolEnd
+	}
+	if next.GatewayIP == "" {
+		next.GatewayIP = existing.GatewayIP
+	}
+	return s.db.Model(&db.NetworkSettings{}).Where("id = ?", 1).Updates(map[string]any{
+		"ip_pool_start": next.IPPoolStart,
+		"ip_pool_end":   next.IPPoolEnd,
+		"gateway_ip":    next.GatewayIP,
+	}).Error
+}
+
 // RegenerateGPUWorkerToken mints a fresh 32-byte hex worker token and
 // persists it. Returns the new token so the caller can surface it in the
 // UI exactly once — admins must capture it for the GX10 install command.


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

Adds three substantial admin surfaces to the cluster view (runtime IP-pool/gateway editing, VM-table reconciliation, per-row VM power controls), plus a hypervisor reachability guard so transient node outages don't reap rows. Iterates on the cluster + IP-pool tables to clarify which "external" you're looking at and to keep dense per-row controls usable. Drops the requirement to restart nimbus to change IP_POOL_START / IP_POOL_END / GATEWAY_IP — env vars now seed the DB on first boot only, and the Settings → Network page is the source of truth thereafter (matches the existing Gopher / GPU pattern).

## Changes Made
<!-- List the main changes -->
- Settings → Network: edit IP pool + gateway live; Renumber every VM and Force gateway on every VM behind typed-confirm modals.
- VM-table reconciler: tracks qm migrate, soft-deletes orphan rows after 3 misses; refuses on empty snapshots.
- Per-row controls (Admin + My machines): Start/Shutdown toggle + … menu (Restart, Force stop, Remove). Remove gated to nimbus-created rows.
- Hypervisor reachability probe (TCP dial pveproxy:8006); reconcilers skip miss bumps for VMs on unreachable nodes.
- IP pool source chips split into NIMBUS / NIMBUS+warn (external hypervisor) / EXTERNAL VM / EXTERNAL; hypervisor IPs render as PROXMOX NODE · <name>.
- Polish: click-only … menus portaled past .glass cards, OS column → version only, SSH moved into Actions, tunnel mappings spell out → <host> · localhost:<port>, provisioning ETA bumped to 90–120s.

## Testing
<!-- Describe how you tested these changes -->
- [x] Tested locally
- [x] Added/updated unit tests
- [x] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

