### PR TITLE
ui: render port-only tunnels as host:port and show every mapping on My machines

### DIFF
--- a/frontend/src/components/ui/TunnelsModal.tsx
+++ b/frontend/src/components/ui/TunnelsModal.tsx
@@ -3,12 +3,14 @@ import { createPortal } from 'react-dom'
 import {
   createVMTunnel,
   deleteVMTunnel,
+  getTunnelInfo,
   listVMTunnels,
   type VMTunnel,
 } from '@/api/client'
 import Button from '@/components/ui/Button'
 import Card from '@/components/ui/Card'
 import CopyButton from '@/components/ui/CopyButton'
+import { formatTunnelPublic } from '@/lib/tunnel'
 
 interface TunnelsModalProps {
   vmId: number
@@ -18,6 +20,11 @@ interface TunnelsModalProps {
 
 export default function TunnelsModal({ vmId, hostname, onClose }: TunnelsModalProps) {
   const [tunnels, setTunnels] = useState<VMTunnel[] | null>(null)
+  // gatewayHost is Gopher's routable hostname (from /api/tunnels/info). Used
+  // to render "host:server_port" for tunnels that don't have a subdomain
+  // URL — port-only TCP, UDP, or HTTP tunnels Gopher created without one.
+  // Without it those rows fall back to the bare hex id, which is unhelpful.
+  const [gatewayHost, setGatewayHost] = useState<string | undefined>(undefined)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [port, setPort] = useState('')
@@ -38,6 +45,13 @@ export default function TunnelsModal({ vmId, hostname, onClose }: TunnelsModalPr
 
   useEffect(() => {
     void load()
+    // Tunnel info lives on a separate endpoint and rarely changes — fetch
+    // once at mount so port-only tunnel rows can render "host:port" instead
+    // of the bare hex id. Failures here are non-fatal: the row will degrade
+    // to subdomain or id, which is the pre-fix behavior.
+    void getTunnelInfo()
+      .then((info) => setGatewayHost(info.host))
+      .catch(() => undefined)
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
@@ -145,7 +159,14 @@ export default function TunnelsModal({ vmId, hostname, onClose }: TunnelsModalPr
           {tunnels !== null && tunnels.length > 0 && (
             <div className="grid gap-2">
               {tunnels.map((t) => (
-                <TunnelRow key={t.id} tunnel={t} hostname={hostname} busy={busy} onDelete={onDelete} />
+                <TunnelRow
+                  key={t.id}
+                  tunnel={t}
+                  hostname={hostname}
+                  gatewayHost={gatewayHost}
+                  busy={busy}
+                  onDelete={onDelete}
+                />
               ))}
             </div>
           )}
@@ -287,12 +308,13 @@ export default function TunnelsModal({ vmId, hostname, onClose }: TunnelsModalPr
 interface TunnelRowProps {
   tunnel: VMTunnel
   hostname: string
+  gatewayHost: string | undefined
   busy: boolean
   onDelete: (id: string) => void
 }
 
-function TunnelRow({ tunnel, hostname, busy, onDelete }: TunnelRowProps) {
-  const display = tunnel.tunnel_url || tunnel.subdomain || tunnel.id
+function TunnelRow({ tunnel, hostname, gatewayHost, busy, onDelete }: TunnelRowProps) {
+  const display = formatTunnelPublic(tunnel, gatewayHost)
   const isFailed = tunnel.status === 'failed'
   // The SSH base tunnel maps the public host's :port to the guest's
   // sshd. Spelling out "→ {hostname}:localhost:{port}" makes that

--- a/frontend/src/lib/tunnel.ts
+++ b/frontend/src/lib/tunnel.ts
@@ -1,0 +1,31 @@
+// Shared formatting helpers for Gopher tunnel rows. Used by both TunnelsModal
+// (per-port tunnels surface on a VM) and MyVMs (cards listing every public
+// exposure on each machine), so the two views agree on what a tunnel's
+// public-facing string looks like.
+
+import type { VMTunnel } from '@/api/client'
+
+// formatTunnelPublic returns the user-facing host string for a Gopher tunnel.
+// Priority:
+//   1. tunnel.tunnel_url       — set by Gopher for HTTP tunnels with a
+//                                subdomain (e.g. "https://foo.altsuite.co").
+//   2. "<host>:<server_port>"  — port-only TCP, UDP, or no-subdomain HTTP.
+//                                Gopher returns server_port for these but
+//                                no tunnel_url.
+//   3. tunnel.subdomain        — degraded fallback, sometimes the only
+//                                non-id field present on edge-case responses.
+//   4. tunnel.id               — last-resort hex id; almost always means we
+//                                haven't fetched /api/tunnels/info yet.
+export function formatTunnelPublic(t: VMTunnel, host: string | undefined): string {
+  if (t.tunnel_url) return t.tunnel_url
+  if (host && t.server_port) return `${host}:${t.server_port}`
+  if (t.subdomain) return t.subdomain
+  return t.id
+}
+
+// formatTunnelMapping is the "<public> → localhost:<target>" string used in
+// the My machines card and anywhere else we want to show *both* sides of a
+// Gopher exposure at a glance.
+export function formatTunnelMapping(t: VMTunnel, host: string | undefined): string {
+  return `${formatTunnelPublic(t, host)} → localhost:${t.target_port}`
+}

--- a/frontend/src/lib/tunnel.ts
+++ b/frontend/src/lib/tunnel.ts
@@ -17,7 +17,7 @@ import type { VMTunnel } from '@/api/client'
 //   4. tunnel.id               — last-resort hex id; almost always means we
 //                                haven't fetched /api/tunnels/info yet.
 export function formatTunnelPublic(t: VMTunnel, host: string | undefined): string {
-  if (t.tunnel_url) return t.tunnel_url
+  if (t.tunnel_url) return t.tunnel_url.replace(/^https?:\/\//, '')
   if (host && t.server_port) return `${host}:${t.server_port}`
   if (t.subdomain) return t.subdomain
   return t.id

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { deleteVM, listVMs, vmLifecycle } from '@/api/client'
+import {
+  deleteVM,
+  getTunnelInfo,
+  listVMTunnels,
+  listVMs,
+  vmLifecycle,
+  type VMTunnel,
+} from '@/api/client'
 import Button from '@/components/ui/Button'
 import Card from '@/components/ui/Card'
 import DeleteVMConfirm from '@/components/ui/DeleteVMConfirm'
@@ -10,6 +17,7 @@ import TunnelsModal from '@/components/ui/TunnelsModal'
 import VMActions from '@/components/ui/VMActions'
 import { NetworkIcon, TerminalIcon } from '@/components/ui/icons'
 import { useAuth } from '@/hooks/useAuth'
+import { formatTunnelMapping } from '@/lib/tunnel'
 import type { VM } from '@/types'
 
 export default function MyVMs() {
@@ -17,6 +25,11 @@ export default function MyVMs() {
   const [vms, setVms] = useState<VM[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Gopher's gateway hostname — fetched once and shared across every VM card
+  // so port-only tunnel rows (no subdomain URL) can render "host:port".
+  // Optional: a missing host degrades each row to its tunnel_url/subdomain
+  // fallback (the pre-mapping behavior), never blocks the page.
+  const [gatewayHost, setGatewayHost] = useState<string | undefined>(undefined)
 
   const refresh = useCallback(async () => {
     try {
@@ -41,6 +54,11 @@ export default function MyVMs() {
       .finally(() => {
         if (!cancelled) setLoading(false)
       })
+    void getTunnelInfo()
+      .then((info) => {
+        if (!cancelled) setGatewayHost(info.host)
+      })
+      .catch(() => undefined)
     return () => {
       cancelled = true
     }
@@ -84,6 +102,7 @@ export default function MyVMs() {
             key={vm.ID}
             vm={vm}
             currentUserId={user?.id}
+            gatewayHost={gatewayHost}
             onChanged={refresh}
           />
         ))}
@@ -95,20 +114,45 @@ export default function MyVMs() {
 function VMRow({
   vm,
   currentUserId,
+  gatewayHost,
   onChanged,
 }: {
   vm: VM
   currentUserId: number | undefined
+  gatewayHost: string | undefined
   onChanged: () => void
 }) {
   const [sshOpen, setSshOpen] = useState(false)
   const [tunnelsOpen, setTunnelsOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [tunnels, setTunnels] = useState<VMTunnel[] | null>(null)
   const hasTunnel = Boolean(vm.tunnel_url)
   // Only show Delete on VMs the current user provisioned. Legacy rows
   // (owner_id null, pre-ownership) and VMs created by other users render
   // without the button — they're not deletable through this UI.
   const canDelete = currentUserId !== undefined && vm.owner_id === currentUserId
+
+  // Pull the full tunnel list for each VM so we can show every public
+  // exposure as "host:port → localhost:target", not just the SSH base. We
+  // gate on hasTunnel so VMs without a Gopher machine don't issue a 404
+  // round-trip per render.
+  useEffect(() => {
+    if (!hasTunnel) {
+      setTunnels(null)
+      return
+    }
+    let cancelled = false
+    listVMTunnels(vm.ID)
+      .then((rows) => {
+        if (!cancelled) setTunnels(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setTunnels(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hasTunnel, vm.ID])
 
   return (
     <Card className="p-5">
@@ -118,7 +162,24 @@ function VMRow({
           <div className="font-mono text-[11px] text-ink-3 mt-1 tracking-wide">
             {vm.ip} · vmid {vm.vmid} · node {vm.node} · {vm.os_template}
           </div>
-          {vm.tunnel_url && (
+          {hasTunnel && tunnels !== null && tunnels.length > 0 && (
+            <div className="mt-1.5 flex flex-col gap-0.5">
+              {tunnels.map((t) => {
+                const mapping = formatTunnelMapping(t, gatewayHost)
+                return (
+                  <div
+                    key={t.id}
+                    className="font-mono text-[11px] text-good inline-flex items-center gap-1.5"
+                    title={mapping}
+                  >
+                    <NetworkIcon size={11} />
+                    <span className="truncate">{mapping}</span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+          {hasTunnel && tunnels === null && vm.tunnel_url && (
             <div className="font-mono text-[11px] text-good mt-1 truncate inline-flex items-center gap-1.5" title={vm.tunnel_url}>
               <NetworkIcon size={11} />
               <span className="truncate">{vm.tunnel_url}</span>

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -162,9 +162,25 @@ function VMRow({
           <div className="font-mono text-[11px] text-ink-3 mt-1 tracking-wide">
             {vm.ip} · vmid {vm.vmid} · node {vm.node} · {vm.os_template}
           </div>
-          {hasTunnel && tunnels !== null && tunnels.length > 0 && (
+          {hasTunnel && (
             <div className="mt-1.5 flex flex-col gap-0.5">
-              {tunnels.map((t) => {
+              {/*
+                SSH base mapping is synthesized from vm.tunnel_url, not the
+                tunnels list. Gopher's /api/v1/tunnels is per-port only —
+                the SSH exposure lives on the machine record (returned at
+                provision time as public_ssh_host:port and stored on vm).
+                Without this line, SSH-only VMs would render zero rows.
+              */}
+              {vm.tunnel_url && (
+                <div
+                  className="font-mono text-[11px] text-good inline-flex items-center gap-1.5"
+                  title={`${vm.tunnel_url} → localhost:22`}
+                >
+                  <NetworkIcon size={11} />
+                  <span className="truncate">{vm.tunnel_url} → localhost:22</span>
+                </div>
+              )}
+              {tunnels?.map((t) => {
                 const mapping = formatTunnelMapping(t, gatewayHost)
                 return (
                   <div
@@ -177,12 +193,6 @@ function VMRow({
                   </div>
                 )
               })}
-            </div>
-          )}
-          {hasTunnel && tunnels === null && vm.tunnel_url && (
-            <div className="font-mono text-[11px] text-good mt-1 truncate inline-flex items-center gap-1.5" title={vm.tunnel_url}>
-              <NetworkIcon size={11} />
-              <span className="truncate">{vm.tunnel_url}</span>
             </div>
           )}
         </div>

--- a/frontend/src/pages/MyVMs.tsx
+++ b/frontend/src/pages/MyVMs.tsx
@@ -17,7 +17,7 @@ import TunnelsModal from '@/components/ui/TunnelsModal'
 import VMActions from '@/components/ui/VMActions'
 import { NetworkIcon, TerminalIcon } from '@/components/ui/icons'
 import { useAuth } from '@/hooks/useAuth'
-import { formatTunnelMapping } from '@/lib/tunnel'
+import { formatTunnelMapping, formatTunnelPublic } from '@/lib/tunnel'
 import type { VM } from '@/types'
 
 export default function MyVMs() {
@@ -181,15 +181,30 @@ function VMRow({
                 </div>
               )}
               {tunnels?.map((t) => {
-                const mapping = formatTunnelMapping(t, gatewayHost)
+                const publicPart = formatTunnelPublic(t, gatewayHost)
+                const tail = ` → localhost:${t.target_port}`
                 return (
                   <div
                     key={t.id}
                     className="font-mono text-[11px] text-good inline-flex items-center gap-1.5"
-                    title={mapping}
+                    title={formatTunnelMapping(t, gatewayHost)}
                   >
                     <NetworkIcon size={11} />
-                    <span className="truncate">{mapping}</span>
+                    <span className="truncate">
+                      {t.tunnel_url ? (
+                        <a
+                          href={t.tunnel_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="underline hover:text-ink"
+                        >
+                          {publicPart}
+                        </a>
+                      ) : (
+                        publicPart
+                      )}
+                      {tail}
+                    </span>
                   </div>
                 )
               })}


### PR DESCRIPTION
## Summary

- TunnelsModal rows for port-only tunnels (TCP/UDP, or HTTP without a subdomain) were falling all the way through `tunnel_url || subdomain || id` to a bare hex id, which is unhelpful as a display string. Fetch `/api/tunnels/info` once on mount and prefer `host:server_port` over the id.
- My machines cards previously showed only the SSH base `vm.tunnel_url` and hid every extra per-port exposure. Now each card lists the full mapping per tunnel (`host:port → localhost:target`), so a VM with several tunnels surfaces all of them inline instead of requiring the modal to inspect.
- Shared formatter at `frontend/src/lib/tunnel.ts` keeps both views in sync — `formatTunnelPublic` for the public-facing host string, `formatTunnelMapping` for the full one-liner.

Pairs with #219 (backend Gopher error pass-through) — together they make tunnel surfaces actually inspectable: the modal stops crying 500 on Gopher 4xxes, and the rows you see are no longer hex ids.

## Test plan

- [ ] Visit `/my` on a deployment with a Gopher-tunneled VM; the card shows `<host>:<port> → localhost:22` for the SSH base.
- [ ] Add a port-only TCP tunnel (no subdomain) via the modal and a subdomain'd HTTP tunnel; confirm both render their full mappings on the card and inside TunnelsModal.
- [ ] Disable Gopher routing host (or temporarily break `/api/tunnels/info`) and confirm rows degrade to subdomain or `vm.tunnel_url`, never blank.
- [ ] `npm run type-check`, `npm run lint`, `npm run build` all clean.