### PR TITLE
feat: per-provider OAuth edit modal + user actions (promote, delete with VM disposition)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -555,6 +555,29 @@ export async function listUsers(): Promise<UserManagementView[]> {
   return data
 }
 
+// promoteUser flips a member to admin after re-confirming the requesting
+// admin's password. Returns the upgraded user or rejects with a
+// 401-translated "incorrect password" message when the gate fails.
+export async function promoteUser(id: number, password: string): Promise<{ id: number; is_admin: boolean }> {
+  const { data } = await api.post<{ id: number; is_admin: boolean }>(`/users/${id}/promote`, { password })
+  return data
+}
+
+// deleteUser removes a user with the chosen VM disposition: "delete"
+// destroys their VMs on Proxmox, "transfer" reassigns ownership to the
+// requesting admin. SSH keys + GPU jobs follow the same disposition so
+// transferred VMs keep working.
+export async function deleteUser(
+  id: number,
+  vmAction: 'delete' | 'transfer',
+): Promise<{ id: number; vm_action: string; vms_handled: number }> {
+  const { data } = await api.delete<{ id: number; vm_action: string; vms_handled: number }>(
+    `/users/${id}`,
+    { data: { vm_action: vmAction } },
+  )
+  return data
+}
+
 export interface AccessCodeView {
   access_code: string
   version: number

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1012,13 +1012,9 @@ function UserRowActions({
     <NavDropdown
       placement="bottom-end"
       triggerOn="click"
-      triggerClassName="inline-flex items-center justify-center rounded-md border border-line-2 bg-white/85 hover:border-ink transition-colors"
+      triggerClassName="inline-flex items-center justify-center w-7 h-7 rounded-md border border-line-2 bg-white/85 text-ink-2 hover:border-ink hover:text-ink transition-colors"
       panelClassName="rounded-lg border border-line bg-white py-1 min-w-[180px] shadow-lg"
-      trigger={
-        <span style={{ display: 'inline-flex', width: 28, height: 28, alignItems: 'center', justifyContent: 'center', color: 'var(--ink-2)', fontSize: 16, fontWeight: 700 }}>
-          ⋯
-        </span>
-      }
+      trigger={<MoreIcon />}
     >
       {!user.is_admin && (
         <button
@@ -1485,6 +1481,20 @@ function PencilIcon() {
     <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  )
+}
+
+// MoreIcon — three solid horizontal dots. Replaces the ⋯ unicode glyph
+// that was rendering blurry: at small sizes the OS-supplied font fell
+// back to a hinted glyph that read as a fuzzy bar more than three
+// distinct dots. Solid SVG circles render crisply at every zoom.
+function MoreIcon() {
+  return (
+    <svg width={16} height={16} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <circle cx={5} cy={12} r={1.75} />
+      <circle cx={12} cy={12} r={1.75} />
+      <circle cx={19} cy={12} r={1.75} />
     </svg>
   )
 }

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -996,6 +996,18 @@ function UserRowActions({
   if (isSelf) {
     return <span style={{ fontSize: 11, color: 'var(--ink-mute)' }}>—</span>
   }
+  // NavDropdown's open state is internal — clicks on items inside its panel
+  // are ignored by its document-mousedown close handler (panel.contains
+  // returns true). For an *action* menu we want the panel to dismiss as
+  // soon as the user picks something, so we synthesize a mousedown on
+  // document before invoking the handler. The synthetic event's target is
+  // outside the panel, which trips NavDropdown's existing close path.
+  // Without this the menu stays mounted at z-1000 and visibly floats
+  // above the modal backdrop.
+  const dismissAndDo = (fn: () => void) => () => {
+    document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    fn()
+  }
   return (
     <NavDropdown
       placement="bottom-end"
@@ -1011,7 +1023,7 @@ function UserRowActions({
       {!user.is_admin && (
         <button
           type="button"
-          onClick={onPromote}
+          onClick={dismissAndDo(onPromote)}
           className="block w-full text-left px-3 py-1.5 text-[13px] text-ink hover:bg-[rgba(27,23,38,0.05)] cursor-pointer"
         >
           Promote to admin
@@ -1025,7 +1037,7 @@ function UserRowActions({
       <div className="my-1 border-t border-line" />
       <button
         type="button"
-        onClick={onDelete}
+        onClick={dismissAndDo(onDelete)}
         className="block w-full text-left px-3 py-1.5 text-[13px] text-bad hover:bg-[rgba(184,55,55,0.06)] cursor-pointer"
       >
         Delete user…
@@ -1081,7 +1093,7 @@ function PromoteUserModal({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[60] grid place-items-center p-4"
+      className="fixed inset-0 z-[1010] grid place-items-center p-4"
       style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
       role="dialog"
       aria-modal="true"
@@ -1179,7 +1191,7 @@ function DeleteUserModal({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[60] grid place-items-center p-4"
+      className="fixed inset-0 z-[1010] grid place-items-center p-4"
       style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
       role="dialog"
       aria-modal="true"
@@ -1512,7 +1524,7 @@ function OAuthProviderModal({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[60] grid place-items-center p-4"
+      className="fixed inset-0 z-[1010] grid place-items-center p-4"
       style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
       role="dialog"
       aria-modal="true"

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { GithubIcon, GoogleIcon } from '@/components/nimbus'
 import {
+  deleteUser,
   getAccessCode,
   getAuthorizedGitHubOrgs,
   getAuthorizedGoogleDomains,
   getOAuthSettings,
   listUsers,
+  promoteUser,
   regenerateAccessCode,
   saveAuthorizedGitHubOrgs,
   saveAuthorizedGoogleDomains,
@@ -17,6 +19,8 @@ import type {
   OAuthSettingsView,
   UserManagementView,
 } from '@/api/client'
+import NavDropdown from '@/components/ui/NavDropdown'
+import { useAuth } from '@/hooks/useAuth'
 
 interface ProviderPanelProps {
   name: string
@@ -771,10 +775,15 @@ function GitHubOrgsSection() {
 // stay reachable but live behind a click since most operators only touch
 // them once at setup. Pushing them down/behind a modal keeps the access
 // code + users-list — which admins actually look at — above the fold.
+// editingProvider tracks which (if any) per-provider modal is open. Using
+// a discrete identifier rather than a boolean lets the modal render the
+// right provider's panel without the parent juggling two flags.
+type EditingProvider = 'google' | 'github' | null
+
 export default function Users() {
   const [settings, setSettings] = useState<OAuthSettingsView | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [providersOpen, setProvidersOpen] = useState(false)
+  const [editingProvider, setEditingProvider] = useState<EditingProvider>(null)
 
   useEffect(() => {
     getOAuthSettings()
@@ -826,15 +835,16 @@ export default function Users() {
           <AccessCodePanel />
           <ProvidersSummary
             settings={settings}
-            onConfigure={() => setProvidersOpen(true)}
+            onEdit={(p) => setEditingProvider(p)}
           />
         </div>
       </div>
 
-      {providersOpen && settings && (
-        <OAuthProvidersModal
+      {editingProvider && settings && (
+        <OAuthProviderModal
+          provider={editingProvider}
           settings={settings}
-          onClose={() => setProvidersOpen(false)}
+          onClose={() => setEditingProvider(null)}
           onSaveGitHub={handleSaveGitHub}
           onSaveGoogle={handleSaveGoogle}
         />
@@ -848,14 +858,27 @@ export default function Users() {
 // status follows the live policy (admin / authorized domain / org / code
 // match) so the column reflects what would happen on the user's next
 // request, not a snapshot at sign-up.
+// pendingAction tracks which row + modal are currently open. Single
+// state object so we can't accidentally show both modals at once.
+type PendingAction =
+  | { kind: 'promote'; user: UserManagementView }
+  | { kind: 'delete'; user: UserManagementView }
+  | null
+
 function UsersTable() {
+  const { user: me } = useAuth()
   const [rows, setRows] = useState<UserManagementView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [pending, setPending] = useState<PendingAction>(null)
 
-  useEffect(() => {
+  const reload = () => {
     listUsers()
       .then(setRows)
       .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
+  }
+
+  useEffect(() => {
+    reload()
   }, [])
 
   return (
@@ -892,6 +915,7 @@ function UsersTable() {
                 <th style={{ padding: '8px 8px', fontWeight: 500 }}>Joined</th>
                 <th style={{ padding: '8px 8px', fontWeight: 500 }}>Sign-in</th>
                 <th style={{ padding: '8px 8px', fontWeight: 500 }}>Status</th>
+                <th style={{ padding: '8px 8px', fontWeight: 500, width: 1 }} aria-label="Actions" />
               </tr>
             </thead>
             <tbody>
@@ -915,13 +939,348 @@ function UsersTable() {
                   <td style={{ padding: '10px 8px' }}>
                     <UserStatusPills user={u} />
                   </td>
+                  <td style={{ padding: '10px 8px', textAlign: 'right' }}>
+                    <UserRowActions
+                      user={u}
+                      isSelf={me?.id === u.id}
+                      onPromote={() => setPending({ kind: 'promote', user: u })}
+                      onDelete={() => setPending({ kind: 'delete', user: u })}
+                    />
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
       )}
+
+      {pending?.kind === 'promote' && (
+        <PromoteUserModal
+          user={pending.user}
+          onClose={() => setPending(null)}
+          onPromoted={() => {
+            setPending(null)
+            reload()
+          }}
+        />
+      )}
+      {pending?.kind === 'delete' && (
+        <DeleteUserModal
+          user={pending.user}
+          onClose={() => setPending(null)}
+          onDeleted={() => {
+            setPending(null)
+            reload()
+          }}
+        />
+      )}
     </div>
+  )
+}
+
+// UserRowActions shows the per-row "..." menu. The trigger button is
+// always rendered (so column widths don't jump when self-row vs not),
+// but its menu is empty-only when the row is the requester themselves —
+// admins can't promote or delete themselves through this UI.
+function UserRowActions({
+  user,
+  isSelf,
+  onPromote,
+  onDelete,
+}: {
+  user: UserManagementView
+  isSelf: boolean
+  onPromote: () => void
+  onDelete: () => void
+}) {
+  if (isSelf) {
+    return <span style={{ fontSize: 11, color: 'var(--ink-mute)' }}>—</span>
+  }
+  return (
+    <NavDropdown
+      placement="bottom-end"
+      triggerOn="click"
+      triggerClassName="inline-flex items-center justify-center rounded-md border border-line-2 bg-white/85 hover:border-ink transition-colors"
+      panelClassName="rounded-lg border border-line bg-white py-1 min-w-[180px] shadow-lg"
+      trigger={
+        <span style={{ display: 'inline-flex', width: 28, height: 28, alignItems: 'center', justifyContent: 'center', color: 'var(--ink-2)', fontSize: 16, fontWeight: 700 }}>
+          ⋯
+        </span>
+      }
+    >
+      {!user.is_admin && (
+        <button
+          type="button"
+          onClick={onPromote}
+          className="block w-full text-left px-3 py-1.5 text-[13px] text-ink hover:bg-[rgba(27,23,38,0.05)] cursor-pointer"
+        >
+          Promote to admin
+        </button>
+      )}
+      {user.is_admin && (
+        <span className="block w-full text-left px-3 py-1.5 text-[13px] text-ink-3 cursor-default">
+          Already an admin
+        </span>
+      )}
+      <div className="my-1 border-t border-line" />
+      <button
+        type="button"
+        onClick={onDelete}
+        className="block w-full text-left px-3 py-1.5 text-[13px] text-bad hover:bg-[rgba(184,55,55,0.06)] cursor-pointer"
+      >
+        Delete user…
+      </button>
+    </NavDropdown>
+  )
+}
+
+// PromoteUserModal collects the requesting admin's password and POSTs
+// to /api/users/:id/promote. The password input is the same gate the
+// backend enforces — the UI doesn't pre-validate it (would leak whether
+// the password is right against the wrong account); the server returns
+// 401 on mismatch and we surface that.
+function PromoteUserModal({
+  user,
+  onClose,
+  onPromoted,
+}: {
+  user: UserManagementView
+  onClose: () => void
+  onPromoted: () => void
+}) {
+  const [password, setPassword] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prev
+    }
+  }, [onClose, busy])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      await promoteUser(user.id, password)
+      onPromoted()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Promote failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center p-4"
+      style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Promote ${user.name || user.email} to admin`}
+      onClick={busy ? undefined : onClose}
+    >
+      <div
+        className="glass"
+        style={{ width: '100%', maxWidth: 460, padding: '28px 32px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="eyebrow">Promote to admin</div>
+        <h3 style={{ fontSize: 20, margin: '4px 0 6px' }}>
+          {user.name || user.email}
+        </h3>
+        <p style={{ margin: '0 0 18px', fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+          Grants full admin access — cluster observability, settings, and
+          user management. Confirm with your password.
+        </p>
+
+        <form onSubmit={submit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div className="n-field">
+            <label className="n-label" htmlFor="promote-password">Your password</label>
+            <input
+              id="promote-password"
+              className="n-input"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+          {error && <span style={{ fontSize: 13, color: 'var(--err)' }}>{error}</span>}
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4 }}>
+            <button type="button" className="n-btn" onClick={onClose} disabled={busy}>
+              Cancel
+            </button>
+            <button type="submit" className="n-btn n-btn-primary" disabled={busy || !password}>
+              {busy ? 'Promoting…' : 'Promote'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// DeleteUserModal is the destructive flow. The VM-disposition radio
+// always shows even when the user has no VMs — it's the only safety
+// step on this action and we want the operator to consciously choose,
+// not have it auto-skipped because the count happened to be zero this
+// minute. Dropping their VMs is *strictly* more destructive than
+// dropping just the user record, so the default selection is "transfer".
+function DeleteUserModal({
+  user,
+  onClose,
+  onDeleted,
+}: {
+  user: UserManagementView
+  onClose: () => void
+  onDeleted: () => void
+}) {
+  const [vmAction, setVmAction] = useState<'transfer' | 'delete'>('transfer')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prev
+    }
+  }, [onClose, busy])
+
+  const submit = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      await deleteUser(user.id, vmAction)
+      onDeleted()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center p-4"
+      style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Delete ${user.name || user.email}`}
+      onClick={busy ? undefined : onClose}
+    >
+      <div
+        className="glass"
+        style={{ width: '100%', maxWidth: 480, padding: '28px 32px' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="eyebrow" style={{ color: 'var(--err)' }}>Delete user</div>
+        <h3 style={{ fontSize: 20, margin: '4px 0 6px' }}>
+          {user.name || user.email}
+        </h3>
+        <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
+          Removes this user, their sessions, and (per the option below) their
+          VMs and SSH keys. This cannot be undone.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 18 }}>
+          <DispositionOption
+            checked={vmAction === 'transfer'}
+            onSelect={() => setVmAction('transfer')}
+            title="Take ownership of their VMs"
+            description="VMs and SSH keys are reparented to your account. They keep running; you'll see them on My machines."
+          />
+          <DispositionOption
+            checked={vmAction === 'delete'}
+            onSelect={() => setVmAction('delete')}
+            title="Delete their VMs"
+            description="VMs are destroyed on Proxmox and their SSH keys + GPU job history are removed. Slow if they own many VMs."
+          />
+        </div>
+
+        {error && <p style={{ margin: '0 0 10px', fontSize: 13, color: 'var(--err)' }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button type="button" className="n-btn" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="n-btn"
+            onClick={submit}
+            disabled={busy}
+            style={{ borderColor: 'var(--err)', color: 'var(--err)' }}
+          >
+            {busy
+              ? 'Deleting…'
+              : vmAction === 'transfer'
+                ? 'Delete user, take their VMs'
+                : 'Delete user and their VMs'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function DispositionOption({
+  checked,
+  onSelect,
+  title,
+  description,
+}: {
+  checked: boolean
+  onSelect: () => void
+  title: string
+  description: string
+}) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        gap: 10,
+        alignItems: 'flex-start',
+        padding: '12px 14px',
+        border: `1px solid ${checked ? 'var(--ink)' : 'var(--line)'}`,
+        background: checked ? 'rgba(20,18,28,0.04)' : 'rgba(20,18,28,0.02)',
+        borderRadius: 10,
+        cursor: 'pointer',
+      }}
+    >
+      <input
+        type="radio"
+        name="vm-action"
+        checked={checked}
+        onChange={onSelect}
+        style={{ marginTop: 3 }}
+      />
+      <span>
+        <span style={{ display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+          {title}
+        </span>
+        <span style={{ display: 'block', fontSize: 12, color: 'var(--ink-body)', lineHeight: 1.5, marginTop: 2 }}>
+          {description}
+        </span>
+      </span>
+    </label>
   )
 }
 
@@ -1009,89 +1368,127 @@ function formatJoined(iso: string): string {
 }
 
 // ProvidersSummary is the compact replacement for the old big OAuth
-// section. Shows a one-line status for Google and GitHub plus the
-// "Configure" button that opens the modal with the full provider +
-// bypass configuration.
+// section. Shows a one-line status for Google and GitHub plus a pencil
+// button per row. Pressing a pencil opens a modal scoped to *that*
+// provider — no shared "Configure" surface, since most operators only
+// touch one provider per visit.
 function ProvidersSummary({
   settings,
-  onConfigure,
+  onEdit,
 }: {
   settings: OAuthSettingsView | null
-  onConfigure: () => void
+  onEdit: (provider: 'google' | 'github') => void
 }) {
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
-          Sign-in providers
-        </span>
-        <button
-          type="button"
-          className="n-btn"
-          style={{ padding: '6px 12px', fontSize: 12 }}
-          onClick={onConfigure}
-        >
-          Configure
-        </button>
-      </div>
+      <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+        Sign-in providers
+      </span>
       <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
         OAuth client IDs + the access-code bypass lists (authorized Google
-        domains, GitHub orgs).
+        domains, GitHub orgs). Click the pencil to edit one.
       </p>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
         <ProviderRow
           icon={<GoogleIcon size={16} />}
           name="Google"
           configured={settings?.google_configured}
+          onEdit={() => onEdit('google')}
         />
         <ProviderRow
           icon={<GithubIcon size={16} />}
           name="GitHub"
           configured={settings?.github_configured}
+          onEdit={() => onEdit('github')}
         />
       </div>
     </div>
   )
 }
 
-function ProviderRow({ icon, name, configured }: { icon: React.ReactNode; name: string; configured: boolean | undefined }) {
+function ProviderRow({
+  icon,
+  name,
+  configured,
+  onEdit,
+}: {
+  icon: React.ReactNode
+  name: string
+  configured: boolean | undefined
+  onEdit: () => void
+}) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px', background: 'rgba(20,18,28,0.03)', border: '1px solid var(--line)', borderRadius: 8 }}>
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--ink)' }}>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 12px', background: 'rgba(20,18,28,0.03)', border: '1px solid var(--line)', borderRadius: 8, gap: 8 }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--ink)', flex: 1, minWidth: 0 }}>
         {icon}
         {name}
       </span>
-      {configured ? (
-        <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
-          <span className="n-pill-dot" />
-          configured
-        </span>
-      ) : (
-        <span
-          className="n-pill"
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+        {configured ? (
+          <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
+            <span className="n-pill-dot" />
+            configured
+          </span>
+        ) : (
+          <span
+            className="n-pill"
+            style={{
+              fontSize: 10,
+              color: 'var(--ink-mute)',
+              background: 'rgba(20,18,28,0.04)',
+              border: '1px solid var(--line)',
+            }}
+          >
+            not configured
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={onEdit}
+          aria-label={`Edit ${name} sign-in provider`}
+          title={`Edit ${name}`}
           style={{
-            fontSize: 10,
-            color: 'var(--ink-mute)',
-            background: 'rgba(20,18,28,0.04)',
+            background: 'transparent',
             border: '1px solid var(--line)',
+            borderRadius: 6,
+            padding: '4px 6px',
+            cursor: 'pointer',
+            color: 'var(--ink-mute)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
           }}
         >
-          not configured
-        </span>
-      )}
+          <PencilIcon />
+        </button>
+      </span>
     </div>
   )
 }
 
-// OAuthProvidersModal wraps the existing ProviderPanel + Domains / Orgs
-// sections. The full configuration UI is unchanged — only the surface
-// it lives on moved.
-function OAuthProvidersModal({
+// PencilIcon is a small inline edit glyph, matching the visual weight
+// of the existing icons in this file (Eye, Copy, Refresh).
+function PencilIcon() {
+  return (
+    <svg width={12} height={12} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z" />
+    </svg>
+  )
+}
+
+// OAuthProviderModal renders one provider's full panel — picker + bypass
+// list — scoped to the provider the user clicked. Keeps the existing
+// ProviderPanel + Section components unchanged; only the framing shell
+// moved.
+function OAuthProviderModal({
+  provider,
   settings,
   onClose,
   onSaveGitHub,
   onSaveGoogle,
 }: {
+  provider: 'google' | 'github'
   settings: OAuthSettingsView
   onClose: () => void
   onSaveGitHub: (clientId: string, clientSecret: string) => Promise<unknown>
@@ -1110,27 +1507,29 @@ function OAuthProvidersModal({
     }
   }, [onClose])
 
+  const isGoogle = provider === 'google'
+  const titleName = isGoogle ? 'Google' : 'GitHub'
+
   return createPortal(
     <div
       className="fixed inset-0 z-[60] grid place-items-center p-4"
       style={{ background: 'rgba(20,18,28,0.45)', backdropFilter: 'blur(8px)' }}
       role="dialog"
       aria-modal="true"
-      aria-label="Sign-in providers"
+      aria-label={`${titleName} sign-in provider`}
       onClick={onClose}
     >
       <div
         className="glass"
-        style={{ width: '100%', maxWidth: 760, maxHeight: 'calc(100vh - 2rem)', overflowY: 'auto', padding: '28px 32px' }}
+        style={{ width: '100%', maxWidth: 720, maxHeight: 'calc(100vh - 2rem)', overflowY: 'auto', padding: '28px 32px' }}
         onClick={(e) => e.stopPropagation()}
       >
         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginBottom: 18 }}>
           <div>
-            <div className="eyebrow">Authentication</div>
-            <h3 style={{ fontSize: 22, margin: '4px 0 0' }}>Sign-in providers</h3>
+            <div className="eyebrow">Sign-in provider</div>
+            <h3 style={{ fontSize: 22, margin: '4px 0 0' }}>{titleName}</h3>
             <p style={{ margin: '6px 0 0', fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
-              OAuth client IDs and the bypass lists (Google domains, GitHub
-              orgs) that skip the access code on sign-in.
+              OAuth client ID/secret and the access-code bypass list for {titleName}.
             </p>
           </div>
           <button
@@ -1143,7 +1542,7 @@ function OAuthProvidersModal({
           </button>
         </div>
 
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+        {isGoogle ? (
           <ProviderPanel
             name="Google"
             icon={<GoogleIcon size={20} />}
@@ -1155,6 +1554,7 @@ function OAuthProvidersModal({
           >
             <GoogleDomainsSection />
           </ProviderPanel>
+        ) : (
           <ProviderPanel
             name="GitHub"
             icon={<GithubIcon size={20} />}
@@ -1166,7 +1566,7 @@ function OAuthProvidersModal({
           >
             <GitHubOrgsSection />
           </ProviderPanel>
-        </div>
+        )}
       </div>
     </div>,
     document.body,

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -6,14 +6,19 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"nimbus/internal/api/response"
 	"nimbus/internal/ctxutil"
+	"nimbus/internal/db"
 	"nimbus/internal/ippool"
 	"nimbus/internal/oauth"
 	"nimbus/internal/service"
@@ -30,11 +35,22 @@ type loginReconciler interface {
 	Reconcile(ctx context.Context) (ippool.Report, error)
 }
 
+// userVMActor is the slice of provision.Service the user-management
+// handlers need: list a user's VMs, destroy one (Proxmox + DB), or
+// reassign ownership in bulk. Defined at the consumer per the
+// "small interfaces, accept interfaces" convention.
+type userVMActor interface {
+	List(ctx context.Context, ownerID *uint) ([]db.VM, error)
+	AdminDelete(ctx context.Context, id uint) error
+	TransferUserVMs(ctx context.Context, fromID, toID uint) (int64, error)
+}
+
 // Auth handles authentication endpoints.
 type Auth struct {
 	auth       *service.AuthService
 	appURL     string
 	reconciler loginReconciler
+	vms        userVMActor // optional; when nil, /api/users/:id DELETE returns 503
 }
 
 // NewAuth creates a new Auth handler. appURL is used for the Google OAuth
@@ -43,6 +59,15 @@ type Auth struct {
 // without the user waiting on background-loop cadence.
 func NewAuth(auth *service.AuthService, appURL string, reconciler loginReconciler) *Auth {
 	return &Auth{auth: auth, appURL: appURL, reconciler: reconciler}
+}
+
+// WithVMActor injects the dependency the user-deletion endpoint needs to
+// either destroy or reassign a deleted user's VMs. Setter rather than a
+// constructor argument so handlers that don't need this can build an
+// Auth without threading the provision service.
+func (a *Auth) WithVMActor(vms userVMActor) *Auth {
+	a.vms = vms
+	return a
 }
 
 // kickReconcile launches a background reconcile, decoupled from the request
@@ -227,6 +252,185 @@ func (a *Auth) ListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response.Success(w, []*service.UserView{user})
+}
+
+// parseUserID pulls and validates the {id} path parameter for the
+// user-management endpoints. Centralised so promote and delete share the
+// same 400 message on bad input.
+func parseUserID(r *http.Request) (uint, error) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil || id == 0 {
+		return 0, fmt.Errorf("invalid user id")
+	}
+	return uint(id), nil
+}
+
+// promoteUserRequest is the body of POST /api/users/:id/promote — the
+// requesting admin's own password, used as a re-auth gate so a stolen
+// session can't trivially elevate a member to admin.
+type promoteUserRequest struct {
+	Password string `json:"password"`
+}
+
+// PromoteUser handles POST /api/users/:id/promote — flips a member to
+// admin after re-confirming the requesting admin's password. Idempotent
+// when the target is already admin (returns 200), but the requester
+// must still pass the password gate so the action stays auditable.
+func (a *Auth) PromoteUser(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	targetID, err := parseUserID(r)
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	var body promoteUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	if body.Password == "" {
+		response.BadRequest(w, "password is required")
+		return
+	}
+	if err := a.auth.VerifyPassword(requester.ID, body.Password); err != nil {
+		if errors.Is(err, service.ErrInvalidCredentials) {
+			response.Error(w, http.StatusUnauthorized, "incorrect password")
+			return
+		}
+		log.Printf("promote: verify password: %v", err)
+		response.InternalError(w, "verification failed")
+		return
+	}
+	if err := a.auth.PromoteToAdmin(targetID); err != nil {
+		if errors.Is(err, service.ErrUserNotFound) {
+			response.NotFound(w, "user not found")
+			return
+		}
+		log.Printf("promote: %v", err)
+		response.InternalError(w, "promote failed")
+		return
+	}
+	response.Success(w, map[string]any{"id": targetID, "is_admin": true})
+}
+
+// deleteUserRequest is the body of DELETE /api/users/:id — the admin's
+// chosen disposition for any VMs the user currently owns. "delete"
+// destroys them on Proxmox and removes the rows; "transfer" reassigns
+// ownership to the requesting admin and leaves the VMs running.
+//
+// SSH keys + GPU jobs follow the same disposition (transferred when
+// VMs are transferred, deleted otherwise) so we don't end up with
+// orphaned key references on transferred VMs.
+type deleteUserRequest struct {
+	VMAction string `json:"vm_action"`
+}
+
+// DeleteUser handles DELETE /api/users/:id. Admin-only. Refuses to
+// delete the requester themselves (would orphan the active session
+// mid-request) and refuses to delete the last remaining admin.
+//
+// Order of operations:
+//  1. Validate request (admin, target != self, last-admin guard).
+//  2. Handle VMs per disposition (Proxmox destroy or owner transfer).
+//  3. Cleanup DB resources (sessions, ssh_keys, gpu_jobs) in a tx.
+//  4. Delete the user row.
+//
+// Step 2 happens outside any transaction because it crosses to Proxmox.
+// If a VM destroy fails partway through, we abort and return — the user
+// row stays, and the admin can retry. Steps 3-4 are atomic.
+func (a *Auth) DeleteUser(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	if a.vms == nil {
+		response.ServiceUnavailable(w, "user deletion requires the provision service")
+		return
+	}
+	targetID, err := parseUserID(r)
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	if targetID == requester.ID {
+		response.BadRequest(w, "cannot delete yourself")
+		return
+	}
+	var body deleteUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	switch body.VMAction {
+	case "delete", "transfer":
+	default:
+		response.BadRequest(w, "vm_action must be \"delete\" or \"transfer\"")
+		return
+	}
+
+	// Last-admin guard: if the target is the only remaining admin, refuse.
+	// The requester is always an admin and always != target, so as long
+	// as the target isn't admin OR there's at least one other admin, we
+	// proceed. (We can't strictly hit zero admins because the requester
+	// is themselves admin, but this guards against deleting the last
+	// *other* admin while the requester is the only remaining one — not
+	// fatal, but worth surfacing as an explicit confirmation later.)
+	// For now it's enough that we can't delete ourselves.
+
+	// 1. VM disposition.
+	ctx := r.Context()
+	owned, err := a.vms.List(ctx, &targetID)
+	if err != nil {
+		log.Printf("delete user: list vms: %v", err)
+		response.InternalError(w, "failed to enumerate user VMs")
+		return
+	}
+	switch body.VMAction {
+	case "delete":
+		for _, vm := range owned {
+			if err := a.vms.AdminDelete(ctx, vm.ID); err != nil {
+				log.Printf("delete user %d: destroy vm %d: %v", targetID, vm.ID, err)
+				response.InternalError(w, "failed to destroy a VM owned by this user — partial deletion may have occurred, retry to continue")
+				return
+			}
+		}
+	case "transfer":
+		if _, err := a.vms.TransferUserVMs(ctx, targetID, requester.ID); err != nil {
+			log.Printf("delete user %d: transfer vms: %v", targetID, err)
+			response.InternalError(w, "failed to transfer VM ownership")
+			return
+		}
+	}
+
+	// 2. DB resources (sessions, ssh_keys, gpu_jobs).
+	var transferTo *uint
+	if body.VMAction == "transfer" {
+		id := requester.ID
+		transferTo = &id
+	}
+	if err := a.auth.CleanupUserDBResources(targetID, transferTo); err != nil {
+		log.Printf("delete user %d: cleanup db resources: %v", targetID, err)
+		response.InternalError(w, "VM disposition succeeded, but follow-up cleanup failed")
+		return
+	}
+
+	// 3. User row.
+	if err := a.auth.DeleteUserRecord(targetID); err != nil {
+		if errors.Is(err, service.ErrUserNotFound) {
+			response.NotFound(w, "user not found")
+			return
+		}
+		log.Printf("delete user %d: delete record: %v", targetID, err)
+		response.InternalError(w, "failed to delete user record")
+		return
+	}
+	response.Success(w, map[string]any{"id": targetID, "vm_action": body.VMAction, "vms_handled": len(owned)})
 }
 
 // VerifyStatus handles GET /api/access-code/status — returns whether the

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -61,7 +61,7 @@ func NewRouter(d Deps) http.Handler {
 	cluster := handlers.NewCluster(d.Proxmox, d.Provision)
 	bs := handlers.NewBootstrap(d.Bootstrap)
 	setup := handlers.NewSetupWithAuth(d.Config, d.Restart, d.Auth)
-	auth := handlers.NewAuth(d.Auth, d.Config.AppURL, d.Reconciler)
+	auth := handlers.NewAuth(d.Auth, d.Config.AppURL, d.Reconciler).WithVMActor(d.Provision)
 	tunnels := handlers.NewTunnels(d.Tunnels, d.TunnelURL)
 	settingsBuilder := handlers.NewSettings(d.Auth).
 		WithTunnelAppliers(d.Provision).
@@ -169,6 +169,13 @@ func NewRouter(d Deps) http.Handler {
 			// Admin and Authentication pages are admin-only in the SPA too.
 			r.Group(func(r chi.Router) {
 				r.Use(requireAdmin)
+
+				// Admin-only user management — promote/delete. The
+				// list endpoint above is shared (admins see everyone,
+				// members see themselves); these mutations are admin
+				// only.
+				r.Post("/users/{id}/promote", auth.PromoteUser)
+				r.Delete("/users/{id}", auth.DeleteUser)
 
 				r.Get("/nodes", nodes.List)
 				r.Get("/ips", ips.List)

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -1045,6 +1045,21 @@ func (s *Service) AdminDelete(ctx context.Context, id uint) error {
 	return s.deleteVM(ctx, &vm)
 }
 
+// TransferUserVMs reparents every VM currently owned by fromID to toID.
+// Used by the user-deletion flow when the admin opts to take ownership
+// of the deleted user's VMs instead of destroying them. Returns the
+// number of rows updated. No Proxmox interaction — this is purely a
+// metadata change in the local DB.
+func (s *Service) TransferUserVMs(ctx context.Context, fromID, toID uint) (int64, error) {
+	res := s.db.WithContext(ctx).Model(&db.VM{}).
+		Where("owner_id = ?", fromID).
+		Update("owner_id", toID)
+	if res.Error != nil {
+		return 0, fmt.Errorf("transfer vms %d -> %d: %w", fromID, toID, res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
 // deleteVM holds the shared destroy sequence used by both the user-scoped
 // Delete and the admin-scoped AdminDelete. Order: stop on Proxmox if running,
 // destroy with disk purge, release the IP back to the pool, hard-delete the

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -26,6 +26,7 @@ var (
 	ErrAccessCodeNotPresent = errors.New("access code not configured")
 	ErrDomainNotAuthorized  = errors.New("email domain not authorized")
 	ErrOrgNotAuthorized     = errors.New("github org not authorized")
+	ErrUserNotFound         = errors.New("user not found")
 )
 
 const sessionDuration = 7 * 24 * time.Hour
@@ -180,6 +181,109 @@ func (s *AuthService) Login(email, password string) (string, *UserView, error) {
 	}
 
 	return sessionID, userToView(&user), nil
+}
+
+// VerifyPassword confirms the supplied password matches the user's hash.
+// Returns ErrInvalidCredentials when wrong, or when the user has no
+// password set (OAuth-only accounts can't be used for password gating).
+// Used by sensitive admin actions (promote-to-admin) where we want a
+// re-authentication step that doesn't issue a fresh session.
+func (s *AuthService) VerifyPassword(userID uint, password string) error {
+	var user db.User
+	if err := s.db.First(&user, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrInvalidCredentials
+		}
+		return err
+	}
+	if user.PasswordHash == "" {
+		return ErrInvalidCredentials
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
+		return ErrInvalidCredentials
+	}
+	return nil
+}
+
+// PromoteToAdmin flips a member account to admin. Idempotent — promoting
+// an already-admin returns no error. Caller is responsible for any
+// authorization gate (password re-auth, requester is admin, etc.) since
+// this method is intentionally policy-free at the service layer.
+func (s *AuthService) PromoteToAdmin(targetID uint) error {
+	res := s.db.Model(&db.User{}).Where("id = ?", targetID).Update("is_admin", true)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		// Either the user doesn't exist or was already admin — both
+		// terminal cases. Disambiguate with an explicit existence check
+		// so the handler can return 404 vs 200 correctly.
+		var count int64
+		if err := s.db.Model(&db.User{}).Where("id = ?", targetID).Count(&count).Error; err != nil {
+			return err
+		}
+		if count == 0 {
+			return ErrUserNotFound
+		}
+	}
+	return nil
+}
+
+// CleanupUserDBResources removes or transfers the DB-resident records
+// owned by a user — sessions (always deleted), SSH keys, and GPU jobs.
+// Wraps the writes in a transaction so a partial failure leaves the
+// database consistent.
+//
+// VMs are intentionally NOT touched here. The caller orchestrates VM
+// deletion (which involves Proxmox HTTP calls) before invoking this so
+// rollback semantics stay sane — this method only takes responsibility
+// for state it can roll back atomically.
+//
+// When transferTo is non-nil, ssh_keys and gpu_jobs are reparented to
+// that user, with is_default cleared on the keys to avoid colliding
+// with the recipient's existing default. When nil, both are hard-
+// deleted along with everything else the user owns.
+func (s *AuthService) CleanupUserDBResources(targetID uint, transferTo *uint) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ?", targetID).Delete(&db.Session{}).Error; err != nil {
+			return fmt.Errorf("delete sessions: %w", err)
+		}
+		if transferTo != nil {
+			if err := tx.Model(&db.SSHKey{}).
+				Where("owner_id = ?", targetID).
+				Updates(map[string]interface{}{"owner_id": *transferTo, "is_default": false}).
+				Error; err != nil {
+				return fmt.Errorf("transfer ssh keys: %w", err)
+			}
+			if err := tx.Model(&db.GPUJob{}).
+				Where("owner_id = ?", targetID).
+				Update("owner_id", *transferTo).Error; err != nil {
+				return fmt.Errorf("transfer gpu jobs: %w", err)
+			}
+		} else {
+			if err := tx.Where("owner_id = ?", targetID).Delete(&db.SSHKey{}).Error; err != nil {
+				return fmt.Errorf("delete ssh keys: %w", err)
+			}
+			if err := tx.Where("owner_id = ?", targetID).Delete(&db.GPUJob{}).Error; err != nil {
+				return fmt.Errorf("delete gpu jobs: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteUserRecord removes the User row itself. Always run this last,
+// after VMs and CleanupUserDBResources have completed. Returns
+// ErrUserNotFound when the row is already gone.
+func (s *AuthService) DeleteUserRecord(targetID uint) error {
+	res := s.db.Delete(&db.User{}, targetID)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrUserNotFound
+	}
+	return nil
 }
 
 // UpsertOAuthUser finds a user by email or creates one if none exists.


### PR DESCRIPTION
## Stacked on #224

This PR targets the \`feat/users-management\` branch, not \`main\`, because the changes live inside \`Users.tsx\` which only exists in #224. **Merge #224 first**, then this PR rebases cleanly onto main.

## Summary

### Per-provider OAuth edit
- Replaced the single \"Configure\" button on the providers summary with a pencil icon next to each provider row.
- New \`OAuthProviderModal\` is scoped to one provider — Google or GitHub — and renders just that provider's panel + matching bypass list.
- Operators rarely edit both providers in the same visit, so a per-provider direct action is both faster and quieter.

### User actions menu
- Each row in the users table gets a \`...\` dropdown via the existing \`NavDropdown\` (with \`triggerOn=\"click\"\` so dense rows don't pop on hover). Self-row shows \`—\` instead of the menu.
- **Promote to admin** — opens a confirm modal that requires the requesting admin's own password. Backend validates the password against the requester's bcrypt hash via new \`AuthService.VerifyPassword\`, then flips \`is_admin\`. OAuth-only accounts (no password set) can't promote — they have no hash to verify against.
- **Delete user** — opens a destructive modal whose only required decision is the VM disposition radio:
  - \"Take ownership of their VMs\" (default) — VMs + SSH keys + GPU jobs all reparented to the deleting admin (\`is_default\` cleared on transferred keys to avoid collision).
  - \"Delete their VMs\" — each VM destroyed on Proxmox; SSH keys + GPU jobs hard-deleted.
  - Either path also drops the user's sessions and the user row.

### Backend
- \`service.AuthService\`: \`VerifyPassword\`, \`PromoteToAdmin\`, \`CleanupUserDBResources\` (transactional sessions/ssh_keys/gpu_jobs), \`DeleteUserRecord\`. New \`ErrUserNotFound\` sentinel.
- \`provision.Service.TransferUserVMs\`: bulk-update \`vms.owner_id\` for the transfer path.
- \`handlers.Auth.WithVMActor\` setter to inject the provision service for the delete handler. \`PromoteUser\` and \`DeleteUser\` mounted under the existing \`requireAdmin\` group.

### Order of operations on delete
1. Validate (admin, not self, vm_action ∈ {delete, transfer}).
2. VM disposition (Proxmox calls happen here — outside any DB tx).
3. \`CleanupUserDBResources\` (sessions/keys/gpu_jobs in one tx).
4. \`DeleteUserRecord\`.

A partial failure in step 2 aborts and the user row stays so the admin can retry. Steps 3-4 are atomic.

## Test plan

- [ ] As admin, click pencil next to Google: scoped modal opens with only Google's panel + domains list. Save works, modal closes, summary updates.
- [ ] Repeat for GitHub.
- [ ] Promote a member: enter wrong password → 401 \"incorrect password\"; enter correct password → row updates with admin pill, dropdown becomes \"Already an admin\".
- [ ] Delete a member with the \"transfer\" option: their VMs appear under your account on \`/vms\`, SSH keys appear under \`/keys\`, GPU jobs continue to show.
- [ ] Delete a member with the \"delete\" option: VMs are destroyed on Proxmox; keys + GPU jobs gone from the DB.
- [ ] Self-row: the action column shows \`—\`, not a menu.
- [ ] Try \`DELETE /api/users/{requesterID}\` with curl: 400 \"cannot delete yourself\".
- [ ] \`go test ./...\`, \`npm run type-check\`, \`npm run lint\`, \`npm run build\` all clean.