### PR TITLE
feat: rename /settings to /users, add user-management table, move OAuth into a modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import Network from '@/pages/Network'
 import Provision from '@/pages/Provision'
 import MyVMs from '@/pages/MyVMs'
 import S3 from '@/pages/S3'
-import Settings from '@/pages/Settings'
+import Users from '@/pages/Users'
 import SignIn from '@/pages/auth/SignIn'
 import SignUp from '@/pages/auth/SignUp'
 import OAuthCallback from '@/pages/auth/OAuthCallback'
@@ -87,7 +87,11 @@ export default function App() {
                       <Route path="/vms" element={<MyVMs />} />
                       <Route path="/keys" element={<Keys />} />
                       <Route path="/gpu" element={<GPU />} />
-                      <Route path="/settings" element={<RequireAdmin><Settings /></RequireAdmin>} />
+                      <Route path="/users" element={<RequireAdmin><Users /></RequireAdmin>} />
+                      {/* Old /settings URL kept around so any existing
+                          bookmarks / pasted links still resolve to the
+                          rebranded user management page. */}
+                      <Route path="/settings" element={<Navigate to="/users" replace />} />
                       <Route path="/gophers" element={<RequireAdmin><GopherTunnels /></RequireAdmin>} />
                       <Route path="/network" element={<RequireAdmin><Network /></RequireAdmin>} />
                       <Route path="/s3" element={<RequireAdmin><S3 /></RequireAdmin>} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -536,6 +536,25 @@ export async function saveOAuthSettings(
   return data
 }
 
+export interface UserManagementView {
+  id: number
+  name: string
+  email: string
+  is_admin: boolean
+  created_at: string
+  verified: boolean
+  // Best-effort sign-in providers the user has used at least once. May
+  // contain "password" (email/password registered), "github" (GitHub OAuth
+  // login captured), and/or "google" (inferred when neither password nor
+  // github is set — Google OAuth doesn't leave a per-user marker today).
+  providers: string[]
+}
+
+export async function listUsers(): Promise<UserManagementView[]> {
+  const { data } = await api.get<UserManagementView[]>('/users')
+  return data
+}
+
 export interface AccessCodeView {
   access_code: string
   version: number

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -149,8 +149,8 @@ export default function Layout({ children, showNav = true }: LayoutProps) {
                   <div className="px-3 pt-2 pb-1 text-[11px] uppercase tracking-wider text-ink-3 font-semibold">
                     Control Panel
                   </div>
-                  <NavLink to="/settings" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
-                    Authentication
+                  <NavLink to="/users" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
+                    Users
                   </NavLink>
                   <NavLink to="/gophers" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
                     Gopher Tunnels

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { GithubIcon, GoogleIcon } from '@/components/nimbus'
 import {
   getAccessCode,
   getAuthorizedGitHubOrgs,
   getAuthorizedGoogleDomains,
   getOAuthSettings,
+  listUsers,
   regenerateAccessCode,
   saveAuthorizedGitHubOrgs,
   saveAuthorizedGoogleDomains,
   saveOAuthSettings,
 } from '@/api/client'
-import type { AccessCodeView, OAuthSettingsView } from '@/api/client'
+import type {
+  AccessCodeView,
+  OAuthSettingsView,
+  UserManagementView,
+} from '@/api/client'
 
 interface ProviderPanelProps {
   name: string
@@ -753,9 +759,22 @@ function GitHubOrgsSection() {
 }
 
 
-export default function Settings() {
+// Users — admin-facing user management + access policy.
+//
+// Page layout, top-down:
+//   1. Access code panel + Users table (the things admins reach for daily).
+//   2. Sign-in providers summary card (Google + GitHub status pills, plus
+//      a "Configure providers" button that opens the full OAuth + bypass
+//      configuration in a modal).
+//
+// The OAuth provider panels were the bulk of the old /settings page; they
+// stay reachable but live behind a click since most operators only touch
+// them once at setup. Pushing them down/behind a modal keeps the access
+// code + users-list — which admins actually look at — above the fold.
+export default function Users() {
   const [settings, setSettings] = useState<OAuthSettingsView | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [providersOpen, setProvidersOpen] = useState(false)
 
   useEffect(() => {
     getOAuthSettings()
@@ -787,10 +806,11 @@ export default function Settings() {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
       <div>
         <h1 className="n-display" style={{ fontSize: 28, margin: '0 0 6px' }}>
-          Authentication
+          Users
         </h1>
         <p style={{ margin: 0, fontSize: 14, color: 'var(--ink-body)' }}>
-          Manage the access code and OAuth providers users can sign in with.
+          Every account that has signed up, plus the access code and sign-in
+          providers gating new sign-ins.
         </p>
       </div>
 
@@ -800,37 +820,355 @@ export default function Settings() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
         <div className="lg:col-span-2 flex flex-col gap-6">
-          {settings && (
-            <>
-              <ProviderPanel
-                name="Google"
-                icon={<GoogleIcon size={20} />}
-                clientId={settings.google_client_id}
-                configured={settings.google_configured}
-                instructionsUrl="https://console.cloud.google.com/apis/credentials"
-                instructionsLabel="Google Cloud Console"
-                onSave={handleSaveGoogle}
-              >
-                <GoogleDomainsSection />
-              </ProviderPanel>
-              <ProviderPanel
-                name="GitHub"
-                icon={<GithubIcon size={20} />}
-                clientId={settings.github_client_id}
-                configured={settings.github_configured}
-                instructionsUrl="https://github.com/settings/applications/new"
-                instructionsLabel="github.com/settings/applications/new"
-                onSave={handleSaveGitHub}
-              >
-                <GitHubOrgsSection />
-              </ProviderPanel>
-            </>
-          )}
+          <UsersTable />
         </div>
-        <div className="lg:col-span-1">
+        <div className="lg:col-span-1 flex flex-col gap-6">
           <AccessCodePanel />
+          <ProvidersSummary
+            settings={settings}
+            onConfigure={() => setProvidersOpen(true)}
+          />
         </div>
       </div>
+
+      {providersOpen && settings && (
+        <OAuthProvidersModal
+          settings={settings}
+          onClose={() => setProvidersOpen(false)}
+          onSaveGitHub={handleSaveGitHub}
+          onSaveGoogle={handleSaveGoogle}
+        />
+      )}
     </div>
+  )
+}
+
+// UsersTable renders every account the admin can see. Sorted server-side
+// by created_at desc, so the most recent sign-up shows first. Verified
+// status follows the live policy (admin / authorized domain / org / code
+// match) so the column reflects what would happen on the user's next
+// request, not a snapshot at sign-up.
+function UsersTable() {
+  const [rows, setRows] = useState<UserManagementView[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    listUsers()
+      .then(setRows)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
+  }, [])
+
+  return (
+    <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+          Accounts
+        </span>
+        {rows !== null && (
+          <span style={{ fontSize: 12, color: 'var(--ink-mute)' }}>
+            {rows.length} {rows.length === 1 ? 'user' : 'users'}
+          </span>
+        )}
+      </div>
+
+      {rows === null && !error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>Loading…</p>
+      )}
+      {error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--err)' }}>{error}</p>
+      )}
+      {rows !== null && rows.length === 0 && !error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>
+          No accounts yet.
+        </p>
+      )}
+      {rows !== null && rows.length > 0 && (
+        <div style={{ overflowX: 'auto', margin: '0 -8px' }}>
+          <table className="w-full text-left" style={{ fontSize: 13, borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ color: 'var(--ink-mute)', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                <th style={{ padding: '8px 8px', fontWeight: 500 }}>Name</th>
+                <th style={{ padding: '8px 8px', fontWeight: 500 }}>Email</th>
+                <th style={{ padding: '8px 8px', fontWeight: 500 }}>Joined</th>
+                <th style={{ padding: '8px 8px', fontWeight: 500 }}>Sign-in</th>
+                <th style={{ padding: '8px 8px', fontWeight: 500 }}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((u) => (
+                <tr
+                  key={u.id}
+                  style={{ borderTop: '1px solid var(--line)' }}
+                >
+                  <td style={{ padding: '10px 8px', color: 'var(--ink)', fontWeight: 500 }}>
+                    {u.name || <span style={{ color: 'var(--ink-mute)' }}>—</span>}
+                  </td>
+                  <td style={{ padding: '10px 8px', color: 'var(--ink-body)', fontFamily: 'Geist Mono, monospace', fontSize: 12 }}>
+                    {u.email}
+                  </td>
+                  <td style={{ padding: '10px 8px', color: 'var(--ink-body)', whiteSpace: 'nowrap' }}>
+                    {formatJoined(u.created_at)}
+                  </td>
+                  <td style={{ padding: '10px 8px' }}>
+                    <ProviderChips providers={u.providers} />
+                  </td>
+                  <td style={{ padding: '10px 8px' }}>
+                    <UserStatusPills user={u} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProviderChips({ providers }: { providers: string[] }) {
+  if (!providers || providers.length === 0) {
+    return <span style={{ fontSize: 11, color: 'var(--ink-mute)' }}>—</span>
+  }
+  return (
+    <span style={{ display: 'inline-flex', gap: 4, flexWrap: 'wrap' }}>
+      {providers.map((p) => (
+        <span
+          key={p}
+          style={{
+            fontSize: 10,
+            fontFamily: 'Geist Mono, monospace',
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            padding: '2px 6px',
+            borderRadius: 4,
+            background: 'rgba(20,18,28,0.05)',
+            border: '1px solid var(--line)',
+            color: 'var(--ink-body)',
+          }}
+        >
+          {p}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function UserStatusPills({ user }: { user: UserManagementView }) {
+  return (
+    <span style={{ display: 'inline-flex', gap: 6, flexWrap: 'wrap' }}>
+      {user.is_admin ? (
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            padding: '2px 6px',
+            borderRadius: 4,
+            color: '#9a5c2e',
+            background: 'rgba(248,175,130,0.15)',
+            border: '1px solid rgba(248,175,130,0.4)',
+          }}
+        >
+          admin
+        </span>
+      ) : null}
+      {user.verified ? (
+        <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
+          <span className="n-pill-dot" />
+          verified
+        </span>
+      ) : (
+        <span
+          className="n-pill"
+          style={{
+            fontSize: 10,
+            color: 'var(--ink-mute)',
+            background: 'rgba(20,18,28,0.04)',
+            border: '1px solid var(--line)',
+          }}
+        >
+          unverified
+        </span>
+      )}
+    </span>
+  )
+}
+
+// formatJoined renders a relative-ish "joined" string. Recent times show
+// as "today" / "Xd ago"; anything older falls back to a short date.
+function formatJoined(iso: string): string {
+  const t = Date.parse(iso)
+  if (!Number.isFinite(t)) return '—'
+  const ms = Date.now() - t
+  const days = Math.floor(ms / 86_400_000)
+  if (days < 1) return 'today'
+  if (days < 30) return `${days}d ago`
+  return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+// ProvidersSummary is the compact replacement for the old big OAuth
+// section. Shows a one-line status for Google and GitHub plus the
+// "Configure" button that opens the modal with the full provider +
+// bypass configuration.
+function ProvidersSummary({
+  settings,
+  onConfigure,
+}: {
+  settings: OAuthSettingsView | null
+  onConfigure: () => void
+}) {
+  return (
+    <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+          Sign-in providers
+        </span>
+        <button
+          type="button"
+          className="n-btn"
+          style={{ padding: '6px 12px', fontSize: 12 }}
+          onClick={onConfigure}
+        >
+          Configure
+        </button>
+      </div>
+      <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
+        OAuth client IDs + the access-code bypass lists (authorized Google
+        domains, GitHub orgs).
+      </p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <ProviderRow
+          icon={<GoogleIcon size={16} />}
+          name="Google"
+          configured={settings?.google_configured}
+        />
+        <ProviderRow
+          icon={<GithubIcon size={16} />}
+          name="GitHub"
+          configured={settings?.github_configured}
+        />
+      </div>
+    </div>
+  )
+}
+
+function ProviderRow({ icon, name, configured }: { icon: React.ReactNode; name: string; configured: boolean | undefined }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px', background: 'rgba(20,18,28,0.03)', border: '1px solid var(--line)', borderRadius: 8 }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--ink)' }}>
+        {icon}
+        {name}
+      </span>
+      {configured ? (
+        <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
+          <span className="n-pill-dot" />
+          configured
+        </span>
+      ) : (
+        <span
+          className="n-pill"
+          style={{
+            fontSize: 10,
+            color: 'var(--ink-mute)',
+            background: 'rgba(20,18,28,0.04)',
+            border: '1px solid var(--line)',
+          }}
+        >
+          not configured
+        </span>
+      )}
+    </div>
+  )
+}
+
+// OAuthProvidersModal wraps the existing ProviderPanel + Domains / Orgs
+// sections. The full configuration UI is unchanged — only the surface
+// it lives on moved.
+function OAuthProvidersModal({
+  settings,
+  onClose,
+  onSaveGitHub,
+  onSaveGoogle,
+}: {
+  settings: OAuthSettingsView
+  onClose: () => void
+  onSaveGitHub: (clientId: string, clientSecret: string) => Promise<unknown>
+  onSaveGoogle: (clientId: string, clientSecret: string) => Promise<unknown>
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prev
+    }
+  }, [onClose])
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center p-4"
+      style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Sign-in providers"
+      onClick={onClose}
+    >
+      <div
+        className="glass"
+        style={{ width: '100%', maxWidth: 760, maxHeight: 'calc(100vh - 2rem)', overflowY: 'auto', padding: '28px 32px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginBottom: 18 }}>
+          <div>
+            <div className="eyebrow">Authentication</div>
+            <h3 style={{ fontSize: 22, margin: '4px 0 0' }}>Sign-in providers</h3>
+            <p style={{ margin: '6px 0 0', fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+              OAuth client IDs and the bypass lists (Google domains, GitHub
+              orgs) that skip the access code on sign-in.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{ background: 'none', border: 'none', fontSize: 22, lineHeight: 1, color: 'var(--ink-mute)', cursor: 'pointer', padding: 4, marginRight: -4, marginTop: -4 }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          <ProviderPanel
+            name="Google"
+            icon={<GoogleIcon size={20} />}
+            clientId={settings.google_client_id}
+            configured={settings.google_configured}
+            instructionsUrl="https://console.cloud.google.com/apis/credentials"
+            instructionsLabel="Google Cloud Console"
+            onSave={onSaveGoogle}
+          >
+            <GoogleDomainsSection />
+          </ProviderPanel>
+          <ProviderPanel
+            name="GitHub"
+            icon={<GithubIcon size={20} />}
+            clientId={settings.github_client_id}
+            configured={settings.github_configured}
+            instructionsUrl="https://github.com/settings/applications/new"
+            instructionsLabel="github.com/settings/applications/new"
+            onSave={onSaveGitHub}
+          >
+            <GitHubOrgsSection />
+          </ProviderPanel>
+        </div>
+      </div>
+    </div>,
+    document.body,
   )
 }

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -212,11 +212,13 @@ func (a *Auth) Me(w http.ResponseWriter, r *http.Request) {
 }
 
 // ListUsers handles GET /api/users.
-// Admins receive every account; non-admins receive only their own.
+// Admins receive every account in the richer management shape (with
+// signup time, verification status, and provider hints); non-admins
+// receive only their own self-view (no list of peers).
 func (a *Auth) ListUsers(w http.ResponseWriter, r *http.Request) {
 	user := ctxutil.User(r.Context())
 	if user.IsAdmin {
-		users, err := a.auth.ListAllUsers()
+		users, err := a.auth.ListAllUsersForManagement()
 		if err != nil {
 			response.InternalError(w, "Failed to list users")
 			return

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -59,6 +59,73 @@ func userToView(u *db.User) *UserView {
 	return &UserView{ID: u.ID, Name: u.Name, Email: u.Email, IsAdmin: u.IsAdmin}
 }
 
+// UserManagementView is the admin-facing user list shape: UserView plus
+// signup time, verification status, and provider hints. Returned by
+// /api/users so the management page can render a meaningful table without
+// N+1 calls. Provider hints are best-effort — Google OAuth doesn't leave
+// a per-user marker on the User row, so a user who signed in only via
+// Google shows "google" inferred from the absence of password + github.
+type UserManagementView struct {
+	*UserView
+	CreatedAt time.Time `json:"created_at"`
+	// Verified follows the same rules as IsUserVerified — admins are
+	// always verified, then dynamic Google-domain / GitHub-org bypasses,
+	// then the explicit access-code match.
+	Verified  bool     `json:"verified"`
+	Providers []string `json:"providers"`
+}
+
+func userToManagementView(u *db.User, settings *db.OAuthSettings) *UserManagementView {
+	v := &UserManagementView{
+		UserView:  userToView(u),
+		CreatedAt: u.CreatedAt,
+		Providers: detectProviders(u),
+	}
+	v.Verified = isUserVerifiedFromSettings(u, settings)
+	return v
+}
+
+// detectProviders is a best-effort sniff of how the user has signed in
+// at least once. PasswordHash != "" means email/password registration;
+// GitHubOrgs is set (even to "-") on every successful GitHub OAuth login.
+// A user with neither is presumed Google-only — we don't store a
+// per-user Google marker today, so the heuristic is "neither password
+// nor github → google". Order is stable: password, github, google.
+func detectProviders(u *db.User) []string {
+	out := make([]string, 0, 2)
+	if u.PasswordHash != "" {
+		out = append(out, "password")
+	}
+	if u.GitHubOrgs != "" {
+		out = append(out, "github")
+	}
+	if len(out) == 0 {
+		out = append(out, "google")
+	}
+	return out
+}
+
+// isUserVerifiedFromSettings mirrors IsUserVerified but takes a
+// pre-fetched OAuthSettings so a caller iterating over many users avoids
+// the N+1. Decision policy is intentionally identical — keep these in
+// sync if IsUserVerified ever changes.
+func isUserVerifiedFromSettings(u *db.User, settings *db.OAuthSettings) bool {
+	if u.IsAdmin {
+		return true
+	}
+	if domain := emailDomain(u.Email); domain != "" {
+		for _, d := range splitDomains(settings.AuthorizedGoogleDomains) {
+			if d == domain {
+				return true
+			}
+		}
+	}
+	if hasOrgIntersection(u.GitHubOrgs, settings.AuthorizedGitHubOrgs) {
+		return true
+	}
+	return u.VerifiedCodeVersion == settings.AccessCodeVersion && settings.AccessCodeVersion > 0
+}
+
 // Register creates a new user account with a bcrypt-hashed password.
 // Returns ErrEmailTaken if the email is already in use.
 func (s *AuthService) Register(p RegisterParams) (*UserView, error) {
@@ -913,4 +980,24 @@ func (s *AuthService) ListAllUsers() ([]*UserView, error) {
 		views[i] = userToView(&users[i])
 	}
 	return views, nil
+}
+
+// ListAllUsersForManagement returns the richer admin-facing shape:
+// CreatedAt + Verified + provider hints, computed against a single
+// OAuthSettings fetch so this stays O(1) DB reads regardless of user
+// count.
+func (s *AuthService) ListAllUsersForManagement() ([]*UserManagementView, error) {
+	var users []db.User
+	if err := s.db.Order("created_at DESC").Find(&users).Error; err != nil {
+		return nil, err
+	}
+	settings, err := s.GetOAuthSettings()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*UserManagementView, len(users))
+	for i := range users {
+		out[i] = userToManagementView(&users[i], settings)
+	}
+	return out, nil
 }


### PR DESCRIPTION
## Summary

Reframed the old \`/settings\` page (Authentication) as \`/users\` (Users) so admins can actually *see* who has signed up. The access code stays primary; OAuth provider configuration moves into a modal because most operators only touch it once.

### Backend

- New \`UserManagementView\` (UserView + \`created_at\`, \`verified\`, \`providers\`).
- \`ListAllUsersForManagement\` fetches OAuth settings once and computes verified per-user using the same policy as \`IsUserVerified\` (admin / authorized Google domain / authorized GitHub org / explicit access-code match). No N+1.
- \`/api/users\` for admins now returns the management shape; non-admin path (returns the requester only) is unchanged.
- Provider hints are best-effort: \`password\` (hash present), \`github\` (GitHubOrgs snapshot present), \`google\` (inferred when neither — Google OAuth doesn't leave a per-user marker today).

### Frontend

- Page rename: \`Settings.tsx\` → \`Users.tsx\` (git tracks as a rename).
- New \`Accounts\` table: name, email, joined, sign-in providers, status (admin / verified / unverified). Sorted newest first.
- Access code panel unchanged, sits alongside the table.
- New \`Sign-in providers\` summary card with one-line Google/GitHub status + a \`Configure\` button that opens an Esc-dismissable modal containing the existing \`ProviderPanel\` + \`GoogleDomainsSection\` + \`GitHubOrgsSection\` (the heavy UI is unchanged — just moved off the main surface).
- Route: \`/users\` is the primary; \`/settings\` redirects there for any pasted/bookmarked links.
- Dropdown entry: \"Authentication\" → \"Users\".

## Test plan

- [ ] As an admin, visit \`/users\`: see access code panel, accounts table, providers summary; modal opens via Configure.
- [ ] Hit \`/settings\` directly — redirects to \`/users\`.
- [ ] Sign-in providers modal: Google + GitHub panels save successfully; Esc closes it; backdrop click closes it.
- [ ] User row shows correct verified state for: admin, member with code-version match, member without verification, member with authorized Google domain, member with authorized GitHub org.
- [ ] Provider chips render \`password\` / \`github\` / \`google\` based on the heuristic.
- [ ] \`go test ./...\`, \`npm run type-check\`, \`npm run lint\`, \`npm run build\` all clean.