### PR TITLE
fix: pass Gopher 4xx errors through with their actual messages

### DIFF
--- a/internal/api/response/response.go
+++ b/internal/api/response/response.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	internalerrors "nimbus/internal/errors"
+	"nimbus/internal/tunnel"
 )
 
 type Response struct {
@@ -57,11 +58,18 @@ func ServiceUnavailable(w http.ResponseWriter, message string) {
 // FromError maps internal error types to HTTP statuses. Unknown errors are
 // logged with full detail and surfaced as 500 with a generic message — never
 // leak internal error strings to clients.
+//
+// Upstream Gopher 4xx responses (carrying actionable messages like "subdomain
+// in use" or "URL routing is disabled") were previously falling through to
+// the default 500 branch, hiding the actual cause from the SPA. They now
+// pass through with the upstream status preserved and Gopher's own error
+// string used as the body.
 func FromError(w http.ResponseWriter, err error) {
 	var (
 		validation *internalerrors.ValidationError
 		conflict   *internalerrors.ConflictError
 		notFound   *internalerrors.NotFoundError
+		gopherErr  *tunnel.HTTPError
 	)
 	switch {
 	case errors.As(err, &validation):
@@ -70,6 +78,21 @@ func FromError(w http.ResponseWriter, err error) {
 		ServiceUnavailable(w, conflict.Error())
 	case errors.As(err, &notFound):
 		NotFound(w, notFound.Error())
+	case errors.As(err, &gopherErr):
+		msg := gopherErr.Body
+		if msg == "" {
+			msg = http.StatusText(gopherErr.Status)
+		}
+		switch {
+		case gopherErr.Status >= 500:
+			// Gopher itself broke — log the upstream detail (might
+			// include stack-shaped strings we don't want to leak) and
+			// surface a clean 502.
+			log.Printf("gopher upstream error: %v", err)
+			Error(w, http.StatusBadGateway, "tunnel gateway error: "+http.StatusText(gopherErr.Status))
+		default:
+			Error(w, gopherErr.Status, msg)
+		}
 	default:
 		log.Printf("internal error: %v", err)
 		InternalError(w, "internal server error")

--- a/internal/tunnel/client.go
+++ b/internal/tunnel/client.go
@@ -127,7 +127,7 @@ func (c *Client) DeleteMachine(ctx context.Context, id string) error {
 	if err == nil {
 		return nil
 	}
-	var he *httpError
+	var he *HTTPError
 	if errors.As(err, &he) && he.Status == http.StatusNotFound {
 		return nil
 	}
@@ -216,7 +216,7 @@ func (c *Client) DeleteTunnel(ctx context.Context, id string) error {
 	if err == nil {
 		return nil
 	}
-	var he *httpError
+	var he *HTTPError
 	if errors.As(err, &he) && he.Status == http.StatusNotFound {
 		return nil
 	}
@@ -253,13 +253,19 @@ func (c *Client) ListTunnelsForMachine(ctx context.Context, machineID string) ([
 
 // ── Internals ─────────────────────────────────────────────────────────────────
 
-// httpError carries a non-2xx response so callers can branch on status code.
-type httpError struct {
+// HTTPError carries a non-2xx response so callers can branch on status code.
+// Body is the Gopher envelope's `error` field when one was returned, or the
+// raw response body otherwise — usable verbatim as a user-facing message.
+//
+// Exported so callers (notably internal/api/response.FromError) can pattern-
+// match and pass Gopher's status + message through to the SPA instead of
+// coercing every Gopher 4xx into an opaque 500.
+type HTTPError struct {
 	Status int
 	Body   string
 }
 
-func (e *httpError) Error() string {
+func (e *HTTPError) Error() string {
 	return fmt.Sprintf("tunnel: gopher returned HTTP %d: %s", e.Status, e.Body)
 }
 
@@ -334,5 +340,5 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	if body4xx == "" {
 		body4xx = strings.TrimSpace(string(respBody))
 	}
-	return &httpError{Status: resp.StatusCode, Body: body4xx}
+	return &HTTPError{Status: resp.StatusCode, Body: body4xx}
 }


### PR DESCRIPTION
## Summary

Creating a per-port tunnel without a subdomain returned 500 "internal server error" to the SPA. Gopher itself was returning a clean 4xx with the actual reason; \`response.FromError\` was collapsing every Gopher non-2xx into 500 because the matched-error type list didn't include the tunnel client's error.

## Changes

- Export \`tunnel.httpError\` → \`tunnel.HTTPError\` (symmetric with the already-exported \`proxmox.HTTPError\`). \`Body\` already carries Gopher's envelope.error verbatim.
- New case in \`response.FromError\`: 4xx from Gopher passes through with the upstream status + message; 5xx is logged and surfaced as a clean 502 "tunnel gateway error".

## Out of scope

Manual server-port input + collision validation for stable UDP exposures — separate workflow.

## Tests

- [x] go test / lint / build clean