### PR TITLE
feat: live Proxmox status on the My machines list

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,7 +10,7 @@ export interface User {
 
 export type TierName = 'small' | 'medium' | 'large' | 'xl'
 export type OSTemplate = 'ubuntu-24.04' | 'ubuntu-22.04' | 'debian-12' | 'debian-11'
-export type VMStatus = 'provisioning' | 'running' | 'failed'
+export type VMStatus = 'provisioning' | 'running' | 'stopped' | 'paused' | 'failed' | 'unknown'
 
 export interface Tier {
   name: TierName

--- a/internal/api/handlers/vms.go
+++ b/internal/api/handlers/vms.go
@@ -168,7 +168,7 @@ func (h *VMs) List(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusUnauthorized, "Not authenticated")
 		return
 	}
-	vms, err := h.svc.List(r.Context(), &user.ID)
+	vms, err := h.svc.ListWithLiveStatus(r.Context(), &user.ID)
 	if err != nil {
 		response.FromError(w, err)
 		return

--- a/internal/provision/lifecycle_test.go
+++ b/internal/provision/lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"nimbus/internal/db"
 	internalerrors "nimbus/internal/errors"
 	"nimbus/internal/provision"
+	"nimbus/internal/proxmox"
 )
 
 // seedOwnedVM seeds a vms row owned by ownerID at the given (vmid, node, ip).
@@ -115,5 +116,93 @@ func TestAdminLifecycleByVMID_StampsStatusOnLocalRow(t *testing.T) {
 	}
 	if got.Status != "stopped" {
 		t.Errorf("local status after admin shutdown = %q, want stopped", got.Status)
+	}
+}
+
+func TestListWithLiveStatus_OverwritesWhenProxmoxDisagrees(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return []proxmox.ClusterVM{{VMID: 200, Node: "alpha", Status: "stopped"}}, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	owner := uint(42)
+	seedOwnedVM(t, database, owner, "vm-a", 200, "alpha")
+
+	got, err := svc.ListWithLiveStatus(context.Background(), &owner)
+	if err != nil {
+		t.Fatalf("ListWithLiveStatus: %v", err)
+	}
+	if len(got) != 1 || got[0].Status != "stopped" {
+		t.Fatalf("status = %+v, want one row with status=stopped", got)
+	}
+}
+
+func TestListWithLiveStatus_KeepsDBStatusWhenProxmoxSilent(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return nil, nil // VM not yet visible to Proxmox (e.g. mid-provision)
+	}
+	svc, _, database := newTestService(t, fake)
+	owner := uint(42)
+	row := &db.VM{
+		VMID: 200, Hostname: "vm-a", Node: "alpha",
+		Tier: "small", OSTemplate: "ubuntu-24.04",
+		Status: "provisioning", OwnerID: &owner,
+	}
+	if err := database.Create(row).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, err := svc.ListWithLiveStatus(context.Background(), &owner)
+	if err != nil {
+		t.Fatalf("ListWithLiveStatus: %v", err)
+	}
+	if len(got) != 1 || got[0].Status != "provisioning" {
+		t.Fatalf("status = %+v, want one row with status=provisioning", got)
+	}
+}
+
+func TestListWithLiveStatus_FallsBackOnProxmoxError(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return nil, errors.New("proxmox boom")
+	}
+	svc, _, database := newTestService(t, fake)
+	owner := uint(42)
+	seedOwnedVM(t, database, owner, "vm-a", 200, "alpha")
+
+	got, err := svc.ListWithLiveStatus(context.Background(), &owner)
+	if err != nil {
+		t.Fatalf("ListWithLiveStatus: %v", err)
+	}
+	if len(got) != 1 || got[0].Status != "running" {
+		t.Fatalf("status = %+v, want DB-side running on Proxmox failure", got)
+	}
+}
+
+func TestListWithLiveStatus_ScopedToOwner(t *testing.T) {
+	t.Parallel()
+	fake := happyFakePVE(t)
+	fake.getClusterVMs = func(_ context.Context) ([]proxmox.ClusterVM, error) {
+		return []proxmox.ClusterVM{
+			{VMID: 200, Node: "alpha", Status: "stopped"},
+			{VMID: 201, Node: "alpha", Status: "stopped"},
+		}, nil
+	}
+	svc, _, database := newTestService(t, fake)
+	mine := uint(42)
+	other := uint(99)
+	seedOwnedVM(t, database, mine, "mine", 200, "alpha")
+	seedOwnedVM(t, database, other, "theirs", 201, "alpha")
+
+	got, err := svc.ListWithLiveStatus(context.Background(), &mine)
+	if err != nil {
+		t.Fatalf("ListWithLiveStatus: %v", err)
+	}
+	if len(got) != 1 || got[0].VMID != 200 {
+		t.Fatalf("got = %+v, want only owner=42's row", got)
 	}
 }

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -669,6 +669,41 @@ func (s *Service) List(ctx context.Context, ownerID *uint) ([]db.VM, error) {
 	return vms, nil
 }
 
+// ListWithLiveStatus is List enriched with live Proxmox power state so a VM
+// stopped/paused outside Nimbus surfaces correctly on the user's dashboard.
+// The DB-side `vm.status` is otherwise only written when Nimbus itself drives
+// a lifecycle op, so it goes stale the moment someone uses the Proxmox UI or
+// the VM crashes.
+//
+// Rows with no matching Proxmox record keep their DB status unchanged — that
+// preserves "provisioning" mid-clone (the VM doesn't exist on Proxmox yet)
+// and "failed" rows that never got past clone. If the Proxmox call fails the
+// DB rows are returned as-is so a transient outage doesn't blank the page.
+func (s *Service) ListWithLiveStatus(ctx context.Context, ownerID *uint) ([]db.VM, error) {
+	vms, err := s.List(ctx, ownerID)
+	if err != nil {
+		return nil, err
+	}
+	if len(vms) == 0 {
+		return vms, nil
+	}
+	cluster, err := s.px.GetClusterVMs(ctx)
+	if err != nil {
+		log.Printf("list vms: live status lookup failed, returning DB status: %v", err)
+		return vms, nil
+	}
+	live := make(map[int]string, len(cluster))
+	for _, c := range cluster {
+		live[c.VMID] = c.Status
+	}
+	for i := range vms {
+		if status, ok := live[vms[i].VMID]; ok && status != "" {
+			vms[i].Status = status
+		}
+	}
+	return vms, nil
+}
+
 // BackfillOwnership assigns every VM with a NULL owner_id to the
 // lowest-ID admin on the instance. Pre-ownership-tracking VMs (provisioned
 // before this feature shipped) get bound to the original setup admin so


### PR DESCRIPTION

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__
vm.status is only written when Nimbus itself drives a lifecycle op, so power changes made directly in Proxmox (or VMs that crash) leave the My machines page showing a stale "running" badge. Add provision.Service.ListWithLiveStatus, which overlays GetClusterVMs power state onto the user's owned rows. Rows missing from Proxmox keep their DB status (preserves provisioning / failed); a Proxmox error falls back to DB status so a transient outage doesn't blank the page. Ownership scoping is unchanged — filtering still happens through the existing List(ownerID) query before enrichment.


## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

