### PR TITLE
fix: lifecycle ops are idempotent when VM is already in target state

### DIFF
--- a/internal/provision/lifecycle_test.go
+++ b/internal/provision/lifecycle_test.go
@@ -3,7 +3,9 @@ package provision_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"nimbus/internal/db"
 	internalerrors "nimbus/internal/errors"
@@ -204,5 +206,48 @@ func TestListWithLiveStatus_ScopedToOwner(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].VMID != 200 {
 		t.Fatalf("got = %+v, want only owner=42's row", got)
+	}
+}
+
+// TestLifecycleOp_IdempotentWhenAlreadyInTargetState exercises the user-clicks-
+// Start-on-already-running flow that surfaced as a 500 in production. Proxmox
+// returns a UPID and then the qmstart task fails with "VM N already running"
+// from qmeventd. The dispatcher should swallow that specific failure and
+// still write the local status, so the UI sees the click as a no-op success
+// instead of a confusing internal-server-error toast.
+func TestLifecycleOp_IdempotentWhenAlreadyInTargetState(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		op     provision.VMLifecycleOp
+		taskID string // matches what RebootVM/StartVM/etc. return
+		errMsg string // simulates a WaitForTask failure
+	}{
+		{provision.VMOpStart, "task:start", "task UPID:n:00:00:69:qmstart:200: failed: VM 200 already running"},
+		{provision.VMOpShutdown, "task:shutdown", "task UPID:n:00:00:69:qmshutdown:200: failed: VM 200 not running"},
+		{provision.VMOpStop, "task:stop", "task UPID:n:00:00:69:qmstop:200: failed: VM 200 already stopped"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.op), func(t *testing.T) {
+			t.Parallel()
+			fake := happyFakePVE(t)
+			// Make the relevant op return its task ID, then make WaitForTask
+			// return the simulated qmeventd failure.
+			fake.startVM = func(_ context.Context, _ string, _ int) (string, error) { return tc.taskID, nil }
+			fake.stopVM = func(_ context.Context, _ string, _ int) (string, error) { return tc.taskID, nil }
+			fake.shutdownVM = func(_ context.Context, _ string, _ int) (string, error) { return tc.taskID, nil }
+			fake.waitForTask = func(_ context.Context, _, taskID string, _ time.Duration) error {
+				if taskID == tc.taskID {
+					return fmt.Errorf("%s", tc.errMsg)
+				}
+				return nil
+			}
+			svc, _, database := newTestService(t, fake)
+			id := seedOwnedVM(t, database, 42, "vm-a", 200, "alpha")
+
+			if err := svc.LifecycleOp(context.Background(), id, 42, tc.op); err != nil {
+				t.Fatalf("LifecycleOp(%s) on already-in-target-state VM should be a no-op: %v", tc.op, err)
+			}
+		})
 	}
 }

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -883,12 +883,15 @@ func (s *Service) AdminLifecycleByVMID(ctx context.Context, node string, vmid in
 	default:
 		return &internalerrors.ValidationError{Field: "op", Message: fmt.Sprintf("unknown lifecycle op %q", op)}
 	}
-	if err != nil {
+	if err != nil && !isAlreadyInTargetState(op, err) {
 		return fmt.Errorf("%s vm %d on %s: %w", op, vmid, node, err)
 	}
-	if upid != "" {
-		if err := s.px.WaitForTask(ctx, node, upid, s.cfg.PollInterval); err != nil {
-			return fmt.Errorf("%s task vm %d: %w", op, vmid, err)
+	if err == nil && upid != "" {
+		if waitErr := s.px.WaitForTask(ctx, node, upid, s.cfg.PollInterval); waitErr != nil {
+			if !isAlreadyInTargetState(op, waitErr) {
+				return fmt.Errorf("%s task vm %d: %w", op, vmid, waitErr)
+			}
+			log.Printf("admin lifecycle %s vm=%d node=%s: task surfaced a benign already-in-state error: %v", op, vmid, node, waitErr)
 		}
 	}
 	// Best-effort optimistic status sync for local rows.
@@ -902,6 +905,15 @@ func (s *Service) AdminLifecycleByVMID(ctx context.Context, node string, vmid in
 
 // runLifecycleOp dispatches op to the right Proxmox endpoint, waits for the
 // task, then updates vms.status. Returns ValidationError for an unknown op.
+//
+// Idempotency: a Start on an already-running VM (or a Stop/Shutdown on an
+// already-stopped one) returns no-error and still updates the local status.
+// Proxmox surfaces these as either an HTTP 500 from the API call (handled by
+// isAlreadyInTargetState's HTTPError branch) or as a task-failed string from
+// WaitForTask (handled by the substring branch), depending on whether
+// pveproxy or qm/qmeventd notices first. The user's intent — "this VM should
+// be in state X" — is satisfied either way; surfacing a 500 from Start when
+// the VM is already up is just confusing.
 func (s *Service) runLifecycleOp(ctx context.Context, vm *db.VM, op VMLifecycleOp) error {
 	var (
 		upid       string
@@ -924,12 +936,17 @@ func (s *Service) runLifecycleOp(ctx context.Context, vm *db.VM, op VMLifecycleO
 	default:
 		return &internalerrors.ValidationError{Field: "op", Message: fmt.Sprintf("unknown lifecycle op %q", op)}
 	}
-	if err != nil {
+	if err != nil && !isAlreadyInTargetState(op, err) {
 		return fmt.Errorf("%s vm %d on %s: %w", op, vm.VMID, vm.Node, err)
 	}
-	if upid != "" {
-		if err := s.px.WaitForTask(ctx, vm.Node, upid, s.cfg.PollInterval); err != nil {
-			return fmt.Errorf("%s task vm %d: %w", op, vm.VMID, err)
+	if err == nil && upid != "" {
+		if waitErr := s.px.WaitForTask(ctx, vm.Node, upid, s.cfg.PollInterval); waitErr != nil {
+			if !isAlreadyInTargetState(op, waitErr) {
+				return fmt.Errorf("%s task vm %d: %w", op, vm.VMID, waitErr)
+			}
+			// Task failed but only because the VM was already in the
+			// target state — fall through and let the status write run.
+			log.Printf("lifecycle %s vm=%d: task surfaced a benign already-in-state error: %v", op, vm.ID, waitErr)
 		}
 	}
 	if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("id = ?", vm.ID).
@@ -937,6 +954,39 @@ func (s *Service) runLifecycleOp(ctx context.Context, vm *db.VM, op VMLifecycleO
 		log.Printf("lifecycle %s vm=%d: status update failed (proxmox already applied): %v", op, vm.ID, err)
 	}
 	return nil
+}
+
+// isAlreadyInTargetState reports whether a Proxmox-side error means "the VM
+// is already in the state op was trying to put it in" — the kind of failure
+// a user-facing Start/Shutdown click should treat as success rather than a
+// 500.
+//
+// Two surfaces produce this kind of error and they look different:
+//   - The status/start | status/stop endpoint can return HTTP 500 with a body
+//     like "VM N is not running" / "VM N already running".
+//   - The async task can succeed-then-fail in qmeventd with the same wording
+//     in ExitStatus, surfacing as an opaque "task ... failed: VM N ..."
+//     wrapped error from WaitForTask.
+//
+// We accept both. Reboot stays strict — "VM not running" on a reboot click is
+// a real misuse the user should see.
+func isAlreadyInTargetState(op VMLifecycleOp, err error) bool {
+	if err == nil {
+		return false
+	}
+	body := err.Error()
+	if httpErr := (*proxmox.HTTPError)(nil); errors.As(err, &httpErr) {
+		body = httpErr.Body
+	}
+	body = strings.ToLower(body)
+	switch op {
+	case VMOpStart:
+		return strings.Contains(body, "already running")
+	case VMOpShutdown, VMOpStop:
+		return strings.Contains(body, "not running") ||
+			strings.Contains(body, "already stopped")
+	}
+	return false
 }
 
 // AdminDelete destroys a VM regardless of who owns it. Same semantics as


### PR DESCRIPTION

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

Production hit a 500 on POST /api/vms/{id}/start when a user clicked Start on a VM that was already running — Proxmox returned a UPID, then qmeventd failed the qmstart task with "VM 147 already running", which WaitForTask wrapped into an error and bubbled up as 500.

The shutdown path already had similar tolerance via isVMNotRunning, but that helper only matched the HTTP-error surface (the status/stop endpoint rejecting up-front with 500 + body). The qmstart case fails through WaitForTask instead — same wording, different error shape, so the tolerance never fired.

Generalised into isAlreadyInTargetState(op, err) — a single helper that walks both surfaces (proxmox.HTTPError body and the wrapped task-failed string) and recognises the four benign wordings ("already running", "not running", "already stopped"). Wired into both runLifecycleOp (the owner-gated user path) and AdminLifecycleByVMID (the admin by-(node, vmid) path). Reboot stays strict — clicking Restart on a stopped VM is a real misuse the user should see.

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

