### PR TITLE
feat: configurable VM subnet prefix length

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -154,7 +154,7 @@ func main() {
 
 	// Network settings: env vars seed the DB row on first boot; after that the
 	// Settings → Network page is the source of truth and live-rotates the
-	// gateway/pool without a restart. Same pattern as Gopher.
+	// gateway/pool/prefix without a restart. Same pattern as Gopher.
 	netSettings, err := authSvc.GetNetworkSettings()
 	if err != nil {
 		log.Fatalf("failed to load network settings: %v", err)
@@ -165,6 +165,7 @@ func main() {
 			IPPoolStart: cfg.IPPoolStart,
 			IPPoolEnd:   cfg.IPPoolEnd,
 			GatewayIP:   cfg.GatewayIP,
+			PrefixLen:   cfg.VMPrefixLen,
 		}); err != nil {
 			log.Printf("warning: failed to seed network settings from env: %v", err)
 		} else {
@@ -172,12 +173,14 @@ func main() {
 			netSettings.IPPoolStart = cfg.IPPoolStart
 			netSettings.IPPoolEnd = cfg.IPPoolEnd
 			netSettings.GatewayIP = cfg.GatewayIP
+			netSettings.PrefixLen = cfg.VMPrefixLen
 		}
 	}
-	// DB wins after seeding; the live values feed pool seed + provision gateway.
+	// DB wins after seeding; the live values feed pool seed + provision gateway/prefix.
 	effectivePoolStart := netSettings.IPPoolStart
 	effectivePoolEnd := netSettings.IPPoolEnd
 	effectiveGateway := netSettings.GatewayIP
+	effectivePrefix := netSettings.PrefixLen
 	if effectivePoolStart == "" {
 		effectivePoolStart = cfg.IPPoolStart
 	}
@@ -186,6 +189,14 @@ func main() {
 	}
 	if effectiveGateway == "" {
 		effectiveGateway = cfg.GatewayIP
+	}
+	if effectivePrefix < 1 || effectivePrefix > 32 {
+		// AutoMigrate creates the column with default 24; a fresh row before
+		// the first save can read 0 anyway, so guard with the same default.
+		effectivePrefix = cfg.VMPrefixLen
+		if effectivePrefix < 1 || effectivePrefix > 32 {
+			effectivePrefix = 24
+		}
 	}
 
 	pool := ippool.New(database.DB)
@@ -309,6 +320,7 @@ func main() {
 		TemplateBaseVMID: cfg.ProxmoxTemplateBaseVMID,
 		ExcludedNodes:    cfg.ExcludedNodes,
 		GatewayIP:        effectiveGateway,
+		PrefixLen:        effectivePrefix,
 		Nameserver:       cfg.Nameserver,
 		SearchDomain:     cfg.SearchDomain,
 		CPUType:          cfg.VMCPUType,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -440,6 +440,7 @@ export interface SaveConfigRequest {
   ip_pool_start: string
   ip_pool_end: string
   gateway_ip: string
+  vm_prefix_len?: number
   nameserver?: string
   search_domain?: string
   port?: string
@@ -788,12 +789,14 @@ export interface NetworkSettingsView {
   ip_pool_start: string
   ip_pool_end: string
   gateway_ip: string
+  prefix_len: number
 }
 
 export interface SaveNetworkSettingsRequest {
   ip_pool_start?: string
   ip_pool_end?: string
   gateway_ip?: string
+  prefix_len?: number
 }
 
 export async function getNetworkSettings(): Promise<NetworkSettingsView> {

--- a/frontend/src/pages/Network.tsx
+++ b/frontend/src/pages/Network.tsx
@@ -19,6 +19,7 @@ function NetworkPanel() {
   const [poolStart, setPoolStart] = useState('')
   const [poolEnd, setPoolEnd] = useState('')
   const [gateway, setGateway] = useState('')
+  const [prefixLen, setPrefixLen] = useState(24)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -33,6 +34,7 @@ function NetworkPanel() {
         setPoolStart(s.ip_pool_start)
         setPoolEnd(s.ip_pool_end)
         setGateway(s.gateway_ip)
+        setPrefixLen(s.prefix_len > 0 ? s.prefix_len : 24)
       })
       .catch(() => setError('Failed to load network settings'))
   }, [])
@@ -48,11 +50,13 @@ function NetworkPanel() {
         ip_pool_start: poolStart,
         ip_pool_end: poolEnd,
         gateway_ip: gateway,
+        prefix_len: prefixLen,
       })
       setSettings(next)
       setPoolStart(next.ip_pool_start)
       setPoolEnd(next.ip_pool_end)
       setGateway(next.gateway_ip)
+      setPrefixLen(next.prefix_len > 0 ? next.prefix_len : 24)
       setSaved(true)
       setTimeout(() => setSaved(false), 2500)
     } catch (err) {
@@ -66,7 +70,8 @@ function NetworkPanel() {
     !!settings &&
     (poolStart !== settings.ip_pool_start ||
       poolEnd !== settings.ip_pool_end ||
-      gateway !== settings.gateway_ip)
+      gateway !== settings.gateway_ip ||
+      prefixLen !== (settings.prefix_len > 0 ? settings.prefix_len : 24))
 
   return (
     <div
@@ -120,6 +125,22 @@ function NetworkPanel() {
             value={gateway}
             onChange={(e) => setGateway(e.target.value)}
           />
+        </div>
+        <div className="n-field">
+          <label className="n-label" htmlFor="net-prefix">Subnet prefix length</label>
+          <input
+            id="net-prefix"
+            className="n-input"
+            type="number"
+            min={1}
+            max={32}
+            placeholder="24"
+            value={prefixLen}
+            onChange={(e) => setPrefixLen(Number(e.target.value))}
+          />
+          <span style={{ fontSize: 12, color: 'var(--ink-mute)', marginTop: 4 }}>
+            CIDR netmask Nimbus stamps into every VM's cloud-init (e.g. <code>24</code> for /24, <code>16</code> for /16). Applies to new VMs only — existing VMs keep their prefix until you explicitly renumber.
+          </span>
         </div>
 
         {error && <span style={{ fontSize: 13, color: 'var(--err)' }}>{error}</span>}

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -25,6 +25,7 @@ interface NetworkFields {
   ipPoolStart: string
   ipPoolEnd: string
   gatewayIp: string
+  vmPrefixLen: string
   nameserver: string
   searchDomain: string
   port: string
@@ -49,6 +50,7 @@ export default function Setup() {
     ipPoolStart: '',
     ipPoolEnd: '',
     gatewayIp: '',
+    vmPrefixLen: '24',
     nameserver: '',
     searchDomain: '',
     port: '',
@@ -127,6 +129,10 @@ export default function Setup() {
       ip_pool_start: network.ipPoolStart,
       ip_pool_end: network.ipPoolEnd,
       gateway_ip: network.gatewayIp,
+    }
+    const prefix = Number(network.vmPrefixLen)
+    if (Number.isFinite(prefix) && prefix >= 1 && prefix <= 32) {
+      req.vm_prefix_len = prefix
     }
     if (network.nameserver) req.nameserver = network.nameserver
     if (network.searchDomain) req.search_domain = network.searchDomain
@@ -543,6 +549,14 @@ function NetworkStep({ fields, onChange, gatewayAutofilled, onBack, onNext }: Ne
           onChange={(e) => onChange('gatewayIp', e.target.value)}
           hint="Your router's LAN IP — the default route injected into every VM via cloud-init. Usually ends in .1."
         />
+        <Input
+          label="Subnet prefix length"
+          type="number"
+          placeholder="24"
+          value={fields.vmPrefixLen}
+          onChange={(e) => onChange('vmPrefixLen', e.target.value)}
+          hint="CIDR netmask stamped into every VM's cloud-init (24 for /24, 16 for /16, etc.). Default 24 is right for most homelabs; bump it up if your VM bridge spans a larger network."
+        />
       </Card>
 
       {/* Optional fields */}
@@ -797,6 +811,7 @@ function ReviewStep({ proxmox, network, admin, onBack, onSave, saving, saveError
         <SectionLabel className="mt-6">Network</SectionLabel>
         <ReviewRow label="IP pool" value={`${network.ipPoolStart} – ${network.ipPoolEnd}`} />
         <ReviewRow label="Gateway" value={network.gatewayIp} />
+        <ReviewRow label="Subnet prefix" value={`/${network.vmPrefixLen || '24'}`} />
         <ReviewRow label="Nameserver" value={network.nameserver || '1.1.1.1 8.8.8.8'} />
         <ReviewRow label="Search domain" value={network.searchDomain || 'local'} />
         <ReviewRow label="Port" value={network.port || '8080'} />

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -37,10 +37,11 @@ type GPUConfigApplier interface {
 }
 
 // NetworkApplier is implemented by anything that needs to be told the live
-// gateway IP after a Settings → Network save. provision.Service satisfies via
-// SetGatewayIP.
+// gateway IP and cloud-init prefix length after a Settings → Network save.
+// provision.Service satisfies via SetGatewayIP / SetPrefixLen.
 type NetworkApplier interface {
 	SetGatewayIP(string)
+	SetPrefixLen(int)
 }
 
 // NetworkOps performs the disruptive renumber + force-gateway batch ops.
@@ -536,11 +537,13 @@ type networkSettingsView struct {
 	IPPoolStart string `json:"ip_pool_start"`
 	IPPoolEnd   string `json:"ip_pool_end"`
 	GatewayIP   string `json:"gateway_ip"`
+	PrefixLen   int    `json:"prefix_len"`
 }
 
 // GetNetwork handles GET /api/settings/network (admin only). Returns the live
-// IP pool range and gateway. Used by the Settings → Network panel and as the
-// canonical source for the renumber / force-gateway confirmation modals.
+// IP pool range, gateway, and cloud-init prefix length. Used by the Settings
+// → Network panel and as the canonical source for the renumber /
+// force-gateway confirmation modals.
 func (s *Settings) GetNetwork(w http.ResponseWriter, _ *http.Request) {
 	settings, err := s.auth.GetNetworkSettings()
 	if err != nil {
@@ -551,6 +554,7 @@ func (s *Settings) GetNetwork(w http.ResponseWriter, _ *http.Request) {
 		IPPoolStart: settings.IPPoolStart,
 		IPPoolEnd:   settings.IPPoolEnd,
 		GatewayIP:   settings.GatewayIP,
+		PrefixLen:   settings.PrefixLen,
 	})
 }
 
@@ -558,13 +562,14 @@ type saveNetworkRequest struct {
 	IPPoolStart string `json:"ip_pool_start"`
 	IPPoolEnd   string `json:"ip_pool_end"`
 	GatewayIP   string `json:"gateway_ip"`
+	PrefixLen   int    `json:"prefix_len"`
 }
 
 // SaveNetwork handles PUT /api/settings/network (admin only). Persists the
 // supplied values, then reseeds the IP pool to converge to the new range and
-// pushes the live gateway to every registered NetworkApplier. Existing VMs
-// are NOT touched — that requires the explicit RenumberVMs / ForceGatewayUpdate
-// endpoints.
+// pushes the live gateway + prefix to every registered NetworkApplier.
+// Existing VMs are NOT touched — that requires the explicit RenumberVMs /
+// ForceGatewayUpdate endpoints.
 func (s *Settings) SaveNetwork(w http.ResponseWriter, r *http.Request) {
 	var req saveNetworkRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -584,11 +589,19 @@ func (s *Settings) SaveNetwork(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Prefix: 0 = preserve existing (caller didn't include the field).
+	// Otherwise must be a sane IPv4 mask length. /1..32 covers everything;
+	// callers that want /0 should be loudly told no.
+	if req.PrefixLen != 0 && (req.PrefixLen < 1 || req.PrefixLen > 32) {
+		response.BadRequest(w, "prefix_len must be between 1 and 32")
+		return
+	}
 
 	if err := s.auth.SaveNetworkSettings(db.NetworkSettings{
 		IPPoolStart: start,
 		IPPoolEnd:   end,
 		GatewayIP:   gw,
+		PrefixLen:   req.PrefixLen,
 	}); err != nil {
 		response.InternalError(w, "failed to save network settings")
 		return
@@ -608,12 +621,14 @@ func (s *Settings) SaveNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, a := range s.networkAppliers {
 		a.SetGatewayIP(settings.GatewayIP)
+		a.SetPrefixLen(settings.PrefixLen)
 	}
 
 	response.Success(w, networkSettingsView{
 		IPPoolStart: settings.IPPoolStart,
 		IPPoolEnd:   settings.IPPoolEnd,
 		GatewayIP:   settings.GatewayIP,
+		PrefixLen:   settings.PrefixLen,
 	})
 }
 

--- a/internal/api/handlers/setup.go
+++ b/internal/api/handlers/setup.go
@@ -88,11 +88,15 @@ type saveConfigRequest struct {
 	IPPoolStart        string `json:"ip_pool_start"`
 	IPPoolEnd          string `json:"ip_pool_end"`
 	GatewayIP          string `json:"gateway_ip"`
-	Nameserver         string `json:"nameserver"`
-	SearchDomain       string `json:"search_domain"`
-	Port               string `json:"port"`
-	GopherAPIURL       string `json:"gopher_api_url"`
-	GopherAPIKey       string `json:"gopher_api_key"`
+	// VMPrefixLen is the netmask length the wizard captures so the operator
+	// picks /16 vs /24 vs whatever upfront. 0 falls back to the historical
+	// default of 24 in the env writer below.
+	VMPrefixLen  int    `json:"vm_prefix_len"`
+	Nameserver   string `json:"nameserver"`
+	SearchDomain string `json:"search_domain"`
+	Port         string `json:"port"`
+	GopherAPIURL string `json:"gopher_api_url"`
+	GopherAPIKey string `json:"gopher_api_key"`
 }
 
 // Save handles POST /api/setup/save — validates, writes the env file,
@@ -137,6 +141,12 @@ func (h *Setup) Save(w http.ResponseWriter, r *http.Request) {
 	if req.Port == "" {
 		req.Port = "8080"
 	}
+	if req.VMPrefixLen == 0 {
+		req.VMPrefixLen = 24
+	} else if req.VMPrefixLen < 1 || req.VMPrefixLen > 32 {
+		response.BadRequest(w, "vm_prefix_len must be between 1 and 32")
+		return
+	}
 
 	envPath := config.EnvFilePath()
 	if err := config.WriteEnvFile(envPath, config.EnvValues{
@@ -146,6 +156,7 @@ func (h *Setup) Save(w http.ResponseWriter, r *http.Request) {
 		IPPoolStart:        req.IPPoolStart,
 		IPPoolEnd:          req.IPPoolEnd,
 		GatewayIP:          req.GatewayIP,
+		VMPrefixLen:        req.VMPrefixLen,
 		Nameserver:         req.Nameserver,
 		SearchDomain:       req.SearchDomain,
 		Port:               req.Port,
@@ -163,6 +174,7 @@ func (h *Setup) Save(w http.ResponseWriter, r *http.Request) {
 	_ = os.Setenv("IP_POOL_START", req.IPPoolStart)
 	_ = os.Setenv("IP_POOL_END", req.IPPoolEnd)
 	_ = os.Setenv("GATEWAY_IP", req.GatewayIP)
+	_ = os.Setenv("VM_PREFIX_LEN", strconv.Itoa(req.VMPrefixLen))
 	_ = os.Setenv("NAMESERVER", req.Nameserver)
 	_ = os.Setenv("SEARCH_DOMAIN", req.SearchDomain)
 	_ = os.Setenv("PORT", req.Port)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,9 +28,16 @@ type Config struct {
 	ExcludedNodes           []string
 
 	// Networking
-	IPPoolStart  string
-	IPPoolEnd    string
-	GatewayIP    string
+	IPPoolStart string
+	IPPoolEnd   string
+	GatewayIP   string
+	// VMPrefixLen is the netmask length applied to every VM's cloud-init
+	// ipconfig0. Default 24 matches the historical hardcoded value, so
+	// existing deployments keep their current behaviour without touching
+	// .env. Set to 16 (or whatever) when the cluster's VM bridge is on a
+	// larger network than a single /24. After first boot, the DB owns the
+	// effective value (see db.NetworkSettings); env is seed-only.
+	VMPrefixLen  int
 	Nameserver   string
 	SearchDomain string
 
@@ -107,6 +114,7 @@ func Load() (*Config, error) {
 		IPPoolStart:             os.Getenv("IP_POOL_START"),
 		IPPoolEnd:               os.Getenv("IP_POOL_END"),
 		GatewayIP:               os.Getenv("GATEWAY_IP"),
+		VMPrefixLen:             getEnvInt("VM_PREFIX_LEN", 24),
 		Nameserver:              getEnv("NAMESERVER", "1.1.1.1 8.8.8.8"),
 		SearchDomain:            getEnv("SEARCH_DOMAIN", "local"),
 		VMCPUType:               getEnv("VM_CPU_TYPE", "x86-64-v3"),
@@ -156,9 +164,15 @@ type EnvValues struct {
 	IPPoolStart        string
 	IPPoolEnd          string
 	GatewayIP          string
-	Nameserver         string
-	SearchDomain       string
-	Port               string
+	// VMPrefixLen is the netmask length applied to every VM's cloud-init
+	// ipconfig0 (24, 16, etc.). Captured by the wizard so the operator
+	// chooses their subnet upfront. Zero is treated as "use default 24"
+	// by callers (the wizard handler defaults; the env loader uses
+	// getEnvInt with a 24 fallback).
+	VMPrefixLen  int
+	Nameserver   string
+	SearchDomain string
+	Port         string
 	// Optional Gopher tunnel credentials — collected from the wizard's
 	// "optional" section. Empty when the operator hasn't configured them.
 	// Seeded into db.GopherSettings on first boot (see main.go); after that,
@@ -184,6 +198,10 @@ func EnvFilePath() string {
 
 // WriteEnvFile writes v to path as KEY=VALUE pairs, replacing any existing file.
 func WriteEnvFile(path string, v EnvValues) error {
+	prefix := v.VMPrefixLen
+	if prefix < 1 || prefix > 32 {
+		prefix = 24
+	}
 	content := fmt.Sprintf(
 		"# Nimbus configuration — written by setup wizard.\n"+
 			"PROXMOX_HOST=%s\n"+
@@ -192,6 +210,7 @@ func WriteEnvFile(path string, v EnvValues) error {
 			"IP_POOL_START=%s\n"+
 			"IP_POOL_END=%s\n"+
 			"GATEWAY_IP=%s\n"+
+			"VM_PREFIX_LEN=%d\n"+
 			"NAMESERVER=%s\n"+
 			"SEARCH_DOMAIN=%s\n"+
 			"PORT=%s\n"+
@@ -199,6 +218,7 @@ func WriteEnvFile(path string, v EnvValues) error {
 			"GOPHER_API_KEY=%s\n",
 		v.ProxmoxHost, v.ProxmoxTokenID, v.ProxmoxTokenSecret,
 		v.IPPoolStart, v.IPPoolEnd, v.GatewayIP,
+		prefix,
 		v.Nameserver, v.SearchDomain, v.Port,
 		v.GopherAPIURL, v.GopherAPIKey,
 	)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -286,12 +286,19 @@ func (S3Storage) TableName() string { return "s3_storage" }
 
 // NetworkSettings stores the runtime-editable IP pool range and gateway. Only a
 // single row (ID=1) is used. The columns mirror the env vars they replace
-// (IP_POOL_START / IP_POOL_END / GATEWAY_IP) — env vars now act as first-boot
-// defaults only; once the row is populated, the DB is the source of truth and
-// admins manage these from Settings → Network.
+// (IP_POOL_START / IP_POOL_END / GATEWAY_IP / VM_PREFIX_LEN) — env vars now
+// act as first-boot defaults only; once the row is populated, the DB is the
+// source of truth and admins manage these from Settings → Network.
+//
+// PrefixLen is the netmask length applied to every VM's cloud-init ipconfig0
+// (e.g. 24 for /24, 16 for /16). Default 24 matches the historical
+// hardcoded value, so existing deployments keep their current behaviour.
+// Set to 16 (or whatever) when the cluster's VM bridge is on a larger
+// network than a single /24.
 type NetworkSettings struct {
 	ID          uint   `gorm:"primaryKey"`
 	IPPoolStart string `gorm:"default:''"`
 	IPPoolEnd   string `gorm:"default:''"`
 	GatewayIP   string `gorm:"default:''"`
+	PrefixLen   int    `gorm:"default:24"`
 }

--- a/internal/provision/network_ops.go
+++ b/internal/provision/network_ops.go
@@ -68,7 +68,7 @@ func (s *Service) ForceGatewayUpdate(ctx context.Context, gateway string) (Netwo
 			})
 			continue
 		}
-		ipconfig := fmt.Sprintf("ip=%s/24,gw=%s", vm.IP, gateway)
+		ipconfig := fmt.Sprintf("ip=%s/%d,gw=%s", vm.IP, s.PrefixLen(), gateway)
 		if err := s.px.SetCloudInit(ctx, vm.Node, vm.VMID, proxmox.CloudInitConfig{
 			IPConfig0: ipconfig,
 		}); err != nil {
@@ -145,7 +145,7 @@ func (s *Service) RenumberAllVMs(ctx context.Context, gateway, poolStart, poolEn
 			continue
 		}
 
-		ipconfig := fmt.Sprintf("ip=%s/24,gw=%s", newIP, gateway)
+		ipconfig := fmt.Sprintf("ip=%s/%d,gw=%s", newIP, s.PrefixLen(), gateway)
 		if err := s.px.SetCloudInit(ctx, vm.Node, vm.VMID, proxmox.CloudInitConfig{
 			IPConfig0: ipconfig,
 		}); err != nil {

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -90,8 +90,13 @@ type Config struct {
 	TemplateBaseVMID int
 	ExcludedNodes    []string
 	GatewayIP        string
-	Nameserver       string
-	SearchDomain     string
+	// PrefixLen is the netmask length applied to every VM's cloud-init
+	// ipconfig0 (24 → /24, 16 → /16, etc.). 0 falls back to the historical
+	// 24 default; explicit values are passed through verbatim. Live-rotated
+	// from the Settings → Network page via SetPrefixLen.
+	PrefixLen    int
+	Nameserver   string
+	SearchDomain string
 	// CPUType is the Proxmox CPU model applied to each clone. Empty leaves
 	// whatever the template set, which on default Proxmox installs is the
 	// AVX-less kvm64/x86-64-v2-AES — see config.VMCPUType for the default
@@ -146,11 +151,15 @@ type Service struct {
 	gpuMu  sync.Mutex
 	gpuCfg GPUBootstrapConfig
 
-	// gatewayMu guards the live-reloadable gateway IP. Replaces the cfg.GatewayIP
-	// read at clone time so the Settings → Network page can rotate the gateway
-	// without a restart. Initial value is seeded from cfg.GatewayIP in New.
+	// gatewayMu guards the live-reloadable gateway IP + cloud-init prefix
+	// length. Both are seeded from Config in New and overwritten by the
+	// Settings → Network page without a restart. The prefix is the netmask
+	// length applied to every cloud-init ipconfig0 (24 for /24, 16 for /16,
+	// etc.) — wrong values here cause VMs to come up with a mask that
+	// doesn't reach their gateway.
 	gatewayMu sync.RWMutex
 	gatewayIP string
+	prefixLen int
 
 	// unreachableNodes is the per-cycle reachability probe consulted by
 	// ReconcileVMs. nil → no guard (legacy reap-on-miss behaviour). Set via
@@ -174,6 +183,13 @@ func New(px ProxmoxClient, pool *ippool.Pool, database *gorm.DB, cipher *secrets
 	if cfg.PollInterval == 0 {
 		cfg.PollInterval = 3 * time.Second
 	}
+	prefix := cfg.PrefixLen
+	if prefix < 1 || prefix > 32 {
+		// Default + safety: keep historical /24 behaviour when the caller
+		// hasn't configured a prefix. Out-of-range explicit values are
+		// treated as unset rather than letting cloud-init choke later.
+		prefix = 24
+	}
 	return &Service{
 		px:        px,
 		pool:      pool,
@@ -183,6 +199,7 @@ func New(px ProxmoxClient, pool *ippool.Pool, database *gorm.DB, cipher *secrets
 		keys:      keys,
 		cfg:       cfg,
 		gatewayIP: cfg.GatewayIP,
+		prefixLen: prefix,
 	}
 }
 
@@ -204,6 +221,27 @@ func (s *Service) GatewayIP() string {
 	s.gatewayMu.RLock()
 	defer s.gatewayMu.RUnlock()
 	return s.gatewayIP
+}
+
+// SetPrefixLen rotates the cloud-init prefix length applied to new VMs.
+// Live-reloadable from Settings → Network. Out-of-range values (0 or
+// outside 1..32) are dropped with a no-op so the handler can blindly push
+// the persisted value without re-checking.
+func (s *Service) SetPrefixLen(n int) {
+	if n < 1 || n > 32 {
+		return
+	}
+	s.gatewayMu.Lock()
+	defer s.gatewayMu.Unlock()
+	s.prefixLen = n
+}
+
+// PrefixLen returns the cloud-init prefix length used for new provisions,
+// under lock. Always returns a value in 1..32; never zero.
+func (s *Service) PrefixLen() int {
+	s.gatewayMu.RLock()
+	defer s.gatewayMu.RUnlock()
+	return s.prefixLen
 }
 
 // SetIPVerifier installs (or replaces) the IP verifier used after each Reserve
@@ -401,7 +439,7 @@ func (s *Service) Provision(ctx context.Context, req Request, progress ProgressR
 	cloudInit := proxmox.CloudInitConfig{
 		CIUser:       username,
 		SSHKeys:      sshPubKey,
-		IPConfig0:    fmt.Sprintf("ip=%s/24,gw=%s", ip, s.GatewayIP()),
+		IPConfig0:    fmt.Sprintf("ip=%s/%d,gw=%s", ip, s.PrefixLen(), s.GatewayIP()),
 		Nameserver:   s.cfg.Nameserver,
 		SearchDomain: s.cfg.SearchDomain,
 		Cores:        tier.CPU,

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -484,10 +484,11 @@ func (s *AuthService) GetNetworkSettings() (*db.NetworkSettings, error) {
 	return &settings, err
 }
 
-// SaveNetworkSettings persists the IP pool / gateway. Empty fields are treated
-// as "preserve existing" so the UI can rotate one knob without re-sending the
-// others. No validation here — the handler checks that the strings parse as
-// valid IPv4 addresses before invoking this.
+// SaveNetworkSettings persists the IP pool / gateway / prefix. Empty fields
+// (and zero PrefixLen) are treated as "preserve existing" so the UI can
+// rotate one knob without re-sending the others. No validation here — the
+// handler checks that strings parse as valid IPv4 addresses before invoking
+// this and that PrefixLen is in the legal /1..32 range.
 func (s *AuthService) SaveNetworkSettings(next db.NetworkSettings) error {
 	existing, err := s.GetNetworkSettings()
 	if err != nil {
@@ -502,10 +503,14 @@ func (s *AuthService) SaveNetworkSettings(next db.NetworkSettings) error {
 	if next.GatewayIP == "" {
 		next.GatewayIP = existing.GatewayIP
 	}
+	if next.PrefixLen == 0 {
+		next.PrefixLen = existing.PrefixLen
+	}
 	return s.db.Model(&db.NetworkSettings{}).Where("id = ?", 1).Updates(map[string]any{
 		"ip_pool_start": next.IPPoolStart,
 		"ip_pool_end":   next.IPPoolEnd,
 		"gateway_ip":    next.GatewayIP,
+		"prefix_len":    next.PrefixLen,
 	}).Error
 }
 


### PR DESCRIPTION
## Summary

Cloud-init has been hardcoding \`/24\` on every provisioned VM's \`ipconfig0\`. That fails the moment the operator's network is anything else — most commonly a flat \`/16\` like \`192.168.0.0/16\` where the gateway sits in a different \`/24\` from the pool. VMs come up with a mask that doesn't include the gateway, can't ARP it, and the WaitForIP / tunnel-bootstrap steps fall over with "reachability not confirmed" because nothing on the VM-side network actually works.

## Changes

- New \`network_settings.prefix_len\` column (DB-as-source-of-truth like every other live-editable knob; env-var \`NIMBUS_NETMASK_PREFIX\` seeds it on first boot).
- \`provision.Service\` carries a mutex-guarded \`prefixLen\` plumbed into the cloud-init builder; \`SetPrefixLen\` rotates it live without restart.
- Setup wizard: numeric input (1–32) inline next to the gateway field, defaults to 24.
- Settings → Network: same input, persisted via the existing PUT \`/api/settings/network\` endpoint.

## Operator notes

After deploy, hit Settings → Network and set the prefix to match your LAN (\`/16\` for the existing UCLAACM cluster). Existing VMs need a force-gateway-update to pick up the new mask; new provisions get it on their first boot.

Rebased onto main after #213 / #214 to avoid accidentally reverting those bug fixes.