### PR TITLE
fix: secrets.LoadOrCreateKey reads existing key from env file before generating

### DIFF
--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 const (
@@ -72,22 +73,52 @@ func (c *Cipher) Decrypt(ciphertext, nonce []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// LoadOrCreateKey resolves the master key. If the env var is already set it is
-// decoded and returned. Otherwise a fresh 32-byte key is generated, written to
-// envFilePath as a KEY=VALUE line, and exported into the current process env.
+// LoadOrCreateKey resolves the master key. Resolution order:
 //
-// envFilePath may be empty in which case the generated key is only set in the
-// process environment (useful for tests / one-shot CLI runs).
+//  1. Process env (NIMBUS_ENCRYPTION_KEY already set — typical when systemd
+//     loaded the EnvironmentFile before exec).
+//  2. The first NIMBUS_ENCRYPTION_KEY=… line in envFilePath. Falling through
+//     to (3) without consulting the file would generate a NEW key and
+//     append it, which silently rotates the at-rest encryption key out
+//     from under every encrypted SSH blob in the DB. Reading existing
+//     entries first keeps manual `nimbus` invocations (no systemd) safe.
+//  3. Generate a fresh 32-byte key and persist it to envFilePath.
+//
+// As a side effect of (2), if the file contains *multiple*
+// NIMBUS_ENCRYPTION_KEY lines the file is rewritten to keep only the first
+// one. Earlier versions of this function appended on every cold start that
+// didn't see the env var pre-loaded, so production env files have grown
+// duplicate keys over time — the first is the canonical key (matches what
+// systemd's EnvironmentFile resolves to and what already encrypted the
+// vault); later lines are dead weight that would shift the resolved key
+// the day systemd's dedupe behaviour changes.
+//
+// envFilePath may be empty (tests / one-shot CLI runs); then both the
+// file-read fallback and persistence are skipped.
 func LoadOrCreateKey(envFilePath string) ([]byte, error) {
 	if v := os.Getenv(EnvVar); v != "" {
-		key, err := base64.StdEncoding.DecodeString(v)
+		return decodeKey(v)
+	}
+
+	if envFilePath != "" {
+		v, dupes, err := readFirstEnvValue(envFilePath, EnvVar)
 		if err != nil {
-			return nil, fmt.Errorf("decode %s: %w", EnvVar, err)
+			return nil, fmt.Errorf("read %s: %w", envFilePath, err)
 		}
-		if len(key) != KeyLen {
-			return nil, fmt.Errorf("%s decodes to %d bytes, want %d", EnvVar, len(key), KeyLen)
+		if v != "" {
+			if dupes > 0 {
+				if err := dedupeEnvKey(envFilePath, EnvVar); err != nil {
+					// Dedupe failure isn't fatal — we still got a usable
+					// key; just log via a returned wrapped error so the
+					// caller can decide.
+					return nil, fmt.Errorf("dedupe %s in %s: %w", EnvVar, envFilePath, err)
+				}
+			}
+			if err := os.Setenv(EnvVar, v); err != nil {
+				return nil, fmt.Errorf("set %s: %w", EnvVar, err)
+			}
+			return decodeKey(v)
 		}
-		return key, nil
 	}
 
 	key := make([]byte, KeyLen)
@@ -104,6 +135,115 @@ func LoadOrCreateKey(envFilePath string) ([]byte, error) {
 		}
 	}
 	return key, nil
+}
+
+// decodeKey base64-decodes a key string and validates length.
+func decodeKey(v string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", EnvVar, err)
+	}
+	if len(key) != KeyLen {
+		return nil, fmt.Errorf("%s decodes to %d bytes, want %d", EnvVar, len(key), KeyLen)
+	}
+	return key, nil
+}
+
+// readFirstEnvValue returns the value of the first KEY=… line in path, plus
+// the count of additional duplicate lines. Empty value + zero error +
+// dupes==0 means the key isn't in the file. A non-existent file is
+// reported as empty + nil err, not an error — callers fall through to the
+// generate path.
+func readFirstEnvValue(path, key string) (string, int, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path is operator-controlled
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", 0, nil
+		}
+		return "", 0, err
+	}
+	prefix := key + "="
+	first := ""
+	dupes := 0
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, prefix) {
+			continue
+		}
+		if first == "" {
+			first = strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
+			continue
+		}
+		dupes++
+	}
+	return first, dupes, nil
+}
+
+// dedupeEnvKey rewrites path keeping only the first KEY=… line for the
+// given key, preserving every other line verbatim. Atomic via tempfile +
+// rename so a crash mid-write can't corrupt the env file. Permissions are
+// preserved from the original (defaults to 0600 if stat fails).
+func dedupeEnvKey(path, key string) error {
+	raw, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	mode := os.FileMode(0o600)
+	if fi, statErr := os.Stat(path); statErr == nil {
+		mode = fi.Mode().Perm()
+	}
+	prefix := key + "="
+	var out strings.Builder
+	seen := false
+	lines := strings.Split(string(raw), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, prefix) {
+			if seen {
+				continue // drop dup
+			}
+			seen = true
+		}
+		out.WriteString(line)
+		if i < len(lines)-1 {
+			out.WriteByte('\n')
+		}
+	}
+	tmp, err := os.CreateTemp(deriveDir(path), "nimbus-env-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(out.String()); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// deriveDir returns the directory containing path. Used to keep the
+// dedupe tempfile on the same filesystem as the target so the rename is
+// atomic.
+func deriveDir(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '/' {
+			return path[:i]
+		}
+	}
+	return "."
 }
 
 // appendEnvLine appends `KEY=VALUE\n` to path, creating the file with 0600 if

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -105,3 +105,98 @@ func TestLoadOrCreateKey_ReusesExisting(t *testing.T) {
 		t.Fatal("LoadOrCreateKey did not return existing env key")
 	}
 }
+
+// TestLoadOrCreateKey_ReadsFromFileWhenEnvMissing covers the systemd-isn't-
+// the-only-caller case. A manual `nimbus` invocation outside the systemd
+// unit doesn't get NIMBUS_ENCRYPTION_KEY pre-loaded, but the env file may
+// already hold the canonical key — falling through to fresh-generate would
+// silently rotate the at-rest encryption key. The fix consults the file
+// before generating.
+func TestLoadOrCreateKey_ReadsFromFileWhenEnvMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/nimbus.env"
+
+	raw := bytes.Repeat([]byte{0x42}, KeyLen)
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	if err := os.WriteFile(path, []byte("NIMBUS_ENCRYPTION_KEY="+encoded+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvVar, "")
+
+	key, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey: %v", err)
+	}
+	if !bytes.Equal(key, raw) {
+		t.Fatal("did not return existing key from file")
+	}
+
+	// File should still contain exactly one key line — fresh-generate path
+	// must not have fired.
+	got, _ := os.ReadFile(path)
+	if want := "NIMBUS_ENCRYPTION_KEY=" + encoded + "\n"; string(got) != want {
+		t.Errorf("file changed unexpectedly:\n got: %q\nwant: %q", string(got), want)
+	}
+}
+
+// TestLoadOrCreateKey_DedupesFile is the regression for the production env
+// file we found with three duplicate NIMBUS_ENCRYPTION_KEY lines. The first
+// is canonical (systemd's EnvironmentFile dedupe takes the first
+// occurrence, and that's what the existing vault is encrypted under); the
+// extras are leftovers from earlier append-on-cold-start cycles. Loading
+// must keep the first and drop the rest.
+func TestLoadOrCreateKey_DedupesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/nimbus.env"
+
+	first := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x11}, KeyLen))
+	second := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x22}, KeyLen))
+	third := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x33}, KeyLen))
+	contents := "OTHER=keep\n" +
+		"NIMBUS_ENCRYPTION_KEY=" + first + "\n" +
+		"NIMBUS_ENCRYPTION_KEY=" + second + "\n" +
+		"# comment\n" +
+		"NIMBUS_ENCRYPTION_KEY=" + third + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvVar, "")
+
+	key, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey: %v", err)
+	}
+	wantRaw, _ := base64.StdEncoding.DecodeString(first)
+	if !bytes.Equal(key, wantRaw) {
+		t.Errorf("returned key isn't the first one in the file")
+	}
+
+	got, _ := os.ReadFile(path)
+	wantContents := "OTHER=keep\n" +
+		"NIMBUS_ENCRYPTION_KEY=" + first + "\n" +
+		"# comment\n"
+	if string(got) != wantContents {
+		t.Errorf("dedup wrong:\n got: %q\nwant: %q", string(got), wantContents)
+	}
+}
+
+// TestLoadOrCreateKey_GeneratesWhenAbsent covers the truly-fresh-install
+// case. No env var, no existing file → generate, persist, set env. Same
+// flow as before; just guarding against accidental regression.
+func TestLoadOrCreateKey_GeneratesWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/nimbus.env"
+	t.Setenv(EnvVar, "")
+
+	key, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey: %v", err)
+	}
+	if len(key) != KeyLen {
+		t.Errorf("len(key) = %d, want %d", len(key), KeyLen)
+	}
+	got, _ := os.ReadFile(path)
+	if !bytes.Contains(got, []byte("NIMBUS_ENCRYPTION_KEY=")) {
+		t.Errorf("file did not get the new key persisted: %q", string(got))
+	}
+}


### PR DESCRIPTION
## Summary

\`/etc/nimbus/nimbus.env\` was found in production with three \`NIMBUS_ENCRYPTION_KEY=…\` lines stacked. systemd's EnvironmentFile dedupe takes the first occurrence and the existing vault is encrypted under that one, so the system still works — but the extras are time bombs. The day systemd's behaviour changes or any other parser sorts the file differently, every encrypted SSH blob in the DB becomes undecryptable.

## Root cause

\`secrets.LoadOrCreateKey\` checked \`os.Getenv\` and, when missing, generated a fresh key + appended to the env file. It never consulted the file's existing contents, so any cold start without the env pre-loaded (manual \`nimbus\` invocation, install --upgrade in a fresh shell, etc.) tacked on another key.

## Changes

- Insert a "read first existing \`NIMBUS_ENCRYPTION_KEY=…\` line from the env file" step between the env-var check and the generate path. Manual invocations now pick up the canonical key.
- When the file holds multiple key lines, atomically rewrite to keep only the first (tempfile + rename, permissions preserved).
- Tests cover the three resolution paths (env present / file present only / neither) plus the dedupe case with extra content sandwiched between dupes.

## Operator note

On first deploy of this fix, the production env file collapses from three key lines to one in-place. The first key is preserved (matches what systemd was already resolving to), so vault decryption keeps working through the change.

## Testing

- [x] \`go test -race ./internal/secrets/...\`
- [x] \`go test -race ./...\` (full sweep)