### PR TITLE
feat: per-member VM + GPU job quotas, tier allowlist

### DIFF
--- a/internal/api/handlers/gpu.go
+++ b/internal/api/handlers/gpu.go
@@ -132,11 +132,12 @@ func (h *GPU) SubmitJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	job, err := h.svc.EnqueueJob(r.Context(), gpu.EnqueueRequest{
-		OwnerID: user.ID,
-		VMID:    req.VMID,
-		Image:   req.Image,
-		Command: req.Command,
-		Env:     req.Env,
+		OwnerID:          user.ID,
+		VMID:             req.VMID,
+		Image:            req.Image,
+		Command:          req.Command,
+		Env:              req.Env,
+		RequesterIsAdmin: user.IsAdmin,
 	})
 	if err != nil {
 		response.FromError(w, err)

--- a/internal/api/handlers/vms.go
+++ b/internal/api/handlers/vms.go
@@ -96,26 +96,32 @@ func (h *VMs) Create(w http.ResponseWriter, r *http.Request) {
 	// Stamp the creator's user ID so the VM shows up in their My Machines and
 	// is the only person who can delete it later. Pre-existing VMs without an
 	// owner remain visible to everyone (see service.List) but immutable
-	// through the Delete endpoint.
-	var ownerID *uint
+	// through the Delete endpoint. RequesterIsAdmin lets the service skip
+	// member quotas and the tier allowlist for admin callers.
+	var (
+		ownerID          *uint
+		requesterIsAdmin bool
+	)
 	if user := ctxutil.User(r.Context()); user != nil {
 		id := user.ID
 		ownerID = &id
+		requesterIsAdmin = user.IsAdmin
 	}
 
 	res, err := h.svc.Provision(r.Context(), provision.Request{
-		Hostname:     req.Hostname,
-		Tier:         req.Tier,
-		OSTemplate:   req.OSTemplate,
-		SSHKeyID:     req.SSHKeyID,
-		SSHPubKey:    req.SSHPubKey,
-		SSHPrivKey:   req.SSHPrivKey,
-		GenerateKey:  req.GenerateKey,
-		PublicTunnel: req.PublicTunnel,
-		Subdomain:    subdomain,
-		TunnelPort:   req.TunnelPort,
-		EnableGPU:    req.EnableGPU,
-		OwnerID:      ownerID,
+		Hostname:         req.Hostname,
+		Tier:             req.Tier,
+		OSTemplate:       req.OSTemplate,
+		SSHKeyID:         req.SSHKeyID,
+		SSHPubKey:        req.SSHPubKey,
+		SSHPrivKey:       req.SSHPrivKey,
+		GenerateKey:      req.GenerateKey,
+		PublicTunnel:     req.PublicTunnel,
+		Subdomain:        subdomain,
+		TunnelPort:       req.TunnelPort,
+		EnableGPU:        req.EnableGPU,
+		OwnerID:          ownerID,
+		RequesterIsAdmin: requesterIsAdmin,
 	}, reporter)
 	if err != nil {
 		writeLine(map[string]any{
@@ -386,13 +392,9 @@ func validateCreate(req createVMRequest) error {
 	if _, ok := nodescore.Tiers[req.Tier]; !ok {
 		return &internalerrors.ValidationError{Field: "tier", Message: "must be one of small, medium, large"}
 	}
-	// xl is admin-only and not yet wired to OAuth; reject explicitly.
-	if req.Tier == "xl" {
-		return &internalerrors.ValidationError{
-			Field:   "tier",
-			Message: "xl tier requires admin approval (not yet enabled in this build)",
-		}
-	}
+	// Per-tier authorization (member allowlist vs admin-bypass) is enforced
+	// in provision.Service.Provision so the rule lives next to the quota
+	// it shares semantics with. validateCreate only checks tier shape.
 	if _, ok := proxmox.TemplateOffsets[req.OSTemplate]; !ok {
 		return &internalerrors.ValidationError{
 			Field:   "os_template",

--- a/internal/gpu/service.go
+++ b/internal/gpu/service.go
@@ -101,14 +101,25 @@ func (s *Service) LogPath(jobID uint) string {
 	return filepath.Join(s.logDir, fmt.Sprintf("%d.log", jobID))
 }
 
+// MemberMaxActiveJobs caps how many queued+running GPU jobs a single
+// non-admin user can hold. Beyond this, EnqueueJob returns ConflictError.
+// Admins bypass via EnqueueRequest.RequesterIsAdmin. Var (not const) so
+// tests can override.
+var MemberMaxActiveJobs = 5
+
 // EnqueueRequest is the input to EnqueueJob. Env is encoded to JSON for
 // storage (the worker decodes back to map[string]string at run time).
+//
+// RequesterIsAdmin bypasses the member active-jobs cap. Default false —
+// the safe answer when a caller forgets to set it. Handlers populate
+// from user.IsAdmin.
 type EnqueueRequest struct {
-	OwnerID uint
-	VMID    *uint
-	Image   string
-	Command string
-	Env     map[string]string
+	OwnerID          uint
+	VMID             *uint
+	Image            string
+	Command          string
+	Env              map[string]string
+	RequesterIsAdmin bool
 }
 
 // EnqueueJob inserts a new row in the queued state. Image is required;
@@ -117,6 +128,22 @@ func (s *Service) EnqueueJob(ctx context.Context, req EnqueueRequest) (*db.GPUJo
 	image := strings.TrimSpace(req.Image)
 	if image == "" {
 		return nil, &internalerrors.ValidationError{Field: "image", Message: "image is required"}
+	}
+	// Member quota gate. Skipped for admins. Counts queued + running rows
+	// owned by this caller — terminal states (succeeded/failed/cancelled)
+	// don't count, so the cap is on concurrent active load, not lifetime.
+	if !req.RequesterIsAdmin && req.OwnerID != 0 {
+		var active int64
+		if err := s.db.WithContext(ctx).Model(&db.GPUJob{}).
+			Where("owner_id = ? AND status IN ?", req.OwnerID, []string{StatusQueued, StatusRunning}).
+			Count(&active).Error; err != nil {
+			return nil, fmt.Errorf("count active gpu jobs: %w", err)
+		}
+		if int(active) >= MemberMaxActiveJobs {
+			return nil, &internalerrors.ConflictError{
+				Message: fmt.Sprintf("GPU job quota reached: members may have at most %d queued or running jobs at once", MemberMaxActiveJobs),
+			}
+		}
 	}
 	envJSON := ""
 	if len(req.Env) > 0 {

--- a/internal/gpu/service_test.go
+++ b/internal/gpu/service_test.go
@@ -258,3 +258,75 @@ func TestReapStuckJobs_FlipsLongRunningJobsToFailed(t *testing.T) {
 func errorsAs(err error, target any) bool {
 	return errors.As(err, target)
 }
+
+func TestEnqueueJob_MemberAtCapRejected(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	for i := 0; i < gpu.MemberMaxActiveJobs; i++ {
+		if _, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 7, Image: "alpine"}); err != nil {
+			t.Fatalf("seed enqueue %d: %v", i, err)
+		}
+	}
+	_, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 7, Image: "alpine"})
+	var conflict *internalerrors.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("EnqueueJob over cap: err = %v, want ConflictError", err)
+	}
+}
+
+func TestEnqueueJob_AdminBypassesCap(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	for i := 0; i < gpu.MemberMaxActiveJobs; i++ {
+		if _, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 7, Image: "alpine"}); err != nil {
+			t.Fatalf("seed enqueue %d: %v", i, err)
+		}
+	}
+	_, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{
+		OwnerID:          7,
+		Image:            "alpine",
+		RequesterIsAdmin: true,
+	})
+	if err != nil {
+		t.Fatalf("admin should bypass cap: %v", err)
+	}
+}
+
+func TestEnqueueJob_TerminalJobsDontCountTowardCap(t *testing.T) {
+	t.Parallel()
+	svc, database := newTestService(t)
+	ctx := context.Background()
+	// Cap+2 succeeded jobs — terminal, so they don't count.
+	for i := 0; i < gpu.MemberMaxActiveJobs+2; i++ {
+		j, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 7, Image: "alpine"})
+		if err != nil {
+			t.Fatalf("seed enqueue %d: %v", i, err)
+		}
+		if err := database.Model(&db.GPUJob{}).Where("id = ?", j.ID).
+			Update("status", gpu.StatusSucceeded).Error; err != nil {
+			t.Fatalf("flip status: %v", err)
+		}
+	}
+	// New enqueue must succeed — none of the prior jobs are queued/running.
+	if _, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 7, Image: "alpine"}); err != nil {
+		t.Fatalf("EnqueueJob with only-terminal history: %v", err)
+	}
+}
+
+func TestEnqueueJob_OtherUsersJobsDontCountTowardCap(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+	// User 7 fills the queue.
+	for i := 0; i < gpu.MemberMaxActiveJobs; i++ {
+		if _, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 7, Image: "alpine"}); err != nil {
+			t.Fatalf("seed enqueue %d: %v", i, err)
+		}
+	}
+	// User 8 should be unaffected.
+	if _, err := svc.EnqueueJob(ctx, gpu.EnqueueRequest{OwnerID: 8, Image: "alpine"}); err != nil {
+		t.Fatalf("other-user enqueue must not be quota-blocked by user 7: %v", err)
+	}
+}

--- a/internal/provision/quota.go
+++ b/internal/provision/quota.go
@@ -1,0 +1,28 @@
+package provision
+
+// Quota defaults. Members hit these caps; admins bypass via Request.
+// RequesterIsAdmin. They're vars (not consts) so tests can override; once a
+// QuotaSettings table lands, swap these for a settings-backed lookup.
+//
+// MemberMaxVMs caps how many active VMs a single non-admin user can own
+// concurrently. Beyond this, Provision returns ConflictError before any
+// hypervisor work begins. Soft-deleted rows do not count.
+//
+// MemberAllowedTiers is the allowlist (not blocklist) of tiers non-admins
+// may request. New tiers added to nodescore.Tiers are member-denied by
+// default — the operator must explicitly opt them in here.
+var (
+	MemberMaxVMs       = 5
+	MemberAllowedTiers = map[string]struct{}{
+		"small":  {},
+		"medium": {},
+		"large":  {},
+	}
+)
+
+// IsTierMemberAllowed reports whether the given tier is in the member
+// allowlist. Admins should bypass this check via Request.RequesterIsAdmin.
+func IsTierMemberAllowed(tier string) bool {
+	_, ok := MemberAllowedTiers[tier]
+	return ok
+}

--- a/internal/provision/quota_test.go
+++ b/internal/provision/quota_test.go
@@ -1,0 +1,143 @@
+package provision_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	"nimbus/internal/db"
+	internalerrors "nimbus/internal/errors"
+	"nimbus/internal/provision"
+)
+
+// seedManyOwnedVMs creates n VMs owned by ownerID with unique
+// vmid/hostname/ip values so the unique-index constraints don't trip.
+func seedManyOwnedVMs(t *testing.T, database *db.DB, ownerID uint, n int) {
+	t.Helper()
+	owner := ownerID
+	for i := 0; i < n; i++ {
+		row := &db.VM{
+			VMID:       9000 + i,
+			Hostname:   "owned-" + strconv.Itoa(i),
+			IP:         "10.0.0." + strconv.Itoa(100+i),
+			Node:       "alpha",
+			Tier:       "small",
+			OSTemplate: "ubuntu-24.04",
+			Status:     "running",
+			OwnerID:    &owner,
+		}
+		if err := database.Create(row).Error; err != nil {
+			t.Fatalf("seed vm %d: %v", i, err)
+		}
+	}
+}
+
+func TestProvision_MemberAtCapRejected(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	owner := uint(42)
+	seedManyOwnedVMs(t, database, owner, provision.MemberMaxVMs)
+
+	_, err := svc.Provision(context.Background(), provision.Request{
+		Hostname:   "over-cap",
+		Tier:       "small",
+		OSTemplate: "ubuntu-24.04",
+		SSHPubKey:  realPubKey(t),
+		OwnerID:    &owner,
+	}, nil)
+
+	var conflict *internalerrors.ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("Provision over cap: err = %v, want ConflictError", err)
+	}
+}
+
+func TestProvision_AdminBypassesCap(t *testing.T) {
+	t.Parallel()
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	owner := uint(42)
+	seedManyOwnedVMs(t, database, owner, provision.MemberMaxVMs)
+
+	_, err := svc.Provision(context.Background(), provision.Request{
+		Hostname:         "admin-bypass",
+		Tier:             "small",
+		OSTemplate:       "ubuntu-24.04",
+		SSHPubKey:        realPubKey(t),
+		OwnerID:          &owner,
+		RequesterIsAdmin: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("admin should bypass member cap: %v", err)
+	}
+}
+
+func TestProvision_NilOwnerBypassesCap(t *testing.T) {
+	t.Parallel()
+	// Legacy / test paths without OwnerID must not be quota-gated. The
+	// Phase-1 Provision() callers (and the existing test corpus) all pass
+	// nil owner.
+	svc, _, database := newTestService(t, happyFakePVE(t))
+	owner := uint(42)
+	seedManyOwnedVMs(t, database, owner, provision.MemberMaxVMs)
+
+	_, err := svc.Provision(context.Background(), provision.Request{
+		Hostname:   "no-owner",
+		Tier:       "small",
+		OSTemplate: "ubuntu-24.04",
+		SSHPubKey:  realPubKey(t),
+		OwnerID:    nil,
+	}, nil)
+	if err != nil {
+		t.Fatalf("nil-owner provision must not be quota-gated: %v", err)
+	}
+}
+
+func TestProvision_MemberDisallowedTier(t *testing.T) {
+	t.Parallel()
+	svc, _, _ := newTestService(t, happyFakePVE(t))
+	owner := uint(42)
+
+	_, err := svc.Provision(context.Background(), provision.Request{
+		Hostname:   "xl-as-member",
+		Tier:       "xl",
+		OSTemplate: "ubuntu-24.04",
+		SSHPubKey:  realPubKey(t),
+		OwnerID:    &owner,
+	}, nil)
+
+	var ve *internalerrors.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("Provision(xl as member): err = %v, want ValidationError", err)
+	}
+	if ve.Field != "tier" {
+		t.Errorf("ValidationError.Field = %q, want tier", ve.Field)
+	}
+}
+
+func TestProvision_AdminMayUseDisallowedTier(t *testing.T) {
+	t.Parallel()
+	svc, _, _ := newTestService(t, happyFakePVE(t))
+	owner := uint(42)
+
+	_, err := svc.Provision(context.Background(), provision.Request{
+		Hostname:         "xl-as-admin",
+		Tier:             "xl",
+		OSTemplate:       "ubuntu-24.04",
+		SSHPubKey:        realPubKey(t),
+		OwnerID:          &owner,
+		RequesterIsAdmin: true,
+	}, nil)
+	// Admins clear the allowlist; they may still hit unrelated downstream
+	// errors (e.g. tier xl unknown to nodescore.Tiers). The contract this
+	// test enforces is: the *member-allowlist* gate did not fire. Failing
+	// later for unrelated reasons is fine, but we should not see a
+	// ValidationError on the "tier" field with the admin-only message.
+	if err == nil {
+		return // happy path
+	}
+	var ve *internalerrors.ValidationError
+	if errors.As(err, &ve) && ve.Field == "tier" && ve.Message == `tier "xl" is admin-only` {
+		t.Fatalf("admin should bypass member tier allowlist, got %v", err)
+	}
+}

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -274,6 +274,27 @@ func (s *Service) Provision(ctx context.Context, req Request, progress ProgressR
 		return nil, &internalerrors.ValidationError{Field: "os_template", Message: fmt.Sprintf("unknown os_template %q", req.OSTemplate)}
 	}
 
+	// Member quota gate. Skipped for admins and for legacy/test paths that
+	// don't supply an OwnerID. We check here — before IP reserve and clone —
+	// so a flooding member can't burn cluster resources spinning up rejects.
+	if !req.RequesterIsAdmin && req.OwnerID != nil {
+		if !IsTierMemberAllowed(req.Tier) {
+			return nil, &internalerrors.ValidationError{
+				Field:   "tier",
+				Message: fmt.Sprintf("tier %q is admin-only", req.Tier),
+			}
+		}
+		var owned int64
+		if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("owner_id = ?", *req.OwnerID).Count(&owned).Error; err != nil {
+			return nil, fmt.Errorf("count owned vms: %w", err)
+		}
+		if int(owned) >= MemberMaxVMs {
+			return nil, &internalerrors.ConflictError{
+				Message: fmt.Sprintf("VM quota reached: members may own at most %d VMs at once", MemberMaxVMs),
+			}
+		}
+	}
+
 	// Resolve SSH key. The service may either reuse an existing vault entry
 	// or create a new one (generate / BYO / default-fallback).
 	sshKey, sshPrivateKey, err := s.resolveSSHKey(ctx, req)

--- a/internal/provision/types.go
+++ b/internal/provision/types.go
@@ -21,6 +21,11 @@ type Request struct {
 	GenerateKey bool
 	OwnerID     *uint // nil in Phase 1 (no auth)
 
+	// RequesterIsAdmin bypasses member quotas (MemberMaxVMs) and the tier
+	// allowlist (MemberAllowedTiers). Default false — the safe answer when
+	// a caller forgets to set it. Handlers populate from user.IsAdmin.
+	RequesterIsAdmin bool
+
 	// PublicTunnel asks Nimbus to register a Gopher tunnel for the new VM and
 	// expose it at Subdomain.<gopher-zone>. Silently ignored when GOPHER_API_URL
 	// is unset. TunnelPort is the in-VM target port Gopher should forward to;


### PR DESCRIPTION
## Summary

Closes the DoS gap identified in the member-permissions audit alongside #204. A non-admin member could call `POST /api/vms` or `POST /api/gpu/jobs` in a loop with no service-side cap, exhausting cluster IPs/storage/VMID space or flooding the GPU queue. This adds three quotas, all admin-bypassed via a new `RequesterIsAdmin` field on the relevant service-request structs.

- **`provision.MemberMaxVMs`** (default 5): `Service.Provision` counts `vms.owner_id == requester` before any IP/clone work and returns `ConflictError` at cap.
- **`provision.MemberAllowedTiers`** (default `{small, medium, large}`): allowlist replaces the previous "reject xl" blocklist. Future tiers default-deny for members; admins bypass. The check moves from `validateCreate` (shape-only now) into the service so handlers and direct callers share one gate.
- **`gpu.MemberMaxActiveJobs`** (default 5): `EnqueueJob` counts queued+running jobs for the caller and returns `ConflictError` at cap. Terminal states (succeeded/failed/cancelled) don't count — the cap is on concurrent active load, not lifetime submissions.

Vars rather than consts so tests can override. Once a `QuotaSettings` table lands, swap these for a settings-backed lookup. Phase-1 callers that pass `nil OwnerID` keep the existing bypass behavior so existing test corpora and any pre-OAuth code paths still work.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green across all packages
- [x] New `TestProvision_*` (5 cases): cap rejection, admin bypass, nil-owner bypass, member-tier-rejected, admin-tier-bypass
- [x] New `TestEnqueueJob_*` (4 cases): cap rejection, admin bypass, terminal jobs ignored, other users' jobs ignored
- [ ] Manual: as member at 5 VMs, `POST /api/vms` returns 409
- [ ] Manual: as admin at 5 VMs, `POST /api/vms` succeeds
- [ ] Manual: as member, `POST /api/vms {tier:"xl"}` returns 422 with "admin-only" message
- [ ] Manual: as member with 5 queued GPU jobs, `POST /api/gpu/jobs` returns 409

## Follow-ups (not in this PR)
- Admin-configurable settings UI for the three caps (currently in code).
- Per-tier or per-resource (CPU/RAM/storage) budget instead of pure count.
- Rate-limit middleware on the provision endpoint to throttle bursts even within cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)