### PR TITLE
fix: tunnel bootstrap shell syntax error from stray semicolons

### DIFF
--- a/internal/provision/tunnel.go
+++ b/internal/provision/tunnel.go
@@ -144,6 +144,10 @@ func runTunnelBootstrap(ctx context.Context, ip, user, privatePEM, bootstrapURL,
 		// systemd unit actually came up and surface its journal if not, so
 		// future failures land in tunnel_error instead of disappearing.
 		quote := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
+		// Newline-separated, NOT "; "-joined — bash rejects `then; echo` as a
+		// syntax error because `then` expects a command before any separator.
+		// Plain newlines work in both bash and dash and keep the script
+		// readable in the journal when it does fail.
 		cmd := strings.Join([]string{
 			"set -e",
 			"_T=$(mktemp)",
@@ -161,7 +165,7 @@ func runTunnelBootstrap(ctx context.Context, ip, user, privatePEM, bootstrapURL,
 			"  exit 1",
 			"fi",
 			"exit $_RC",
-		}, "; ")
+		}, "\n")
 
 		// Bound the exec separately from the dial. If the bootstrap genuinely
 		// runs longer than tunnelBootstrapExecTimeout, close the session to


### PR DESCRIPTION
## Summary

#213's bootstrap pipeline joined statements with \`\"; \"\`, which produced \`; then; echo …\` — bash rejects \`then;\` because control words expect a command before any separator. Result: every new VM's tunnel failed with \`syntax error near unexpected token ';'\` instead of bootstrapping.

## Fix

Join with \`\"\\n\"\` instead. Both bash and dash parse the resulting script cleanly (\`bash -n\` / \`dash -n\` both report OK).

## Testing

- [x] Local parse-check on the generated script with both shells
- [x] go test / lint / build clean