### PR TITLE
fix: default NIMBUS_NETSCAN_MODE to arp (closes #205)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ in `internal/tunnel/client.go` handles both — confirmed against
 | `NIMBUS_VM_DISK_STORAGE` | `local-lvm` | Proxmox storage pool the disk gate checks for free space; empty disables the disk gate (scorer reverts to mem+cpu) |
 | `NIMBUS_MEM_BUFFER_MIB` | 256 | RAM headroom required above the tier's request — avoids packing a node to literal zero free |
 | `NIMBUS_CPU_LOAD_FACTOR` | 0.5 | Share of a fresh VM's vCPUs the soft score assumes consumed (range 0.25–1.0) |
-| `NIMBUS_NETSCAN_MODE` | `both` | `off` / `tcp` / `both` — netscan probe mode |
+| `NIMBUS_NETSCAN_MODE` | `arp` | `off` / `tcp` / `arp` / `both` — `arp` is passive (reads `/proc/net/arp`); `tcp` / `both` actively probe and read as a port scan to network IDS, opt in only on networks where you control the monitoring |
 | `NIMBUS_NETSCAN_INTERVAL_SECONDS` | 300 | Netscan loop cadence; 0 disables |
 | `NIMBUS_NETSCAN_TIMEOUT_MS` | 200 | Per-port TCP dial timeout for netscan |
 | `NIMBUS_NETSCAN_CONCURRENCY` | 50 | Parallel probes during a netscan sweep |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,7 +53,10 @@ type Config struct {
 	// the IP pool range (gateway, NAS, IoT, statically-assigned workstations).
 	// Closes a hole in the Proxmox reconciler, which only sees VM-claimed IPs.
 	//
-	// NetscanMode:     off | tcp | both — default "both" (TCP probe + ARP cache read)
+	// NetscanMode:     off | tcp | arp | both — default "arp" (passive ARP cache
+	//                  read only). The active TCP probe (`tcp` or `both`) trips
+	//                  IDS/IPS rules and reads as a horizontal port scan on
+	//                  corporate networks; opt in with `both` on a homelab.
 	// NetscanInterval: scan cadence in seconds — default 300 (5min); 0 disables
 	// NetscanTimeoutMS: per-port TCP dial timeout — default 200
 	// NetscanConcurrency: parallel probes — default 50
@@ -113,7 +116,7 @@ func Load() (*Config, error) {
 		VerifyCacheTTLSeconds:    getEnvInt("VERIFY_CACHE_TTL_SECONDS", 5),
 		VacateMissThreshold:      getEnvInt("VACATE_MISS_THRESHOLD", 3),
 
-		NetscanMode:         getEnv("NIMBUS_NETSCAN_MODE", "both"),
+		NetscanMode:         getEnv("NIMBUS_NETSCAN_MODE", "arp"),
 		NetscanIntervalSecs: getEnvInt("NIMBUS_NETSCAN_INTERVAL_SECONDS", 300),
 		NetscanTimeoutMS:    getEnvInt("NIMBUS_NETSCAN_TIMEOUT_MS", 200),
 		NetscanConcurrency:  getEnvInt("NIMBUS_NETSCAN_CONCURRENCY", 50),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #205 
The previous default (`both`) TCP-probed 22/80/443/445 across the whole pool every 5 minutes — a textbook horizontal port scan. Suricata and Snort `ET SCAN` rules, Crowdstrike, Defender for Endpoint, and most enterprise NDR appliances will fire on it; port 445 specifically reads as EternalBlue / Conficker / lateral-movement reconnaissance.

ARP-only is passive (reads `/proc/net/arp`) and stays quiet on the wire while still catching the gateway, anything chatty, and anything the nimbus box has talked to — ~90% of devices on a typical LAN. The remaining gap (silent static-IP hosts) is recovered by the existing verifyAndRetryReserve check against Proxmox cluster claims plus the 60-s IP reconciler, so the worst-case outcome is one retried provision not a sustained IP collision.

Operators who want the active probe set NIMBUS_NETSCAN_MODE=both in nimbus.env — the env-var read path is unchanged, so existing overrides keep their behaviour.

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

