### PR TITLE
fix: gate VM Get + tunnel CRUD on ownership

### DIFF
--- a/internal/api/handlers/vms.go
+++ b/internal/api/handlers/vms.go
@@ -246,7 +246,9 @@ func (h *VMs) GetPrivateKey(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// Get handles GET /api/vms/{id}.
+// Get handles GET /api/vms/{id}. Owner-gated: a non-owning requester gets
+// 404 (not 403) so existence isn't disclosed — same convention as Delete and
+// Lifecycle.
 func (h *VMs) Get(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := strconv.ParseUint(idStr, 10, 64)
@@ -254,7 +256,12 @@ func (h *VMs) Get(w http.ResponseWriter, r *http.Request) {
 		response.BadRequest(w, "invalid id")
 		return
 	}
-	vm, err := h.svc.Get(r.Context(), uint(id))
+	user := ctxutil.User(r.Context())
+	if user == nil {
+		response.Error(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+	vm, err := h.svc.Get(r.Context(), uint(id), &user.ID)
 	if err != nil {
 		response.FromError(w, err)
 		return
@@ -264,13 +271,19 @@ func (h *VMs) Get(w http.ResponseWriter, r *http.Request) {
 
 // ListTunnels handles GET /api/vms/{id}/tunnels — every Gopher per-port
 // tunnel attached to this VM. Returns an empty array for VMs without a
-// Gopher machine record (and for tunnel-disabled deployments).
+// Gopher machine record (and for tunnel-disabled deployments). Owner-gated
+// to prevent enumeration of another user's tunnel layout.
 func (h *VMs) ListTunnels(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseVMID(w, r)
 	if !ok {
 		return
 	}
-	tunnels, err := h.svc.ListVMTunnels(r.Context(), id)
+	user := ctxutil.User(r.Context())
+	if user == nil {
+		response.Error(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+	tunnels, err := h.svc.ListVMTunnels(r.Context(), id, &user.ID)
 	if err != nil {
 		response.FromError(w, err)
 		return
@@ -293,10 +306,16 @@ type createTunnelRequest struct {
 // CreateTunnel handles POST /api/vms/{id}/tunnels — registers a per-port
 // tunnel on this VM's Gopher machine. Mirrors Gopher's POST /api/v1/tunnels
 // body shape; see Gopher's OpenAPI spec for field semantics + UDP/bot-
-// protection coercion rules.
+// protection coercion rules. Owner-gated: only the VM owner may attach
+// internet-facing tunnels to it.
 func (h *VMs) CreateTunnel(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseVMID(w, r)
 	if !ok {
+		return
+	}
+	user := ctxutil.User(r.Context())
+	if user == nil {
+		response.Error(w, http.StatusUnauthorized, "Not authenticated")
 		return
 	}
 	var req createTunnelRequest
@@ -314,7 +333,7 @@ func (h *VMs) CreateTunnel(w http.ResponseWriter, r *http.Request) {
 		BotProtectionTTL:     req.BotProtectionTTL,
 		BotProtectionAllowIP: req.BotProtectionAllowIP,
 		TLSSkipVerify:        req.TLSSkipVerify,
-	})
+	}, &user.ID)
 	if err != nil {
 		response.FromError(w, err)
 		return
@@ -322,7 +341,7 @@ func (h *VMs) CreateTunnel(w http.ResponseWriter, r *http.Request) {
 	response.Created(w, t)
 }
 
-// DeleteTunnel handles DELETE /api/vms/{id}/tunnels/{tunnelId}.
+// DeleteTunnel handles DELETE /api/vms/{id}/tunnels/{tunnelId}. Owner-gated.
 func (h *VMs) DeleteTunnel(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseVMID(w, r)
 	if !ok {
@@ -333,7 +352,12 @@ func (h *VMs) DeleteTunnel(w http.ResponseWriter, r *http.Request) {
 		response.BadRequest(w, "missing tunnelId")
 		return
 	}
-	if err := h.svc.DeleteVMTunnel(r.Context(), id, tunnelID); err != nil {
+	user := ctxutil.User(r.Context())
+	if user == nil {
+		response.Error(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+	if err := h.svc.DeleteVMTunnel(r.Context(), id, tunnelID, &user.ID); err != nil {
 		response.FromError(w, err)
 		return
 	}

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -709,13 +709,21 @@ func (s *Service) GetPrivateKey(ctx context.Context, id uint, requesterID *uint)
 }
 
 // Get returns a single VM by row ID.
-func (s *Service) Get(ctx context.Context, id uint) (*db.VM, error) {
+//
+// requesterID enforces ownership — non-nil values must match vm.OwnerID or
+// NotFound is returned (no info leak about other users' VMs). Pass nil for
+// trusted internal callers; handlers always pass the signed-in user. Mirrors
+// GetPrivateKey's gating semantics.
+func (s *Service) Get(ctx context.Context, id uint, requesterID *uint) (*db.VM, error) {
 	var vm db.VM
 	if err := s.db.WithContext(ctx).First(&vm, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, &internalerrors.NotFoundError{Resource: "vm", ID: fmt.Sprintf("%d", id)}
 		}
 		return nil, fmt.Errorf("get vm %d: %w", id, err)
+	}
+	if requesterID != nil && (vm.OwnerID == nil || *vm.OwnerID != *requesterID) {
+		return nil, &internalerrors.NotFoundError{Resource: "vm", ID: fmt.Sprintf("%d", id)}
 	}
 	return &vm, nil
 }

--- a/internal/provision/tunnel.go
+++ b/internal/provision/tunnel.go
@@ -158,8 +158,11 @@ func runTunnelBootstrap(ctx context.Context, ip, user, privatePEM, bootstrapURL,
 // ListVMTunnels returns every Gopher per-port tunnel attached to this VM.
 // Returns an empty slice when the VM has no Gopher machine record (i.e.
 // public_tunnel was not requested at provision time, or registration failed).
-func (s *Service) ListVMTunnels(ctx context.Context, vmID uint) ([]tunnel.Tunnel, error) {
-	vm, err := s.Get(ctx, vmID)
+//
+// requesterID is forwarded to Get for ownership gating; non-nil values must
+// match vm.OwnerID or NotFound is returned.
+func (s *Service) ListVMTunnels(ctx context.Context, vmID uint, requesterID *uint) ([]tunnel.Tunnel, error) {
+	vm, err := s.Get(ctx, vmID, requesterID)
 	if err != nil {
 		return nil, err
 	}
@@ -191,19 +194,26 @@ type VMTunnelRequest struct {
 // the created tunnel record — note Gopher coerces some fields server-side
 // (e.g. clears bot_protection on UDP tunnels), so the response is the
 // source of truth, not the request.
-func (s *Service) CreateVMTunnel(ctx context.Context, vmID uint, req VMTunnelRequest) (*tunnel.Tunnel, error) {
-	if s.tunnels == nil {
-		return nil, errors.New("gopher tunnel integration is not configured")
-	}
+//
+// requesterID is forwarded to Get for ownership gating; non-nil values must
+// match vm.OwnerID or NotFound is returned. Without this gate a member could
+// create internet-facing tunnels on another member's VM.
+func (s *Service) CreateVMTunnel(ctx context.Context, vmID uint, req VMTunnelRequest, requesterID *uint) (*tunnel.Tunnel, error) {
+	// Cheap input validation comes first — same answer for any caller.
 	if req.TargetPort < 1 || req.TargetPort > 65535 {
 		return nil, &internalerrors.ValidationError{Field: "target_port", Message: "must be 1-65535"}
 	}
 	if req.Transport != "" && req.Transport != "tcp" && req.Transport != "udp" {
 		return nil, &internalerrors.ValidationError{Field: "transport", Message: "must be \"tcp\" or \"udp\""}
 	}
-	vm, err := s.Get(ctx, vmID)
+	// Ownership before deployment-config so a non-owner gets NotFound rather
+	// than learning whether tunnels are wired up at all.
+	vm, err := s.Get(ctx, vmID, requesterID)
 	if err != nil {
 		return nil, err
+	}
+	if s.tunnels == nil {
+		return nil, errors.New("gopher tunnel integration is not configured")
 	}
 	if vm.TunnelID == "" {
 		return nil, &internalerrors.ValidationError{
@@ -228,13 +238,19 @@ func (s *Service) CreateVMTunnel(ctx context.Context, vmID uint, req VMTunnelReq
 // DeleteVMTunnel removes a per-port tunnel. The tunnelID must belong to the
 // named VM's Gopher machine — we filter by machine_id before deleting so a
 // caller can't tear down another VM's tunnel by guessing IDs.
-func (s *Service) DeleteVMTunnel(ctx context.Context, vmID uint, tunnelID string) error {
-	if s.tunnels == nil {
-		return errors.New("gopher tunnel integration is not configured")
-	}
-	vm, err := s.Get(ctx, vmID)
+//
+// requesterID is forwarded to Get for ownership gating; non-nil values must
+// match vm.OwnerID or NotFound is returned. The machine_id filter on its own
+// only prevents cross-VM mismatch, not cross-user access.
+func (s *Service) DeleteVMTunnel(ctx context.Context, vmID uint, tunnelID string, requesterID *uint) error {
+	// Ownership before deployment-config so a non-owner gets NotFound rather
+	// than learning whether tunnels are wired up at all.
+	vm, err := s.Get(ctx, vmID, requesterID)
 	if err != nil {
 		return err
+	}
+	if s.tunnels == nil {
+		return errors.New("gopher tunnel integration is not configured")
 	}
 	if vm.TunnelID == "" {
 		return &internalerrors.NotFoundError{Resource: "tunnel", ID: tunnelID}

--- a/internal/provision/tunnel_test.go
+++ b/internal/provision/tunnel_test.go
@@ -1,0 +1,94 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	internalerrors "nimbus/internal/errors"
+	"nimbus/internal/provision"
+)
+
+func TestGet_OwnerSeesVM(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "owned-vm", 200, "alpha")
+
+	owner := uint(42)
+	vm, err := svc.Get(context.Background(), id, &owner)
+	if err != nil {
+		t.Fatalf("Get(owner): %v", err)
+	}
+	if vm.ID != id {
+		t.Errorf("Get returned wrong VM: got id=%d, want id=%d", vm.ID, id)
+	}
+}
+
+func TestGet_NonOwnerGets404(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "owned-vm", 200, "alpha")
+
+	other := uint(99)
+	_, err := svc.Get(context.Background(), id, &other)
+	var notFound *internalerrors.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("Get(non-owner): err = %v, want NotFoundError (existence must not be disclosed)", err)
+	}
+}
+
+func TestGet_NilRequesterBypassesOwnership(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "owned-vm", 200, "alpha")
+
+	vm, err := svc.Get(context.Background(), id, nil)
+	if err != nil {
+		t.Fatalf("Get(nil): %v", err)
+	}
+	if vm.ID != id {
+		t.Errorf("Get(nil) returned wrong VM: got id=%d, want id=%d", vm.ID, id)
+	}
+}
+
+func TestListVMTunnels_NonOwnerGets404(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "owned-vm", 200, "alpha")
+
+	other := uint(99)
+	_, err := svc.ListVMTunnels(context.Background(), id, &other)
+	var notFound *internalerrors.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("ListVMTunnels(non-owner): err = %v, want NotFoundError", err)
+	}
+}
+
+func TestCreateVMTunnel_NonOwnerGets404(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "owned-vm", 200, "alpha")
+
+	other := uint(99)
+	_, err := svc.CreateVMTunnel(context.Background(), id, provision.VMTunnelRequest{
+		TargetPort: 8080,
+		Transport:  "tcp",
+	}, &other)
+	var notFound *internalerrors.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("CreateVMTunnel(non-owner): err = %v, want NotFoundError (existence must not be disclosed; non-owner must not learn deployment-config state either)", err)
+	}
+}
+
+func TestDeleteVMTunnel_NonOwnerGets404(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	id := seedOwnedVM(t, database, 42, "owned-vm", 200, "alpha")
+
+	other := uint(99)
+	err := svc.DeleteVMTunnel(context.Background(), id, "tunnel-abc", &other)
+	var notFound *internalerrors.NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Errorf("DeleteVMTunnel(non-owner): err = %v, want NotFoundError", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `Service.Get` and the per-VM tunnel CRUD methods (`ListVMTunnels`, `CreateVMTunnel`, `DeleteVMTunnel`) skipped the ownership check that `Delete` and `Lifecycle` already enforce. A non-admin member could iterate IDs to enumerate other members' VMs, list their tunnel layout, and — most pointedly — POST a tunnel onto someone else's VM exposing arbitrary ports to the public internet.
- `Service.Get` now takes `requesterID *uint` and returns `NotFoundError` on mismatch, mirroring `GetPrivateKey`'s pattern.
- The four VM handlers (`Get`, `ListTunnels`, `CreateTunnel`, `DeleteTunnel`) now extract user from context and pass `&user.ID`.
- `CreateVMTunnel` / `DeleteVMTunnel` reordered so ownership fires before the deployment-level "tunnels not configured" check, preventing non-owners from probing deployment state via differing error messages.
- Six new ownership tests in `internal/provision/tunnel_test.go`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green
- [x] New `TestGet_*` / `TestListVMTunnels_NonOwnerGets404` / `TestCreateVMTunnel_NonOwnerGets404` / `TestDeleteVMTunnel_NonOwnerGets404` cover the gating
- [ ] Manual: as member A, `GET /api/vms/<B's id>` → 404
- [ ] Manual: as member A, `POST /api/vms/<B's id>/tunnels` → 404
- [ ] Manual: as VM owner, `GET /api/vms/<own id>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)