### PR TITLE
feat: OAuth linking on /account + admin-controlled passwordless sign-in goal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,16 @@ so any backfill in `main()` runs on the first post-upgrade boot for free.
   uses `subtle.ConstantTimeCompare` against the stored hex. Don't add
   shortcut comparisons elsewhere; rotate the token via the Settings page,
   never by hand-editing the DB.
+- **GORM splits camel-case acronyms when deriving column names.**
+  `User.GitHubOrgs` becomes `git_hub_orgs` on disk, *not* `github_orgs`
+  — GORM treats every uppercase boundary as a word boundary. Raw
+  `Where("github_orgs = ?")` runs but errors at query time with
+  `no such column`. Fix: either use the actual column (`git_hub_orgs`)
+  or pin the name with a struct tag (`gorm:"column:github_orgs"`). When
+  in doubt, check `sqlite3 nimbus.db ".schema users"` for the
+  ground-truth column names. The new fields added in the same schema
+  bump (`google_sub`, `github_id`) are pinned with explicit `column:`
+  tags for that reason.
 
 ## When you change reconciliation, verification, or the IP pool
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,7 +115,8 @@ func main() {
 	}
 
 	database, err := db.New(cfg.DBPath,
-		&db.User{}, &db.Session{}, &db.OAuthSettings{}, &db.GopherSettings{},
+		&db.User{}, &db.Session{}, &db.OAuthSettings{}, &db.SMTPSettings{},
+		&db.GopherSettings{},
 		&db.GPUSettings{}, &db.GPUJob{}, &db.NetworkSettings{},
 		&db.VM{}, &db.NodeTemplate{}, &db.SSHKey{}, &db.S3Storage{},
 		ippool.Model(),
@@ -215,6 +216,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to init secrets cipher: %v", err)
 	}
+	// Late-bind the cipher onto the auth service so SMTP credentials
+	// (the only secret-bearing field on AuthService today) can be
+	// encrypted before storage. AuthService was constructed earlier
+	// for the Gopher seed step, which doesn't need a cipher.
+	authSvc.WithCipher(cipher)
 
 	// Long timeout: the bootstrap path makes calls that wait on Proxmox tasks
 	// (image downloads) which can run for several minutes. The HTTP server

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Layout from '@/components/Layout'
 import RequireAdmin from '@/components/RequireAdmin'
 import RequireAuth from '@/components/RequireAuth'
 import RequireVerified from '@/components/RequireVerified'
+import Account from '@/pages/Account'
 import Admin from '@/pages/Admin'
 import GopherTunnels from '@/pages/GopherTunnels'
 import GPU from '@/pages/GPU'
@@ -88,6 +89,7 @@ export default function App() {
                       <Route path="/keys" element={<Keys />} />
                       <Route path="/gpu" element={<GPU />} />
                       <Route path="/users" element={<RequireAdmin><Users /></RequireAdmin>} />
+                      <Route path="/account" element={<Account />} />
                       {/* Old /settings URL kept around so any existing
                           bookmarks / pasted links still resolve to the
                           rebranded user management page. */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import RequireAuth from '@/components/RequireAuth'
 import RequireVerified from '@/components/RequireVerified'
 import Account from '@/pages/Account'
 import Admin from '@/pages/Admin'
+import Email from '@/pages/Email'
 import GopherTunnels from '@/pages/GopherTunnels'
 import GPU from '@/pages/GPU'
 import GPUHost from '@/pages/GPUHost'
@@ -89,6 +90,7 @@ export default function App() {
                       <Route path="/keys" element={<Keys />} />
                       <Route path="/gpu" element={<GPU />} />
                       <Route path="/users" element={<RequireAdmin><Users /></RequireAdmin>} />
+                      <Route path="/email" element={<RequireAdmin><Email /></RequireAdmin>} />
                       <Route path="/account" element={<Account />} />
                       {/* Old /settings URL kept around so any existing
                           bookmarks / pasted links still resolve to the

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -583,10 +583,11 @@ export interface UserManagementView {
   is_admin: boolean
   created_at: string
   verified: boolean
-  // Best-effort sign-in providers the user has used at least once. May
-  // contain "password" (email/password registered), "github" (GitHub OAuth
-  // login captured), and/or "google" (inferred when neither password nor
-  // github is set — Google OAuth doesn't leave a per-user marker today).
+  suspended: boolean
+  // Sign-in paths the user has at least touched: "password" (set),
+  // "github" (one or more handshakes), "google" (one or more
+  // handshakes). Now derived from explicit per-provider flags rather
+  // than absence-inference.
   providers: string[]
 }
 
@@ -600,6 +601,22 @@ export async function listUsers(): Promise<UserManagementView[]> {
 // 401-translated "incorrect password" message when the gate fails.
 export async function promoteUser(id: number, password: string): Promise<{ id: number; is_admin: boolean }> {
   const { data } = await api.post<{ id: number; is_admin: boolean }>(`/users/${id}/promote`, { password })
+  return data
+}
+
+// setUserSuspended flips one user's suspended flag. Suspending also
+// kills every session they have so the change applies on the next
+// request rather than waiting for cookies to expire.
+export async function setUserSuspended(id: number, suspended: boolean): Promise<{ id: number; suspended: boolean }> {
+  const { data } = await api.post<{ id: number; suspended: boolean }>(`/users/${id}/suspend-status`, { suspended })
+  return data
+}
+
+// suspendUnlinkedUsers is the bulk version: suspends every active user
+// without OAuth (excluding the requester). Used by the passwordless
+// toggle's "Suspend stragglers" button.
+export async function suspendUnlinkedUsers(): Promise<{ suspended: number }> {
+  const { data } = await api.post<{ suspended: number }>('/users/suspend-unlinked')
   return data
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -533,6 +533,44 @@ export interface PasswordlessStatus {
   passwordless_goal: boolean
   stragglers: number
   password_active: boolean
+  // smtp_ready is true when SMTP is both configured (host + from
+  // address present) AND the admin has flipped the Enabled switch on
+  // /email. The "Email N unlinked users" button on /users gates on
+  // this. Send pipeline itself is still pending.
+  smtp_ready: boolean
+}
+
+export interface SMTPSettingsView {
+  host: string
+  port: number
+  username: string
+  has_password: boolean
+  from_address: string
+  encryption: 'starttls' | 'tls' | 'none' | string
+  enabled: boolean
+  configured: boolean
+}
+
+export interface SaveSMTPRequest {
+  host: string
+  port: number
+  username: string
+  // Omit to leave the existing password untouched. Empty string clears
+  // the stored password. Non-empty replaces.
+  password?: string
+  from_address: string
+  encryption: 'starttls' | 'tls' | 'none'
+  enabled: boolean
+}
+
+export async function getSMTPSettings(): Promise<SMTPSettingsView> {
+  const { data } = await api.get<SMTPSettingsView>('/settings/smtp')
+  return data
+}
+
+export async function saveSMTPSettings(req: SaveSMTPRequest): Promise<SMTPSettingsView> {
+  const { data } = await api.put<SMTPSettingsView>('/settings/smtp', req)
+  return data
 }
 
 export async function getPasswordlessStatus(): Promise<PasswordlessStatus> {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -503,6 +503,46 @@ export async function createAdminAccount(req: CreateAdminRequest): Promise<{ id:
 export interface OAuthProviders {
   github: boolean
   google: boolean
+  // password is true when the sign-in page should still render the
+  // email/password form. Stays true unless the admin has set
+  // passwordless_goal AND every user has linked an OAuth provider.
+  password: boolean
+  // passwordless_goal is the admin's stated intent. When true but
+  // password is also still true, the system is in transition (some
+  // users haven't linked yet); the UI uses both fields to render the
+  // explanatory banner.
+  passwordless_goal: boolean
+}
+
+export interface AccountView {
+  id: number
+  name: string
+  email: string
+  is_admin: boolean
+  has_password: boolean
+  google_connected: boolean
+  github_connected: boolean
+}
+
+export async function getAccount(): Promise<AccountView> {
+  const { data } = await api.get<AccountView>('/account')
+  return data
+}
+
+export interface PasswordlessStatus {
+  passwordless_goal: boolean
+  stragglers: number
+  password_active: boolean
+}
+
+export async function getPasswordlessStatus(): Promise<PasswordlessStatus> {
+  const { data } = await api.get<PasswordlessStatus>('/settings/oauth/passwordless')
+  return data
+}
+
+export async function setPasswordlessAuth(enabled: boolean): Promise<PasswordlessStatus> {
+  const { data } = await api.put<PasswordlessStatus>('/settings/oauth/passwordless', { enabled })
+  return data
 }
 
 export interface OAuthSettingsView {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -152,6 +152,17 @@ export default function Layout({ children, showNav = true }: LayoutProps) {
                   <NavLink to="/users" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
                     Users
                   </NavLink>
+                  <NavLink to="/email" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
+                    <span className="inline-flex items-center gap-1.5">
+                      Email
+                      <span
+                        className="font-mono text-[9px] uppercase tracking-widest text-warn bg-[rgba(184,101,15,0.12)] border border-[rgba(184,101,15,0.25)] px-1.5 py-px rounded"
+                        title="Preview — config saves but the send pipeline ships in a follow-up release"
+                      >
+                        Preview
+                      </span>
+                    </span>
+                  </NavLink>
                   <NavLink to="/gophers" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
                     Gopher Tunnels
                   </NavLink>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -180,6 +180,9 @@ export default function Layout({ children, showNav = true }: LayoutProps) {
 
                   <div className="my-1 border-t border-line" />
 
+                  <NavLink to="/account" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
+                    Account
+                  </NavLink>
                   <button
                     type="button"
                     onClick={handleSignOut}
@@ -190,17 +193,29 @@ export default function Layout({ children, showNav = true }: LayoutProps) {
                   </button>
                 </NavDropdown>
               ) : user ? (
-                <>
-                  <span className="px-2.5 py-2 text-sm text-ink-2 font-mono">
-                    {user.name}
-                  </span>
+                <NavDropdown
+                  placement="bottom-end"
+                  triggerClassName="px-3.5 py-2 rounded-[8px] text-sm font-medium text-ink-2 hover:bg-[rgba(27,23,38,0.05)] hover:text-ink transition-colors flex items-center gap-1.5 cursor-pointer"
+                  trigger={
+                    <>
+                      <span className="font-mono">{user.name}</span>
+                      <span className="text-xl text-ink-2 leading-none ml-0.5" aria-hidden="true">▾</span>
+                    </>
+                  }
+                >
+                  <NavLink to="/account" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
+                    Account
+                  </NavLink>
+                  <div className="my-1 border-t border-line" />
                   <button
+                    type="button"
                     onClick={handleSignOut}
-                    className="px-3.5 py-2 rounded-[8px] text-sm font-medium text-ink-2 hover:bg-[rgba(27,23,38,0.05)] hover:text-ink transition-colors"
+                    style={{ cursor: 'pointer' }}
+                    className="block w-full px-3 py-1.5 text-sm text-ink-2 hover:bg-[rgba(27,23,38,0.05)] hover:text-ink transition-colors text-left cursor-pointer"
                   >
                     Sign out
                   </button>
-                </>
+                </NavDropdown>
               ) : null}
             </div>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -128,6 +128,14 @@
 }
 
 /* ── Buttons ────────────────────────────────────────────── */
+/* `.n-btn` alone now renders as a visible secondary button — white
+   surface, 22%-opacity border (--line-strong). The earlier default
+   was `border: 1px solid transparent` with no background, so any
+   call site that forgot a variant suffix rendered as plain text
+   indistinguishable from the surrounding copy. The `n-btn-secondary`
+   class becomes redundant (kept as an alias for explicit intent in
+   call sites), and `n-btn-ghost` explicitly drops the chrome back
+   to transparent for the rare actually-textual button. */
 .n-btn {
   display: inline-flex;
   align-items: center;
@@ -141,10 +149,17 @@
   font-weight: 500;
   letter-spacing: -0.005em;
   cursor: pointer;
-  border: 1px solid transparent;
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--line-strong);
   transition: all 0.15s ease;
   text-decoration: none;
   white-space: nowrap;
+}
+
+.n-btn:hover {
+  border-color: rgba(20, 18, 28, 0.32);
+  background: rgba(20, 18, 28, 0.03);
 }
 
 .n-btn-primary {
@@ -155,6 +170,7 @@
 
 .n-btn-primary:hover {
   background: #000;
+  border-color: #000;
   transform: translateY(-1px);
   box-shadow: 0 6px 20px -8px rgba(20, 18, 28, 0.5);
 }
@@ -163,24 +179,33 @@
   transform: translateY(0);
 }
 
+/* Idempotent — same as base .n-btn now. Kept so existing call sites
+   that explicitly request the secondary look still compile and so
+   future code that wants to be loud about intent can. */
 .n-btn-secondary {
   background: var(--surface);
   color: var(--ink);
-  border-color: var(--line);
+  border-color: var(--line-strong);
 }
 
 .n-btn-secondary:hover {
-  border-color: var(--line-strong);
-  background: #ffffff;
+  border-color: rgba(20, 18, 28, 0.32);
+  background: rgba(20, 18, 28, 0.03);
 }
 
+/* Genuinely chromeless — for buttons that should read as inline text
+   actions, like a "Cancel" embedded next to copy. Strips the visible
+   defaults `.n-btn` now provides. */
 .n-btn-ghost {
   background: transparent;
   color: var(--ink-body);
+  border-color: transparent;
 }
 
 .n-btn-ghost:hover {
   color: var(--ink);
+  background: transparent;
+  border-color: transparent;
 }
 
 .n-btn-block {

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { GithubIcon, GoogleIcon } from '@/components/nimbus'
+import { getAccount, getProviders } from '@/api/client'
+import type { AccountView, OAuthProviders } from '@/api/client'
+
+// Account — a personal page reachable from the user dropdown by every
+// signed-in user (admin or member). Renders the read-only profile and
+// the Connect Google / Connect GitHub buttons. Linking goes through
+// /api/auth/{provider}/link, which sets a link-intent cookie before the
+// OAuth dance — the same callback then attaches the identity to the
+// current user instead of creating/finding by email.
+//
+// After a successful link the OAuth callback redirects here with
+// `?linked=google` or `?linked=github`; we surface a small banner and
+// refresh the account view so the Connect button flips to Connected.
+export default function Account() {
+  const [account, setAccount] = useState<AccountView | null>(null)
+  const [providers, setProviders] = useState<OAuthProviders | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [params, setParams] = useSearchParams()
+  const justLinked = params.get('linked')
+
+  const reload = () => {
+    Promise.all([getAccount(), getProviders()])
+      .then(([a, p]) => {
+        setAccount(a)
+        setProviders(p)
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed to load'))
+  }
+
+  useEffect(() => {
+    reload()
+    // If we landed here from a successful link callback, drop the
+    // query string after a beat so a refresh doesn't keep showing the
+    // banner. The reload above will pick up the new state.
+    if (justLinked) {
+      const t = setTimeout(() => {
+        params.delete('linked')
+        setParams(params, { replace: true })
+      }, 4000)
+      return () => clearTimeout(t)
+    }
+    return undefined
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const linkedBanner = useMemo(() => {
+    if (!justLinked) return null
+    const label = justLinked === 'google' ? 'Google' : justLinked === 'github' ? 'GitHub' : null
+    if (!label) return null
+    return `${label} account linked.`
+  }, [justLinked])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <div>
+        <h1 className="n-display" style={{ fontSize: 28, margin: '0 0 6px' }}>
+          Account
+        </h1>
+        <p style={{ margin: 0, fontSize: 14, color: 'var(--ink-body)' }}>
+          Your profile and the sign-in providers linked to this account.
+        </p>
+      </div>
+
+      {linkedBanner && (
+        <div
+          className="n-pill n-pill-ok"
+          style={{ alignSelf: 'flex-start', fontSize: 12, padding: '6px 12px' }}
+        >
+          <span className="n-pill-dot" />
+          {linkedBanner}
+        </div>
+      )}
+
+      {error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--err)' }}>{error}</p>
+      )}
+
+      {account === null && !error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>Loading…</p>
+      )}
+
+      {account && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+          <div className="lg:col-span-2 flex flex-col gap-6">
+            <ProfileCard account={account} />
+            <LinkedProvidersCard account={account} providers={providers} />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProfileCard({ account }: { account: AccountView }) {
+  return (
+    <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+        Profile
+      </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <ProfileRow label="Display name" value={account.name || '—'} />
+        <ProfileRow label="Email" value={account.email} mono />
+        <ProfileRow
+          label="Role"
+          value={account.is_admin ? 'admin' : 'member'}
+        />
+      </div>
+    </div>
+  )
+}
+
+function ProfileRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
+      <span style={{ fontSize: 12, color: 'var(--ink-mute)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        {label}
+      </span>
+      <span
+        style={{
+          fontSize: 13,
+          color: 'var(--ink)',
+          fontFamily: mono ? 'Geist Mono, monospace' : undefined,
+          textAlign: 'right',
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function LinkedProvidersCard({
+  account,
+  providers,
+}: {
+  account: AccountView
+  providers: OAuthProviders | null
+}) {
+  return (
+    <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+      <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+        Linked sign-in providers
+      </span>
+      <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
+        Connect Google or GitHub so you can sign in with one click. Linking
+        is required if your admin moves the workspace to OAuth-only sign-in.
+      </p>
+
+      <ProviderLinkRow
+        icon={<GoogleIcon size={18} />}
+        name="Google"
+        connected={account.google_connected}
+        configured={Boolean(providers?.google)}
+        href="/api/auth/google/link"
+      />
+      <ProviderLinkRow
+        icon={<GithubIcon size={18} />}
+        name="GitHub"
+        connected={account.github_connected}
+        configured={Boolean(providers?.github)}
+        href="/api/auth/github/link"
+      />
+
+      {account.has_password && (
+        <p style={{ margin: '4px 0 0', fontSize: 11, color: 'var(--ink-mute)' }}>
+          You also have a password set on this account.
+        </p>
+      )}
+    </div>
+  )
+}
+
+function ProviderLinkRow({
+  icon,
+  name,
+  connected,
+  configured,
+  href,
+}: {
+  icon: React.ReactNode
+  name: string
+  connected: boolean
+  // configured tells us whether the admin has filled in OAuth client
+  // ID/secret for this provider. Without that, the Connect button
+  // can't lead anywhere useful.
+  configured: boolean
+  href: string
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '10px 14px',
+        background: 'rgba(20,18,28,0.03)',
+        border: '1px solid var(--line)',
+        borderRadius: 10,
+      }}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 10, fontSize: 14, color: 'var(--ink)' }}>
+        {icon}
+        {name}
+      </span>
+      {connected ? (
+        <span className="n-pill n-pill-ok" style={{ fontSize: 11 }}>
+          <span className="n-pill-dot" />
+          connected
+        </span>
+      ) : configured ? (
+        // Direct browser navigation rather than an axios call: the
+        // OAuth dance must hit the provider via top-level redirects.
+        <a
+          href={href}
+          className="n-btn"
+          style={{ fontSize: 12, padding: '6px 12px', textDecoration: 'none' }}
+        >
+          Connect
+        </a>
+      ) : (
+        <span
+          className="n-pill"
+          style={{
+            fontSize: 11,
+            color: 'var(--ink-mute)',
+            background: 'rgba(20,18,28,0.04)',
+            border: '1px solid var(--line)',
+          }}
+          title={`${name} OAuth isn't configured on this Nimbus instance yet — ask an admin to add the client ID/secret.`}
+        >
+          provider not configured
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Email.tsx
+++ b/frontend/src/pages/Email.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from 'react'
+import { getSMTPSettings, saveSMTPSettings } from '@/api/client'
+import type { SMTPSettingsView, SaveSMTPRequest } from '@/api/client'
+
+// Email — admin-only SMTP configuration. Today the saved config is
+// dormant: nothing reads it for sending yet. The /users page's
+// "Email N unlinked users" button gates on this card's Configured +
+// Enabled state, but the actual recovery-email send pipeline lands in
+// a follow-up release. Storing now (vs. later) means the schema and
+// form scaffolding are ready when send wires up.
+//
+// Password handling follows the standard "edit secrets" pattern:
+// leave the field blank to keep the existing stored value (the
+// placeholder shows ••••••••), or type a new one to replace it. The
+// request omits `password` when blank, sends the new value otherwise.
+// Backend encrypts at rest with the same secrets.Cipher used for the
+// SSH key vault.
+export default function Email() {
+  const [view, setView] = useState<SMTPSettingsView | null>(null)
+  const [host, setHost] = useState('')
+  const [port, setPort] = useState(587)
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [fromAddress, setFromAddress] = useState('')
+  const [encryption, setEncryption] = useState<'starttls' | 'tls' | 'none'>('starttls')
+  const [enabled, setEnabled] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getSMTPSettings()
+      .then((v) => {
+        setView(v)
+        setHost(v.host)
+        setPort(v.port || 587)
+        setUsername(v.username)
+        setFromAddress(v.from_address)
+        setEncryption((v.encryption as 'starttls' | 'tls' | 'none') || 'starttls')
+        setEnabled(v.enabled)
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed to load'))
+  }, [])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSaved(false)
+    setBusy(true)
+    try {
+      const req: SaveSMTPRequest = {
+        host: host.trim(),
+        port,
+        username: username.trim(),
+        from_address: fromAddress.trim(),
+        encryption,
+        enabled,
+      }
+      if (password) req.password = password
+      const next = await saveSMTPSettings(req)
+      setView(next)
+      setPassword('')
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2500)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'save failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <div>
+        <h1 className="n-display" style={{ fontSize: 28, margin: '0 0 6px', display: 'inline-flex', alignItems: 'center', gap: 10 }}>
+          Email
+          <span className="font-mono text-[9px] uppercase tracking-widest text-warn bg-[rgba(184,101,15,0.12)] border border-[rgba(184,101,15,0.25)] px-1.5 py-0.5 rounded">
+            Preview
+          </span>
+        </h1>
+        <p style={{ margin: 0, fontSize: 14, color: 'var(--ink-body)' }}>
+          Outbound SMTP for account-recovery emails. Configure once here;
+          the Users page can then trigger magic-link emails to password-only
+          users. The send pipeline itself ships in a follow-up release —
+          credentials saved here stay dormant until then.
+        </p>
+      </div>
+
+      {view === null && !error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>Loading…</p>
+      )}
+
+      {error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--err)' }}>{error}</p>
+      )}
+
+      {view && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+          <div className="lg:col-span-2">
+            <form onSubmit={submit} className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+                  SMTP server
+                </span>
+                {view.configured && view.enabled ? (
+                  <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
+                    <span className="n-pill-dot" />
+                    enabled
+                  </span>
+                ) : view.configured ? (
+                  <span
+                    className="n-pill"
+                    style={{
+                      fontSize: 10,
+                      color: 'var(--warn)',
+                      background: 'rgba(184,101,15,0.10)',
+                      border: '1px solid rgba(184,101,15,0.25)',
+                    }}
+                  >
+                    configured · disabled
+                  </span>
+                ) : (
+                  <span
+                    className="n-pill"
+                    style={{
+                      fontSize: 10,
+                      color: 'var(--ink-mute)',
+                      background: 'rgba(20,18,28,0.04)',
+                      border: '1px solid var(--line)',
+                    }}
+                  >
+                    not configured
+                  </span>
+                )}
+              </div>
+
+              <div className="n-field">
+                <label className="n-label" htmlFor="smtp-host">Host</label>
+                <input
+                  id="smtp-host"
+                  className="n-input"
+                  type="text"
+                  placeholder="smtp.example.com"
+                  value={host}
+                  onChange={(e) => setHost(e.target.value)}
+                  required
+                />
+              </div>
+
+              <div style={{ display: 'flex', gap: 12 }}>
+                <div className="n-field" style={{ flex: '0 0 120px' }}>
+                  <label className="n-label" htmlFor="smtp-port">Port</label>
+                  <input
+                    id="smtp-port"
+                    className="n-input"
+                    type="number"
+                    min={1}
+                    max={65535}
+                    value={port}
+                    onChange={(e) => setPort(Number(e.target.value) || 587)}
+                  />
+                </div>
+                <div className="n-field" style={{ flex: 1 }}>
+                  <label className="n-label" htmlFor="smtp-encryption">Encryption</label>
+                  <select
+                    id="smtp-encryption"
+                    className="n-input"
+                    value={encryption}
+                    onChange={(e) => setEncryption(e.target.value as 'starttls' | 'tls' | 'none')}
+                  >
+                    <option value="starttls">STARTTLS (port 587)</option>
+                    <option value="tls">TLS (port 465)</option>
+                    <option value="none">None — plain SMTP</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className="n-field">
+                <label className="n-label" htmlFor="smtp-username">Username</label>
+                <input
+                  id="smtp-username"
+                  className="n-input"
+                  type="text"
+                  placeholder="apikey, postmaster@…, etc."
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                />
+              </div>
+
+              <div className="n-field">
+                <label className="n-label" htmlFor="smtp-password">
+                  Password{view.has_password ? <span style={{ marginLeft: 8, fontSize: 11, color: 'var(--ink-mute)' }}>· stored — leave blank to keep</span> : null}
+                </label>
+                <input
+                  id="smtp-password"
+                  className="n-input"
+                  type="password"
+                  placeholder={view.has_password ? '••••••••' : ''}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete="new-password"
+                />
+              </div>
+
+              <div className="n-field">
+                <label className="n-label" htmlFor="smtp-from">From address</label>
+                <input
+                  id="smtp-from"
+                  className="n-input"
+                  type="email"
+                  placeholder="nimbus@example.com"
+                  value={fromAddress}
+                  onChange={(e) => setFromAddress(e.target.value)}
+                  required
+                />
+              </div>
+
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 10,
+                  padding: '10px 12px',
+                  border: '1px solid var(--line)',
+                  borderRadius: 10,
+                  cursor: 'pointer',
+                  background: enabled ? 'rgba(20,18,28,0.05)' : 'rgba(20,18,28,0.02)',
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={enabled}
+                  onChange={(e) => setEnabled(e.target.checked)}
+                  style={{ marginTop: 3 }}
+                />
+                <span>
+                  <span style={{ display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+                    Enable outbound mail
+                  </span>
+                  <span style={{ display: 'block', fontSize: 12, color: 'var(--ink-body)', lineHeight: 1.5, marginTop: 2 }}>
+                    Off by default. Flip on once you've tested credentials in
+                    your provider's web UI — turning this on is the gate that
+                    unlocks the email-stragglers button on the Users page.
+                  </span>
+                </span>
+              </label>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 4 }}>
+                <button
+                  type="submit"
+                  className="n-btn n-btn-primary"
+                  disabled={busy}
+                  style={{ minWidth: 100 }}
+                >
+                  {busy ? 'Saving…' : 'Save'}
+                </button>
+                {saved && <span style={{ fontSize: 13, color: 'var(--ok)' }}>Saved.</span>}
+              </div>
+            </form>
+          </div>
+
+          <div className="lg:col-span-1">
+            <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+                What this powers
+              </span>
+              <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
+                Once SMTP is enabled and the send pipeline ships, admins on
+                /users can email password-only accounts a magic-link
+                recovery URL. Clicking the link signs the user in (and
+                unsuspends them if needed) and drops them on /account so
+                they can connect Google or GitHub.
+              </p>
+              <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
+                Until then the button stays disabled. Saving credentials
+                here is harmless — the server stores them encrypted but
+                doesn't dial out yet.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -848,8 +848,9 @@ export default function Users() {
           <ProvidersSummary
             settings={settings}
             onEdit={(p) => setEditingProvider(p)}
+            refreshTick={refreshTick}
+            onMutated={refreshAll}
           />
-          <PasswordlessPanel refreshTick={refreshTick} onMutated={refreshAll} />
         </div>
       </div>
 
@@ -884,33 +885,61 @@ type PendingAction =
 // want the user to have to refresh to see that. refreshTick is the
 // inbound counterpart: when another panel mutates, the parent bumps
 // the tick and we re-fetch.
-// Each chip narrows the visible set; chips combine with AND (so e.g.
-// Admins + Unverified shows admins who haven't completed access-code
-// verification). A user is "password-only" when their providers slice
-// is exactly ["password"] — having Google or GitHub also linked moves
-// them out of straggler territory.
-type ChipFilter = 'admins' | 'suspended' | 'unverified' | 'passwordOnly'
+// Filter dimensions — each is a dropdown with an "any" sentinel that
+// disables filtering on that axis. Combinations AND together: pick
+// "Members" + "Unverified" + "Password-only" to find members who
+// haven't verified and have no OAuth, the typical straggler set.
+type RoleFilter = 'any' | 'admin' | 'member'
+type StatusFilter = 'any' | 'active' | 'suspended'
+type VerifiedFilter = 'any' | 'verified' | 'unverified'
+type ProviderFilter = 'any' | 'password-only' | 'has-oauth'
 
-const CHIPS: { id: ChipFilter; label: string }[] = [
-  { id: 'admins', label: 'Admins' },
-  { id: 'suspended', label: 'Suspended' },
-  { id: 'unverified', label: 'Unverified' },
-  { id: 'passwordOnly', label: 'Password-only' },
-]
+interface UserFilters {
+  role: RoleFilter
+  status: StatusFilter
+  verified: VerifiedFilter
+  provider: ProviderFilter
+  search: string
+}
 
-function rowMatchesFilters(u: UserManagementView, search: string, active: Set<ChipFilter>): boolean {
-  if (active.has('admins') && !u.is_admin) return false
-  if (active.has('suspended') && !u.suspended) return false
-  if (active.has('unverified') && u.verified) return false
-  if (active.has('passwordOnly')) {
+const DEFAULT_FILTERS: UserFilters = {
+  role: 'any',
+  status: 'any',
+  verified: 'any',
+  provider: 'any',
+  search: '',
+}
+
+function rowMatchesFilters(u: UserManagementView, f: UserFilters): boolean {
+  if (f.role === 'admin' && !u.is_admin) return false
+  if (f.role === 'member' && u.is_admin) return false
+  if (f.status === 'active' && u.suspended) return false
+  if (f.status === 'suspended' && !u.suspended) return false
+  if (f.verified === 'verified' && !u.verified) return false
+  if (f.verified === 'unverified' && u.verified) return false
+  if (f.provider === 'password-only') {
     const onlyPassword = u.providers.length === 1 && u.providers[0] === 'password'
     if (!onlyPassword) return false
   }
-  if (search) {
-    const q = search.toLowerCase()
+  if (f.provider === 'has-oauth') {
+    const hasOAuth = u.providers.includes('google') || u.providers.includes('github')
+    if (!hasOAuth) return false
+  }
+  if (f.search) {
+    const q = f.search.toLowerCase()
     if (!u.name.toLowerCase().includes(q) && !u.email.toLowerCase().includes(q)) return false
   }
   return true
+}
+
+function filtersAreActive(f: UserFilters): boolean {
+  return (
+    f.role !== 'any' ||
+    f.status !== 'any' ||
+    f.verified !== 'any' ||
+    f.provider !== 'any' ||
+    f.search.trim() !== ''
+  )
 }
 
 function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated: () => void }) {
@@ -918,8 +947,7 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
   const [rows, setRows] = useState<UserManagementView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState<PendingAction>(null)
-  const [search, setSearch] = useState('')
-  const [activeChips, setActiveChips] = useState<Set<ChipFilter>>(new Set())
+  const [filters, setFilters] = useState<UserFilters>(DEFAULT_FILTERS)
 
   useEffect(() => {
     listUsers()
@@ -929,21 +957,12 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
 
   const filteredRows = useMemo(() => {
     if (!rows) return null
-    return rows.filter((u) => rowMatchesFilters(u, search.trim(), activeChips))
-  }, [rows, search, activeChips])
-
-  const toggleChip = (id: ChipFilter) => {
-    setActiveChips((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
+    return rows.filter((u) => rowMatchesFilters(u, filters))
+  }, [rows, filters])
 
   const filteredCount = filteredRows?.length ?? 0
   const totalCount = rows?.length ?? 0
-  const filtersActive = search.trim() !== '' || activeChips.size > 0
+  const filtersActive = filtersAreActive(filters)
 
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
@@ -959,69 +978,86 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
       </div>
 
       {rows !== null && rows.length > 0 && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          <input
-            type="search"
-            className="n-input"
-            placeholder="Search by name or email…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            style={{ height: 36, fontSize: 13 }}
-          />
-          <div style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 6 }}>
-            {CHIPS.map((c) => {
-              const active = activeChips.has(c.id)
-              return (
-                <button
-                  key={c.id}
-                  type="button"
-                  onClick={() => toggleChip(c.id)}
-                  className="n-btn-ghost"
-                  style={{
-                    fontSize: 11,
-                    fontFamily: 'Geist Mono, monospace',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.06em',
-                    padding: '4px 10px',
-                    height: 26,
-                    borderRadius: 999,
-                    border: '1px solid',
-                    borderColor: active ? 'var(--ink)' : 'var(--line-strong)',
-                    background: active ? 'var(--ink)' : 'transparent',
-                    color: active ? '#FCFBFA' : 'var(--ink-body)',
-                    cursor: 'pointer',
-                    transition: 'all 0.12s ease',
-                  }}
-                >
-                  {c.label}
-                </button>
-              )
-            })}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {/* Filter row: four small dropdowns. Each "Any …" option is
+              the disable-this-axis sentinel; combinations AND together. */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+            <FilterSelect
+              ariaLabel="Role"
+              value={filters.role}
+              onChange={(v) => setFilters((f) => ({ ...f, role: v as RoleFilter }))}
+              options={[
+                { value: 'any', label: 'Any role' },
+                { value: 'admin', label: 'Admins' },
+                { value: 'member', label: 'Members' },
+              ]}
+            />
+            <FilterSelect
+              ariaLabel="Status"
+              value={filters.status}
+              onChange={(v) => setFilters((f) => ({ ...f, status: v as StatusFilter }))}
+              options={[
+                { value: 'any', label: 'Any status' },
+                { value: 'active', label: 'Active' },
+                { value: 'suspended', label: 'Suspended' },
+              ]}
+            />
+            <FilterSelect
+              ariaLabel="Verification"
+              value={filters.verified}
+              onChange={(v) => setFilters((f) => ({ ...f, verified: v as VerifiedFilter }))}
+              options={[
+                { value: 'any', label: 'Any verification' },
+                { value: 'verified', label: 'Verified' },
+                { value: 'unverified', label: 'Unverified' },
+              ]}
+            />
+            <FilterSelect
+              ariaLabel="Sign-in"
+              value={filters.provider}
+              onChange={(v) => setFilters((f) => ({ ...f, provider: v as ProviderFilter }))}
+              options={[
+                { value: 'any', label: 'Any sign-in' },
+                { value: 'has-oauth', label: 'OAuth-linked' },
+                { value: 'password-only', label: 'Password-only' },
+              ]}
+            />
             {filtersActive && (
               <button
                 type="button"
-                onClick={() => {
-                  setSearch('')
-                  setActiveChips(new Set())
-                }}
+                onClick={() => setFilters(DEFAULT_FILTERS)}
                 className="n-btn-ghost"
                 style={{
                   fontSize: 11,
                   fontFamily: 'Geist Mono, monospace',
                   textTransform: 'uppercase',
                   letterSpacing: '0.06em',
-                  padding: '4px 10px',
-                  height: 26,
+                  padding: '4px 8px',
+                  height: 28,
                   cursor: 'pointer',
                   color: 'var(--ink-mute)',
-                  background: 'transparent',
-                  border: 'none',
                 }}
               >
                 Clear
               </button>
             )}
           </div>
+          <input
+            type="search"
+            placeholder="Search by name or email…"
+            value={filters.search}
+            onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
+            style={{
+              height: 30,
+              fontSize: 12,
+              padding: '0 10px',
+              borderRadius: 6,
+              border: '1px solid var(--line-strong)',
+              background: 'var(--surface)',
+              color: 'var(--ink)',
+              outline: 'none',
+            }}
+          />
         </div>
       )}
 
@@ -1552,13 +1588,63 @@ function formatJoined(iso: string): string {
 // button per row. Pressing a pencil opens a modal scoped to *that*
 // provider — no shared "Configure" surface, since most operators only
 // touch one provider per visit.
+// ProvidersSummary now also hosts the passwordless-sign-in toggle —
+// it's the same conceptual scope (sign-in providers + which sign-in
+// surfaces are exposed on the login page), so giving it its own card
+// was overkill. The toggle and bulk-suspend live in a divided second
+// section so the OAuth client config stays the visual anchor.
 function ProvidersSummary({
   settings,
   onEdit,
+  refreshTick,
+  onMutated,
 }: {
   settings: OAuthSettingsView | null
   onEdit: (provider: 'google' | 'github') => void
+  refreshTick: number
+  onMutated: () => void
 }) {
+  const [status, setStatus] = useState<PasswordlessStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getPasswordlessStatus()
+      .then(setStatus)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
+  }, [refreshTick])
+
+  const toggle = async () => {
+    if (!status) return
+    setError(null)
+    setBusy(true)
+    try {
+      const next = await setPasswordlessAuth(!status.passwordless_goal)
+      setStatus(next)
+      onMutated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const bulkSuspend = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      const { suspended } = await suspendUnlinkedUsers()
+      onMutated()
+      if (suspended === 0) {
+        setError('No users needed suspending.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
       <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
@@ -1582,6 +1668,70 @@ function ProvidersSummary({
           onEdit={() => onEdit('github')}
         />
       </div>
+
+      <div style={{ height: 1, background: 'var(--line)', margin: '4px 0' }} />
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+          Passwordless sign-in
+        </span>
+        {status?.passwordless_goal && (
+          <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
+            <span className="n-pill-dot" />
+            active
+          </span>
+        )}
+      </div>
+
+      {status && (
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 10,
+            padding: '10px 12px',
+            border: '1px solid var(--line)',
+            borderRadius: 10,
+            cursor: busy ? 'wait' : 'pointer',
+            background: status.passwordless_goal ? 'rgba(20,18,28,0.05)' : 'rgba(20,18,28,0.02)',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={status.passwordless_goal}
+            disabled={busy}
+            onChange={toggle}
+            style={{ marginTop: 3 }}
+          />
+          <span>
+            <span style={{ display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+              Require OAuth sign-in
+            </span>
+            <span style={{ display: 'block', fontSize: 12, color: 'var(--ink-body)', lineHeight: 1.5, marginTop: 2 }}>
+              {status.passwordless_goal
+                ? 'Password form is hidden on the sign-in page.'
+                : status.stragglers === 0
+                  ? 'Every active user has OAuth linked. Toggle on to hide the password form.'
+                  : `${status.stragglers} active user${status.stragglers === 1 ? '' : 's'} still depend${status.stragglers === 1 ? 's' : ''} on password sign-in. Suspend or delete them before enabling.`}
+            </span>
+          </span>
+        </label>
+      )}
+
+      {status && !status.passwordless_goal && status.stragglers > 0 && (
+        <button
+          type="button"
+          className="n-btn"
+          onClick={bulkSuspend}
+          disabled={busy}
+          style={{ alignSelf: 'flex-start', fontSize: 12, padding: '6px 12px', height: 32 }}
+          title="Suspends every active password-only user so you can flip the toggle. They keep their data and can be unsuspended later."
+        >
+          {busy ? 'Working…' : `Suspend ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
+        </button>
+      )}
+
+      {error && <p style={{ margin: 0, fontSize: 12, color: 'var(--err)' }}>{error}</p>}
     </div>
   )
 }
@@ -1657,135 +1807,53 @@ function PencilIcon() {
   )
 }
 
-// PasswordlessPanel surfaces the OAuth-only-sign-in toggle. The
-// backend hard-gates enabling: the requesting admin must have OAuth
-// linked themselves AND zero active password-only users can remain.
-// We surface the rejection messages verbatim from the server (409
-// with the service error string) so the admin sees exactly what's
-// blocking the toggle, and we offer a one-click "Suspend stragglers"
-// affordance so they can clear the gate without manually walking
-// every row in the table.
-function PasswordlessPanel({ refreshTick, onMutated }: { refreshTick: number; onMutated: () => void }) {
-  const [status, setStatus] = useState<PasswordlessStatus | null>(null)
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  // Re-fetch on parent tick so suspending or unsuspending a user from
-  // the table immediately moves the straggler count + bulk-suspend
-  // button on this panel without a page refresh.
-  useEffect(() => {
-    getPasswordlessStatus()
-      .then(setStatus)
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
-  }, [refreshTick])
-
-  const toggle = async () => {
-    if (!status) return
-    setError(null)
-    setBusy(true)
-    try {
-      const next = await setPasswordlessAuth(!status.passwordless_goal)
-      setStatus(next)
-      // Notify parent so the table picks up any side effects (none
-      // today, but cheap insurance against future toggle behaviour).
-      onMutated()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'failed')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const bulkSuspend = async () => {
-    setError(null)
-    setBusy(true)
-    try {
-      const { suspended } = await suspendUnlinkedUsers()
-      // Suspending stragglers updates every dependent count — kick
-      // the parent so the user table re-renders with the suspended
-      // pills and dimmed rows alongside our straggler-count drop.
-      onMutated()
-      if (suspended === 0) {
-        setError('No users needed suspending.')
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'failed')
-    } finally {
-      setBusy(false)
-    }
-  }
-
+// FilterSelect is a small, dense dropdown for the row of axis filters
+// above the user table. Native <select> for accessibility (keyboard
+// open, screen-reader announce) styled inline so it lines up with
+// the table's compact aesthetic. The "Any …" option always sits at
+// the top of every list — picking it disables that axis.
+function FilterSelect({
+  ariaLabel,
+  value,
+  onChange,
+  options,
+}: {
+  ariaLabel: string
+  value: string
+  onChange: (next: string) => void
+  options: { value: string; label: string }[]
+}) {
+  const isDefault = options[0]?.value === value
   return (
-    <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
-          Passwordless sign-in
-        </span>
-        {status?.passwordless_goal && (
-          <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
-            <span className="n-pill-dot" />
-            active
-          </span>
-        )}
-      </div>
-      <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
-        Hides the password form on the sign-in page so only Google /
-        GitHub buttons remain. Can only be enabled once every active
-        user has linked an OAuth provider — link your own account from
-        the Account page first, then suspend or delete the stragglers
-        below.
-      </p>
-
-      {status && (
-        <label
-          style={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: 10,
-            padding: '10px 12px',
-            border: '1px solid var(--line)',
-            borderRadius: 10,
-            cursor: busy ? 'wait' : 'pointer',
-            background: status.passwordless_goal ? 'rgba(20,18,28,0.05)' : 'rgba(20,18,28,0.02)',
-          }}
-        >
-          <input
-            type="checkbox"
-            checked={status.passwordless_goal}
-            disabled={busy}
-            onChange={toggle}
-            style={{ marginTop: 3 }}
-          />
-          <span>
-            <span style={{ display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
-              Require OAuth sign-in
-            </span>
-            <span style={{ display: 'block', fontSize: 12, color: 'var(--ink-body)', lineHeight: 1.5, marginTop: 2 }}>
-              {status.passwordless_goal
-                ? 'Password form is hidden on the sign-in page.'
-                : status.stragglers === 0
-                  ? 'Every active user has OAuth linked. Toggle on to hide the password form.'
-                  : `${status.stragglers} active user${status.stragglers === 1 ? '' : 's'} still depend${status.stragglers === 1 ? 's' : ''} on password sign-in. Suspend or delete them before enabling.`}
-            </span>
-          </span>
-        </label>
-      )}
-
-      {status && !status.passwordless_goal && status.stragglers > 0 && (
-        <button
-          type="button"
-          className="n-btn"
-          onClick={bulkSuspend}
-          disabled={busy}
-          style={{ alignSelf: 'flex-start', fontSize: 12, padding: '6px 12px' }}
-          title="Suspends every active password-only user so you can flip the toggle. They keep their data and can be unsuspended later."
-        >
-          {busy ? 'Working…' : `Suspend ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
-        </button>
-      )}
-
-      {error && <p style={{ margin: 0, fontSize: 12, color: 'var(--err)' }}>{error}</p>}
-    </div>
+    <select
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      style={{
+        height: 28,
+        fontSize: 12,
+        padding: '0 24px 0 10px',
+        borderRadius: 6,
+        border: '1px solid var(--line-strong)',
+        background: isDefault ? 'transparent' : 'var(--ink)',
+        color: isDefault ? 'var(--ink-body)' : '#FCFBFA',
+        cursor: 'pointer',
+        appearance: 'none',
+        WebkitAppearance: 'none',
+        MozAppearance: 'none',
+        // Inline caret so the select reads as a dropdown without
+        // pulling in the OS-native chrome.
+        backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='none' stroke='${isDefault ? '%2363606E' : '%23FCFBFA'}' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l4 4 4-4'/></svg>")`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'right 8px center',
+      }}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
   )
 }
 

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { GithubIcon, GoogleIcon } from '@/components/nimbus'
 import {
@@ -884,17 +884,66 @@ type PendingAction =
 // want the user to have to refresh to see that. refreshTick is the
 // inbound counterpart: when another panel mutates, the parent bumps
 // the tick and we re-fetch.
+// Each chip narrows the visible set; chips combine with AND (so e.g.
+// Admins + Unverified shows admins who haven't completed access-code
+// verification). A user is "password-only" when their providers slice
+// is exactly ["password"] — having Google or GitHub also linked moves
+// them out of straggler territory.
+type ChipFilter = 'admins' | 'suspended' | 'unverified' | 'passwordOnly'
+
+const CHIPS: { id: ChipFilter; label: string }[] = [
+  { id: 'admins', label: 'Admins' },
+  { id: 'suspended', label: 'Suspended' },
+  { id: 'unverified', label: 'Unverified' },
+  { id: 'passwordOnly', label: 'Password-only' },
+]
+
+function rowMatchesFilters(u: UserManagementView, search: string, active: Set<ChipFilter>): boolean {
+  if (active.has('admins') && !u.is_admin) return false
+  if (active.has('suspended') && !u.suspended) return false
+  if (active.has('unverified') && u.verified) return false
+  if (active.has('passwordOnly')) {
+    const onlyPassword = u.providers.length === 1 && u.providers[0] === 'password'
+    if (!onlyPassword) return false
+  }
+  if (search) {
+    const q = search.toLowerCase()
+    if (!u.name.toLowerCase().includes(q) && !u.email.toLowerCase().includes(q)) return false
+  }
+  return true
+}
+
 function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated: () => void }) {
   const { user: me } = useAuth()
   const [rows, setRows] = useState<UserManagementView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState<PendingAction>(null)
+  const [search, setSearch] = useState('')
+  const [activeChips, setActiveChips] = useState<Set<ChipFilter>>(new Set())
 
   useEffect(() => {
     listUsers()
       .then(setRows)
       .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
   }, [refreshTick])
+
+  const filteredRows = useMemo(() => {
+    if (!rows) return null
+    return rows.filter((u) => rowMatchesFilters(u, search.trim(), activeChips))
+  }, [rows, search, activeChips])
+
+  const toggleChip = (id: ChipFilter) => {
+    setActiveChips((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const filteredCount = filteredRows?.length ?? 0
+  const totalCount = rows?.length ?? 0
+  const filtersActive = search.trim() !== '' || activeChips.size > 0
 
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
@@ -904,10 +953,77 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
         </span>
         {rows !== null && (
           <span style={{ fontSize: 12, color: 'var(--ink-mute)' }}>
-            {rows.length} {rows.length === 1 ? 'user' : 'users'}
+            {filtersActive ? `${filteredCount} of ${totalCount}` : `${totalCount} ${totalCount === 1 ? 'user' : 'users'}`}
           </span>
         )}
       </div>
+
+      {rows !== null && rows.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <input
+            type="search"
+            className="n-input"
+            placeholder="Search by name or email…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ height: 36, fontSize: 13 }}
+          />
+          <div style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 6 }}>
+            {CHIPS.map((c) => {
+              const active = activeChips.has(c.id)
+              return (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => toggleChip(c.id)}
+                  className="n-btn-ghost"
+                  style={{
+                    fontSize: 11,
+                    fontFamily: 'Geist Mono, monospace',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    padding: '4px 10px',
+                    height: 26,
+                    borderRadius: 999,
+                    border: '1px solid',
+                    borderColor: active ? 'var(--ink)' : 'var(--line-strong)',
+                    background: active ? 'var(--ink)' : 'transparent',
+                    color: active ? '#FCFBFA' : 'var(--ink-body)',
+                    cursor: 'pointer',
+                    transition: 'all 0.12s ease',
+                  }}
+                >
+                  {c.label}
+                </button>
+              )
+            })}
+            {filtersActive && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearch('')
+                  setActiveChips(new Set())
+                }}
+                className="n-btn-ghost"
+                style={{
+                  fontSize: 11,
+                  fontFamily: 'Geist Mono, monospace',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  padding: '4px 10px',
+                  height: 26,
+                  cursor: 'pointer',
+                  color: 'var(--ink-mute)',
+                  background: 'transparent',
+                  border: 'none',
+                }}
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        </div>
+      )}
 
       {rows === null && !error && (
         <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>Loading…</p>
@@ -920,7 +1036,12 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
           No accounts yet.
         </p>
       )}
-      {rows !== null && rows.length > 0 && (
+      {rows !== null && rows.length > 0 && filteredRows !== null && filteredRows.length === 0 && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>
+          No accounts match the active filters.
+        </p>
+      )}
+      {filteredRows !== null && filteredRows.length > 0 && (
         <div style={{ overflowX: 'auto', margin: '0 -8px' }}>
           <table className="w-full text-left" style={{ fontSize: 13, borderCollapse: 'collapse' }}>
             <thead>
@@ -934,7 +1055,7 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
               </tr>
             </thead>
             <tbody>
-              {rows.map((u) => (
+              {filteredRows.map((u) => (
                 <tr
                   key={u.id}
                   style={{ borderTop: '1px solid var(--line)', opacity: u.suspended ? 0.55 : 1 }}

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -15,6 +15,8 @@ import {
   saveAuthorizedGoogleDomains,
   saveOAuthSettings,
   setPasswordlessAuth,
+  setUserSuspended,
+  suspendUnlinkedUsers,
 } from '@/api/client'
 import type {
   AccessCodeView,
@@ -926,7 +928,7 @@ function UsersTable() {
               {rows.map((u) => (
                 <tr
                   key={u.id}
-                  style={{ borderTop: '1px solid var(--line)' }}
+                  style={{ borderTop: '1px solid var(--line)', opacity: u.suspended ? 0.55 : 1 }}
                 >
                   <td style={{ padding: '10px 8px', color: 'var(--ink)', fontWeight: 500 }}>
                     {u.name || <span style={{ color: 'var(--ink-mute)' }}>—</span>}
@@ -949,6 +951,14 @@ function UsersTable() {
                       isSelf={me?.id === u.id}
                       onPromote={() => setPending({ kind: 'promote', user: u })}
                       onDelete={() => setPending({ kind: 'delete', user: u })}
+                      onSuspend={async () => {
+                        try {
+                          await setUserSuspended(u.id, !u.suspended)
+                          reload()
+                        } catch (err) {
+                          setError(err instanceof Error ? err.message : 'failed')
+                        }
+                      }}
                     />
                   </td>
                 </tr>
@@ -991,11 +1001,13 @@ function UserRowActions({
   isSelf,
   onPromote,
   onDelete,
+  onSuspend,
 }: {
   user: UserManagementView
   isSelf: boolean
   onPromote: () => void
   onDelete: () => void
+  onSuspend: () => void
 }) {
   if (isSelf) {
     return <span style={{ fontSize: 11, color: 'var(--ink-mute)' }}>—</span>
@@ -1034,6 +1046,13 @@ function UserRowActions({
           Already an admin
         </span>
       )}
+      <button
+        type="button"
+        onClick={dismissAndDo(onSuspend)}
+        className="block w-full text-left px-3 py-1.5 text-[13px] text-ink hover:bg-[rgba(27,23,38,0.05)] cursor-pointer"
+      >
+        {user.suspended ? 'Unsuspend' : 'Suspend'}
+      </button>
       <div className="my-1 border-t border-line" />
       <button
         type="button"
@@ -1345,7 +1364,26 @@ function UserStatusPills({ user }: { user: UserManagementView }) {
           admin
         </span>
       ) : null}
-      {user.verified ? (
+      {user.suspended ? (
+        // suspended dominates the status column — verified state is
+        // moot when the user can't sign in.
+        <span
+          className="font-mono"
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            padding: '2px 6px',
+            borderRadius: 4,
+            color: 'var(--err)',
+            background: 'rgba(184,55,55,0.08)',
+            border: '1px solid rgba(184,55,55,0.25)',
+          }}
+        >
+          suspended
+        </span>
+      ) : user.verified ? (
         <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
           <span className="n-pill-dot" />
           verified
@@ -1489,12 +1527,14 @@ function PencilIcon() {
   )
 }
 
-// PasswordlessPanel surfaces the admin's "remove password sign-in"
-// preference and the live stragglers count. Toggling on while the
-// requesting admin has no OAuth linked is rejected by the backend
-// (returns 409 with ErrRequesterNotLinked) — we surface the message
-// inline so they understand what to do next: link their own account
-// first via /account.
+// PasswordlessPanel surfaces the OAuth-only-sign-in toggle. The
+// backend hard-gates enabling: the requesting admin must have OAuth
+// linked themselves AND zero active password-only users can remain.
+// We surface the rejection messages verbatim from the server (409
+// with the service error string) so the admin sees exactly what's
+// blocking the toggle, and we offer a one-click "Suspend stragglers"
+// affordance so they can clear the gate without manually walking
+// every row in the table.
 function PasswordlessPanel() {
   const [status, setStatus] = useState<PasswordlessStatus | null>(null)
   const [busy, setBusy] = useState(false)
@@ -1522,36 +1562,44 @@ function PasswordlessPanel() {
     }
   }
 
+  const bulkSuspend = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      const { suspended } = await suspendUnlinkedUsers()
+      reload()
+      // Best-effort UX: surface the count so the admin knows the
+      // bulk action ran. We use the error slot rendered in green-ish
+      // tone — but realistically use a transient inline message.
+      if (suspended === 0) {
+        setError('No users needed suspending.')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 12 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
           Passwordless sign-in
         </span>
-        {status?.password_active === false && (
+        {status?.passwordless_goal && (
           <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
             <span className="n-pill-dot" />
             active
           </span>
         )}
-        {status?.passwordless_goal && status?.password_active && (
-          <span
-            className="n-pill"
-            style={{
-              fontSize: 10,
-              color: 'var(--warn)',
-              background: 'rgba(184,101,15,0.10)',
-              border: '1px solid rgba(184,101,15,0.25)',
-            }}
-          >
-            transitioning
-          </span>
-        )}
       </div>
       <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
-        When enabled, the sign-in page hides the password form once every
-        user has linked an OAuth provider. Until then, password sign-in
-        stays available so users can sign in to add their OAuth link.
+        Hides the password form on the sign-in page so only Google /
+        GitHub buttons remain. Can only be enabled once every active
+        user has linked an OAuth provider — link your own account from
+        the Account page first, then suspend or delete the stragglers
+        below.
       </p>
 
       {status && (
@@ -1580,13 +1628,26 @@ function PasswordlessPanel() {
             </span>
             <span style={{ display: 'block', fontSize: 12, color: 'var(--ink-body)', lineHeight: 1.5, marginTop: 2 }}>
               {status.passwordless_goal
-                ? status.stragglers === 0
-                  ? 'All users have linked OAuth. Password sign-in is hidden on the login page.'
-                  : `${status.stragglers} user${status.stragglers === 1 ? '' : 's'} still need${status.stragglers === 1 ? 's' : ''} to link OAuth or be removed before password sign-in disappears from the login page.`
-                : 'Password sign-in is currently allowed alongside OAuth.'}
+                ? 'Password form is hidden on the sign-in page.'
+                : status.stragglers === 0
+                  ? 'Every active user has OAuth linked. Toggle on to hide the password form.'
+                  : `${status.stragglers} active user${status.stragglers === 1 ? '' : 's'} still depend${status.stragglers === 1 ? 's' : ''} on password sign-in. Suspend or delete them before enabling.`}
             </span>
           </span>
         </label>
+      )}
+
+      {status && !status.passwordless_goal && status.stragglers > 0 && (
+        <button
+          type="button"
+          className="n-btn"
+          onClick={bulkSuspend}
+          disabled={busy}
+          style={{ alignSelf: 'flex-start', fontSize: 12, padding: '6px 12px' }}
+          title="Suspends every active password-only user so you can flip the toggle. They keep their data and can be unsuspended later."
+        >
+          {busy ? 'Working…' : `Suspend ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
+        </button>
       )}
 
       {error && <p style={{ margin: 0, fontSize: 12, color: 'var(--err)' }}>{error}</p>}

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { GithubIcon, GoogleIcon } from '@/components/nimbus'
 import {
@@ -789,6 +789,13 @@ export default function Users() {
   const [settings, setSettings] = useState<OAuthSettingsView | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [editingProvider, setEditingProvider] = useState<EditingProvider>(null)
+  // refreshTick is the parent-owned signal that mutations from one
+  // panel (e.g. the user-row "Suspend" action) need to invalidate the
+  // other (the PasswordlessPanel's straggler count). Both children
+  // re-fetch when this ticks. Using a counter rather than a callback
+  // bus keeps each panel's own load logic local.
+  const [refreshTick, setRefreshTick] = useState(0)
+  const refreshAll = useCallback(() => setRefreshTick((t) => t + 1), [])
 
   useEffect(() => {
     getOAuthSettings()
@@ -834,7 +841,7 @@ export default function Users() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
         <div className="lg:col-span-2 flex flex-col gap-6">
-          <UsersTable />
+          <UsersTable refreshTick={refreshTick} onMutated={refreshAll} />
         </div>
         <div className="lg:col-span-1 flex flex-col gap-6">
           <AccessCodePanel />
@@ -842,7 +849,7 @@ export default function Users() {
             settings={settings}
             onEdit={(p) => setEditingProvider(p)}
           />
-          <PasswordlessPanel />
+          <PasswordlessPanel refreshTick={refreshTick} onMutated={refreshAll} />
         </div>
       </div>
 
@@ -871,21 +878,23 @@ type PendingAction =
   | { kind: 'delete'; user: UserManagementView }
   | null
 
-function UsersTable() {
+// onMutated bubbles every successful row-action up to the parent so the
+// PasswordlessPanel's straggler count stays in sync — suspending a row
+// here changes whether the OAuth-only toggle is reachable, and we don't
+// want the user to have to refresh to see that. refreshTick is the
+// inbound counterpart: when another panel mutates, the parent bumps
+// the tick and we re-fetch.
+function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated: () => void }) {
   const { user: me } = useAuth()
   const [rows, setRows] = useState<UserManagementView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState<PendingAction>(null)
 
-  const reload = () => {
+  useEffect(() => {
     listUsers()
       .then(setRows)
       .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
-  }
-
-  useEffect(() => {
-    reload()
-  }, [])
+  }, [refreshTick])
 
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
@@ -954,7 +963,7 @@ function UsersTable() {
                       onSuspend={async () => {
                         try {
                           await setUserSuspended(u.id, !u.suspended)
-                          reload()
+                          onMutated()
                         } catch (err) {
                           setError(err instanceof Error ? err.message : 'failed')
                         }
@@ -974,7 +983,7 @@ function UsersTable() {
           onClose={() => setPending(null)}
           onPromoted={() => {
             setPending(null)
-            reload()
+            onMutated()
           }}
         />
       )}
@@ -984,7 +993,7 @@ function UsersTable() {
           onClose={() => setPending(null)}
           onDeleted={() => {
             setPending(null)
-            reload()
+            onMutated()
           }}
         />
       )}
@@ -1535,18 +1544,19 @@ function PencilIcon() {
 // blocking the toggle, and we offer a one-click "Suspend stragglers"
 // affordance so they can clear the gate without manually walking
 // every row in the table.
-function PasswordlessPanel() {
+function PasswordlessPanel({ refreshTick, onMutated }: { refreshTick: number; onMutated: () => void }) {
   const [status, setStatus] = useState<PasswordlessStatus | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const reload = () => {
+  // Re-fetch on parent tick so suspending or unsuspending a user from
+  // the table immediately moves the straggler count + bulk-suspend
+  // button on this panel without a page refresh.
+  useEffect(() => {
     getPasswordlessStatus()
       .then(setStatus)
       .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
-  }
-
-  useEffect(reload, [])
+  }, [refreshTick])
 
   const toggle = async () => {
     if (!status) return
@@ -1555,6 +1565,9 @@ function PasswordlessPanel() {
     try {
       const next = await setPasswordlessAuth(!status.passwordless_goal)
       setStatus(next)
+      // Notify parent so the table picks up any side effects (none
+      // today, but cheap insurance against future toggle behaviour).
+      onMutated()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'failed')
     } finally {
@@ -1567,10 +1580,10 @@ function PasswordlessPanel() {
     setBusy(true)
     try {
       const { suspended } = await suspendUnlinkedUsers()
-      reload()
-      // Best-effort UX: surface the count so the admin knows the
-      // bulk action ran. We use the error slot rendered in green-ish
-      // tone — but realistically use a transient inline message.
+      // Suspending stragglers updates every dependent count — kick
+      // the parent so the user table re-renders with the suspended
+      // pills and dimmed rows alongside our straggler-count drop.
+      onMutated()
       if (suspended === 0) {
         setError('No users needed suspending.')
       }

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -978,77 +978,61 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
       </div>
 
       {rows !== null && rows.length > 0 && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {/* Filter row: four small dropdowns. Each "Any …" option is
-              the disable-this-axis sentinel; combinations AND together. */}
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
-            <FilterSelect
-              ariaLabel="Role"
-              value={filters.role}
-              onChange={(v) => setFilters((f) => ({ ...f, role: v as RoleFilter }))}
-              options={[
-                { value: 'any', label: 'Any role' },
-                { value: 'admin', label: 'Admins' },
-                { value: 'member', label: 'Members' },
-              ]}
-            />
-            <FilterSelect
-              ariaLabel="Status"
-              value={filters.status}
-              onChange={(v) => setFilters((f) => ({ ...f, status: v as StatusFilter }))}
-              options={[
-                { value: 'any', label: 'Any status' },
-                { value: 'active', label: 'Active' },
-                { value: 'suspended', label: 'Suspended' },
-              ]}
-            />
-            <FilterSelect
-              ariaLabel="Verification"
-              value={filters.verified}
-              onChange={(v) => setFilters((f) => ({ ...f, verified: v as VerifiedFilter }))}
-              options={[
-                { value: 'any', label: 'Any verification' },
-                { value: 'verified', label: 'Verified' },
-                { value: 'unverified', label: 'Unverified' },
-              ]}
-            />
-            <FilterSelect
-              ariaLabel="Sign-in"
-              value={filters.provider}
-              onChange={(v) => setFilters((f) => ({ ...f, provider: v as ProviderFilter }))}
-              options={[
-                { value: 'any', label: 'Any sign-in' },
-                { value: 'has-oauth', label: 'OAuth-linked' },
-                { value: 'password-only', label: 'Password-only' },
-              ]}
-            />
-            {filtersActive && (
-              <button
-                type="button"
-                onClick={() => setFilters(DEFAULT_FILTERS)}
-                className="n-btn-ghost"
-                style={{
-                  fontSize: 11,
-                  fontFamily: 'Geist Mono, monospace',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.06em',
-                  padding: '4px 8px',
-                  height: 28,
-                  cursor: 'pointer',
-                  color: 'var(--ink-mute)',
-                }}
-              >
-                Clear
-              </button>
-            )}
-          </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+          {/* Filter row: four compact dropdowns then a flex-growing
+              search input as the last column. flex-wrap lets the search
+              drop to its own line on narrow viewports rather than
+              squeezing everything. Combinations AND across axes; "Any …"
+              disables that axis. */}
+          <FilterSelect
+            ariaLabel="Role"
+            value={filters.role}
+            onChange={(v) => setFilters((f) => ({ ...f, role: v as RoleFilter }))}
+            options={[
+              { value: 'any', label: 'Any role' },
+              { value: 'admin', label: 'Admins' },
+              { value: 'member', label: 'Members' },
+            ]}
+          />
+          <FilterSelect
+            ariaLabel="Status"
+            value={filters.status}
+            onChange={(v) => setFilters((f) => ({ ...f, status: v as StatusFilter }))}
+            options={[
+              { value: 'any', label: 'Any status' },
+              { value: 'active', label: 'Active' },
+              { value: 'suspended', label: 'Suspended' },
+            ]}
+          />
+          <FilterSelect
+            ariaLabel="Verification"
+            value={filters.verified}
+            onChange={(v) => setFilters((f) => ({ ...f, verified: v as VerifiedFilter }))}
+            options={[
+              { value: 'any', label: 'Any verification' },
+              { value: 'verified', label: 'Verified' },
+              { value: 'unverified', label: 'Unverified' },
+            ]}
+          />
+          <FilterSelect
+            ariaLabel="Sign-in"
+            value={filters.provider}
+            onChange={(v) => setFilters((f) => ({ ...f, provider: v as ProviderFilter }))}
+            options={[
+              { value: 'any', label: 'Any sign-in' },
+              { value: 'has-oauth', label: 'OAuth-linked' },
+              { value: 'password-only', label: 'Password-only' },
+            ]}
+          />
           <input
             type="search"
             placeholder="Search by name or email…"
             value={filters.search}
             onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
             style={{
-              height: 30,
+              flex: 1,
+              minWidth: 160,
+              height: 28,
               fontSize: 12,
               padding: '0 10px',
               borderRadius: 6,
@@ -1058,6 +1042,25 @@ function UsersTable({ refreshTick, onMutated }: { refreshTick: number; onMutated
               outline: 'none',
             }}
           />
+          {filtersActive && (
+            <button
+              type="button"
+              onClick={() => setFilters(DEFAULT_FILTERS)}
+              className="n-btn-ghost"
+              style={{
+                fontSize: 11,
+                fontFamily: 'Geist Mono, monospace',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                padding: '4px 8px',
+                height: 28,
+                cursor: 'pointer',
+                color: 'var(--ink-mute)',
+              }}
+            >
+              Clear
+            </button>
+          )}
         </div>
       )}
 
@@ -1809,9 +1812,17 @@ function PencilIcon() {
 
 // FilterSelect is a small, dense dropdown for the row of axis filters
 // above the user table. Native <select> for accessibility (keyboard
-// open, screen-reader announce) styled inline so it lines up with
-// the table's compact aesthetic. The "Any …" option always sits at
-// the top of every list — picking it disables that axis.
+// open, screen-reader announce) styled inline. The "Any …" option
+// always sits at the top of every list — picking it disables that
+// axis.
+//
+// Active state is signalled by a stronger border and a faint tint,
+// not by flipping the whole control to a dark fill. The dark-fill
+// approach broke on browsers that don't fully honour `appearance:
+// none` for selects (Firefox/Win, some Chromium configs render the
+// OS-native "filled select" chrome — a striped/zigzag pattern —
+// over our background, looking horrific). Keeping the surface white
+// dodges the issue entirely.
 function FilterSelect({
   ariaLabel,
   value,
@@ -1834,16 +1845,17 @@ function FilterSelect({
         fontSize: 12,
         padding: '0 24px 0 10px',
         borderRadius: 6,
-        border: '1px solid var(--line-strong)',
-        background: isDefault ? 'transparent' : 'var(--ink)',
-        color: isDefault ? 'var(--ink-body)' : '#FCFBFA',
+        border: `1px solid ${isDefault ? 'var(--line-strong)' : 'var(--ink)'}`,
+        backgroundColor: isDefault ? 'var(--surface)' : 'rgba(20, 18, 28, 0.05)',
+        color: 'var(--ink)',
+        fontWeight: isDefault ? 400 : 500,
         cursor: 'pointer',
         appearance: 'none',
         WebkitAppearance: 'none',
         MozAppearance: 'none',
-        // Inline caret so the select reads as a dropdown without
-        // pulling in the OS-native chrome.
-        backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='none' stroke='${isDefault ? '%2363606E' : '%23FCFBFA'}' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l4 4 4-4'/></svg>")`,
+        // Inline caret so the dropdown reads as a select without the
+        // OS-native chrome. Always dark — we never invert.
+        backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='none' stroke='%2363606E' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l4 4 4-4'/></svg>")`,
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'right 8px center',
       }}

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -7,16 +7,19 @@ import {
   getAuthorizedGitHubOrgs,
   getAuthorizedGoogleDomains,
   getOAuthSettings,
+  getPasswordlessStatus,
   listUsers,
   promoteUser,
   regenerateAccessCode,
   saveAuthorizedGitHubOrgs,
   saveAuthorizedGoogleDomains,
   saveOAuthSettings,
+  setPasswordlessAuth,
 } from '@/api/client'
 import type {
   AccessCodeView,
   OAuthSettingsView,
+  PasswordlessStatus,
   UserManagementView,
 } from '@/api/client'
 import NavDropdown from '@/components/ui/NavDropdown'
@@ -837,6 +840,7 @@ export default function Users() {
             settings={settings}
             onEdit={(p) => setEditingProvider(p)}
           />
+          <PasswordlessPanel />
         </div>
       </div>
 
@@ -1482,6 +1486,111 @@ function PencilIcon() {
       <path d="M12 20h9" />
       <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4Z" />
     </svg>
+  )
+}
+
+// PasswordlessPanel surfaces the admin's "remove password sign-in"
+// preference and the live stragglers count. Toggling on while the
+// requesting admin has no OAuth linked is rejected by the backend
+// (returns 409 with ErrRequesterNotLinked) — we surface the message
+// inline so they understand what to do next: link their own account
+// first via /account.
+function PasswordlessPanel() {
+  const [status, setStatus] = useState<PasswordlessStatus | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = () => {
+    getPasswordlessStatus()
+      .then(setStatus)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'failed'))
+  }
+
+  useEffect(reload, [])
+
+  const toggle = async () => {
+    if (!status) return
+    setError(null)
+    setBusy(true)
+    try {
+      const next = await setPasswordlessAuth(!status.passwordless_goal)
+      setStatus(next)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
+          Passwordless sign-in
+        </span>
+        {status?.password_active === false && (
+          <span className="n-pill n-pill-ok" style={{ fontSize: 10 }}>
+            <span className="n-pill-dot" />
+            active
+          </span>
+        )}
+        {status?.passwordless_goal && status?.password_active && (
+          <span
+            className="n-pill"
+            style={{
+              fontSize: 10,
+              color: 'var(--warn)',
+              background: 'rgba(184,101,15,0.10)',
+              border: '1px solid rgba(184,101,15,0.25)',
+            }}
+          >
+            transitioning
+          </span>
+        )}
+      </div>
+      <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
+        When enabled, the sign-in page hides the password form once every
+        user has linked an OAuth provider. Until then, password sign-in
+        stays available so users can sign in to add their OAuth link.
+      </p>
+
+      {status && (
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 10,
+            padding: '10px 12px',
+            border: '1px solid var(--line)',
+            borderRadius: 10,
+            cursor: busy ? 'wait' : 'pointer',
+            background: status.passwordless_goal ? 'rgba(20,18,28,0.05)' : 'rgba(20,18,28,0.02)',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={status.passwordless_goal}
+            disabled={busy}
+            onChange={toggle}
+            style={{ marginTop: 3 }}
+          />
+          <span>
+            <span style={{ display: 'block', fontSize: 13, fontWeight: 600, color: 'var(--ink)' }}>
+              Require OAuth sign-in
+            </span>
+            <span style={{ display: 'block', fontSize: 12, color: 'var(--ink-body)', lineHeight: 1.5, marginTop: 2 }}>
+              {status.passwordless_goal
+                ? status.stragglers === 0
+                  ? 'All users have linked OAuth. Password sign-in is hidden on the login page.'
+                  : `${status.stragglers} user${status.stragglers === 1 ? '' : 's'} still need${status.stragglers === 1 ? 's' : ''} to link OAuth or be removed before password sign-in disappears from the login page.`
+                : 'Password sign-in is currently allowed alongside OAuth.'}
+            </span>
+          </span>
+        </label>
+      )}
+
+      {error && <p style={{ margin: 0, fontSize: 12, color: 'var(--err)' }}>{error}</p>}
+    </div>
   )
 }
 

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -1722,16 +1722,38 @@ function ProvidersSummary({
       )}
 
       {status && !status.passwordless_goal && status.stragglers > 0 && (
-        <button
-          type="button"
-          className="n-btn"
-          onClick={bulkSuspend}
-          disabled={busy}
-          style={{ alignSelf: 'flex-start', fontSize: 12, padding: '6px 12px', height: 32 }}
-          title="Suspends every active password-only user so you can flip the toggle. They keep their data and can be unsuspended later."
-        >
-          {busy ? 'Working…' : `Suspend ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
-        </button>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          <button
+            type="button"
+            className="n-btn"
+            onClick={bulkSuspend}
+            disabled={busy}
+            style={{ fontSize: 12, padding: '6px 12px', height: 32 }}
+            title="Suspends every active password-only user so you can flip the toggle. They keep their data and can be unsuspended later."
+          >
+            {busy ? 'Working…' : `Suspend ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
+          </button>
+          {/* Email-stragglers button. Always disabled today — the send
+              pipeline ships in a follow-up release. Tooltip routes the
+              admin to /email so they can configure SMTP in the meantime;
+              once SMTP is configured + enabled the button stays disabled
+              but shows "Email coming soon" instead of the configure
+              prompt. The first version of the click action will mint
+              magic-link tokens and send recovery emails. */}
+          <button
+            type="button"
+            className="n-btn"
+            disabled
+            style={{ fontSize: 12, padding: '6px 12px', height: 32, cursor: 'not-allowed' }}
+            title={
+              status.smtp_ready
+                ? 'Email recovery is in preview — magic-link send lands in a follow-up release.'
+                : 'SMTP not configured — set up Email in the Control Panel to enable.'
+            }
+          >
+            Email {status.stragglers} unlinked user{status.stragglers === 1 ? '' : 's'}
+          </button>
+        </div>
       )}
 
       {error && <p style={{ margin: 0, fontSize: 12, color: 'var(--err)' }}>{error}</p>}

--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -39,8 +39,17 @@ export default function SignIn() {
   const { displayed, done } = useTypingEffect(HEADING_FULL)
 
   useEffect(() => {
-    getProviders().then(setProviders).catch(() => setProviders({ github: false, google: false }))
+    getProviders()
+      .then(setProviders)
+      .catch(() => setProviders({ github: false, google: false, password: true, passwordless_goal: false }))
   }, [])
+
+  // passwordActive defaults to true while providers are still loading,
+  // so the email/password form doesn't briefly disappear and pop back.
+  // Once the response arrives, we honour what the server tells us:
+  // password sign-in is hidden only when the admin has set the
+  // passwordless goal AND no users are blocking it.
+  const passwordActive = providers ? providers.password : true
 
   const plainVisible = displayed.slice(0, HEADING_PLAIN.length)
   const italicVisible = displayed.slice(HEADING_PLAIN.length)
@@ -130,7 +139,7 @@ export default function SignIn() {
                   </button>
                 )}
               </div>
-              <div className="n-divider" style={{ marginBottom: 20 }}>or</div>
+              {passwordActive && <div className="n-divider" style={{ marginBottom: 20 }}>or</div>}
             </>
           )}
 
@@ -150,51 +159,62 @@ export default function SignIn() {
             </div>
           )}
 
-          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            <div className="n-field">
-              <label className="n-label" htmlFor="signin-email">Email</label>
-              <input
-                id="signin-email"
-                className="n-input"
-                type="email"
-                placeholder="you@example.com"
-                autoComplete="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-            </div>
+          {passwordActive && (
+            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <div className="n-field">
+                <label className="n-label" htmlFor="signin-email">Email</label>
+                <input
+                  id="signin-email"
+                  className="n-input"
+                  type="email"
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+              </div>
 
-            <div className="n-field">
-              <label className="n-label" htmlFor="signin-password">Password</label>
-              <input
-                id="signin-password"
-                className="n-input"
-                type="password"
-                placeholder="••••••••"
-                autoComplete="current-password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-            </div>
+              <div className="n-field">
+                <label className="n-label" htmlFor="signin-password">Password</label>
+                <input
+                  id="signin-password"
+                  className="n-input"
+                  type="password"
+                  placeholder="••••••••"
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
 
-            <button
-              className="n-btn n-btn-primary n-btn-block"
-              type="submit"
-              disabled={loading}
-              style={{ marginTop: 4 }}
-            >
-              {loading ? 'Signing in…' : 'Sign in'}
-            </button>
-          </form>
+              <button
+                className="n-btn n-btn-primary n-btn-block"
+                type="submit"
+                disabled={loading}
+                style={{ marginTop: 4 }}
+              >
+                {loading ? 'Signing in…' : 'Sign in'}
+              </button>
+            </form>
+          )}
 
-          <p style={{ marginTop: 20, textAlign: 'center', fontSize: 13, color: 'var(--ink-mute)' }}>
-            Don&apos;t have an account?{' '}
-            <Link to="/signup" className="n-link" style={{ fontWeight: 500 }}>
-              Create one
-            </Link>
-          </p>
+          {!passwordActive && (
+            <p style={{ marginTop: 8, fontSize: 13, color: 'var(--ink-mute)', lineHeight: 1.5 }}>
+              This workspace requires sign-in via Google or GitHub. Pick a
+              provider above to continue.
+            </p>
+          )}
+
+          {passwordActive && (
+            <p style={{ marginTop: 20, textAlign: 'center', fontSize: 13, color: 'var(--ink-mute)' }}>
+              Don&apos;t have an account?{' '}
+              <Link to="/signup" className="n-link" style={{ fontWeight: 500 }}>
+                Create one
+              </Link>
+            </p>
+          )}
         </div>
 
         <NimbusFooter

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -42,7 +42,9 @@ export default function SignUp() {
   const { displayed, done: typingDone } = useTypingEffect(HEADING_FULL)
 
   useEffect(() => {
-    getProviders().then(setProviders).catch(() => setProviders({ github: false, google: false }))
+    getProviders()
+      .then(setProviders)
+      .catch(() => setProviders({ github: false, google: false, password: true, passwordless_goal: false }))
   }, [])
 
   const plainVisible = displayed.slice(0, HEADING_PLAIN.length)

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -238,6 +238,10 @@ func (a *Auth) Login(w http.ResponseWriter, r *http.Request) {
 		response.Error(w, http.StatusUnauthorized, "Invalid email or password")
 		return
 	}
+	if errors.Is(err, service.ErrUserSuspended) {
+		response.Error(w, http.StatusForbidden, "Account suspended. Contact your admin.")
+		return
+	}
 	if err != nil {
 		response.InternalError(w, "Failed to sign in")
 		return
@@ -491,9 +495,12 @@ func (a *Auth) Account(w http.ResponseWriter, r *http.Request) {
 }
 
 // SetPasswordlessAuth handles PUT /api/settings/oauth/passwordless —
-// admin-only toggle for the "remove password sign-in once everyone
-// has OAuth" intent. The service guards against the requester
-// locking themselves out (must have OAuth linked first).
+// admin-only toggle for the OAuth-only-sign-in setting. Hard gate:
+// the service rejects with ErrRequesterNotLinked when the admin
+// hasn't linked OAuth themselves and ErrStragglersBlock when any
+// active password-only user remains. Both surface as 409 with the
+// service error message so the admin can act on it (link your own
+// account, then suspend or delete the stragglers).
 type passwordlessToggleRequest struct {
 	Enabled bool `json:"enabled"`
 }
@@ -510,7 +517,7 @@ func (a *Auth) SetPasswordlessAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.auth.SetRequirePasswordlessAuth(requester.ID, body.Enabled); err != nil {
-		if errors.Is(err, service.ErrRequesterNotLinked) {
+		if errors.Is(err, service.ErrRequesterNotLinked) || errors.Is(err, service.ErrStragglersBlock) {
 			response.Error(w, http.StatusConflict, err.Error())
 			return
 		}
@@ -533,6 +540,62 @@ func (a *Auth) SetPasswordlessAuth(w http.ResponseWriter, r *http.Request) {
 		"stragglers":        stragglers,
 		"password_active":   active,
 	})
+}
+
+// SuspendUnlinked handles POST /api/users/suspend-unlinked — bulk
+// action that suspends every active user without OAuth (excluding the
+// requester). Used by the passwordless toggle's "Suspend stragglers"
+// button to clear the gate in one click.
+func (a *Auth) SuspendUnlinked(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	count, err := a.auth.SuspendUnlinkedUsers(requester.ID)
+	if err != nil {
+		log.Printf("suspend unlinked: %v", err)
+		response.InternalError(w, "failed to suspend users")
+		return
+	}
+	response.Success(w, map[string]any{"suspended": count})
+}
+
+// suspendRequest is the body of POST /api/users/{id}/suspend-status —
+// a single-user version of the bulk action above.
+type suspendRequest struct {
+	Suspended bool `json:"suspended"`
+}
+
+func (a *Auth) SetSuspended(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	targetID, err := parseUserID(r)
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	var body suspendRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	if err := a.auth.SetUserSuspended(targetID, requester.ID, body.Suspended); err != nil {
+		switch {
+		case errors.Is(err, service.ErrUserNotFound):
+			response.NotFound(w, "user not found")
+		case errors.Is(err, service.ErrCannotSuspendSelf), errors.Is(err, service.ErrCannotSuspendLastAdmin):
+			response.Error(w, http.StatusConflict, err.Error())
+		default:
+			log.Printf("set suspended: %v", err)
+			response.InternalError(w, "failed to update suspension")
+		}
+		return
+	}
+	response.Success(w, map[string]any{"id": targetID, "suspended": body.Suspended})
 }
 
 // PasswordlessStatus handles GET /api/settings/oauth/passwordless —
@@ -788,6 +851,21 @@ func (a *Auth) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/auth/callback?error=link_unauthenticated&provider=github", http.StatusTemporaryRedirect)
 			return
 		}
+		// Conflict guard: if this GitHub identity is already bound to
+		// a different Nimbus user, refuse the link rather than silently
+		// overwriting either side's binding.
+		if userInfo.ProviderID != "" {
+			existing, err := a.auth.FindUserByOAuthIdentity("github", userInfo.ProviderID)
+			if err != nil {
+				log.Printf("github link: lookup by id: %v", err)
+				http.Redirect(w, r, "/account?error=link_failed&provider=github", http.StatusTemporaryRedirect)
+				return
+			}
+			if existing != nil && existing.ID != current.ID {
+				http.Redirect(w, r, "/account?error=already_linked_other&provider=github", http.StatusTemporaryRedirect)
+				return
+			}
+		}
 		// Update the user's org snapshot (so the dynamic org bypass
 		// reflects this login) without minting a session. We touch the
 		// row directly rather than going through UpsertGitHubOAuthUser
@@ -798,7 +876,12 @@ func (a *Auth) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := a.auth.UpdateGitHubLinkSnapshot(current.ID, orgs); err != nil {
 			log.Printf("github link: update snapshot: %v", err)
-			http.Redirect(w, r, "/auth/callback?error=link_failed&provider=github", http.StatusTemporaryRedirect)
+			http.Redirect(w, r, "/account?error=link_failed&provider=github", http.StatusTemporaryRedirect)
+			return
+		}
+		if err := a.auth.MarkGitHubConnected(current.ID, userInfo.ProviderID); err != nil {
+			log.Printf("github link: mark connected: %v", err)
+			http.Redirect(w, r, "/account?error=link_failed&provider=github", http.StatusTemporaryRedirect)
 			return
 		}
 		http.Redirect(w, r, "/account?linked=github", http.StatusTemporaryRedirect)
@@ -808,8 +891,12 @@ func (a *Auth) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 	// allowCreate is intentionally permissive here — the gate above already
 	// rejected unauthorized users when the gate is on. When the gate is off,
 	// new accounts are allowed (and will fall into the access code flow).
-	user, _, err := a.auth.UpsertGitHubOAuthUser(userInfo.Name, userInfo.Email, userInfo.Orgs, nil)
+	user, _, err := a.auth.UpsertGitHubOAuthUser(userInfo.Name, userInfo.Email, userInfo.ProviderID, userInfo.Orgs, nil)
 	if err != nil {
+		if errors.Is(err, service.ErrUserSuspended) {
+			http.Redirect(w, r, "/auth/callback?error=account_suspended&provider=github", http.StatusTemporaryRedirect)
+			return
+		}
 		http.Redirect(w, r, "/auth/callback?error=user_failed&provider=github", http.StatusTemporaryRedirect)
 		return
 	}
@@ -909,25 +996,46 @@ func (a *Auth) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/auth/callback?error=link_unauthenticated&provider=google", http.StatusTemporaryRedirect)
 			return
 		}
-		if err := a.auth.MarkGoogleConnected(current.ID); err != nil {
+		// Refuse to link a Google identity that's already bound to a
+		// different Nimbus account — would silently steal sign-in
+		// from the other user. Also surfaced on the /account page so
+		// the operator gets a clear message about the conflict.
+		if userInfo.ProviderID != "" {
+			existing, err := a.auth.FindUserByOAuthIdentity("google", userInfo.ProviderID)
+			if err != nil {
+				log.Printf("google link: lookup by sub: %v", err)
+				http.Redirect(w, r, "/account?error=link_failed&provider=google", http.StatusTemporaryRedirect)
+				return
+			}
+			if existing != nil && existing.ID != current.ID {
+				http.Redirect(w, r, "/account?error=already_linked_other&provider=google", http.StatusTemporaryRedirect)
+				return
+			}
+		}
+		if err := a.auth.MarkGoogleConnected(current.ID, userInfo.ProviderID); err != nil {
 			log.Printf("google link: mark connected: %v", err)
-			http.Redirect(w, r, "/auth/callback?error=link_failed&provider=google", http.StatusTemporaryRedirect)
+			http.Redirect(w, r, "/account?error=link_failed&provider=google", http.StatusTemporaryRedirect)
 			return
 		}
 		http.Redirect(w, r, "/account?linked=google", http.StatusTemporaryRedirect)
 		return
 	}
 
-	user, err := a.auth.UpsertOAuthUser(userInfo.Name, userInfo.Email)
+	user, err := a.auth.UpsertOAuthUser(userInfo.Name, userInfo.Email, userInfo.ProviderID)
 	if err != nil {
+		if errors.Is(err, service.ErrUserSuspended) {
+			http.Redirect(w, r, "/auth/callback?error=account_suspended&provider=google", http.StatusTemporaryRedirect)
+			return
+		}
 		http.Redirect(w, r, "/auth/callback?error=user_failed&provider=google", http.StatusTemporaryRedirect)
 		return
 	}
 
 	// Sign-in mode also records the connection — every Google login,
-	// new or returning, sets google_connected=true so the /account
-	// page and the passwordless straggler check see consistent state.
-	if err := a.auth.MarkGoogleConnected(user.ID); err != nil {
+	// new or returning, sets google_connected=true and stamps the
+	// google_sub so the /account page, the passwordless straggler
+	// check, and the next sign-in's identity lookup all stay in sync.
+	if err := a.auth.MarkGoogleConnected(user.ID, userInfo.ProviderID); err != nil {
 		log.Printf("google sign-in: mark connected: %v", err)
 		// Non-fatal; sign-in continues.
 	}

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -27,6 +27,13 @@ import (
 const (
 	sessionCookieName = "nimbus_sid"
 	oauthStateCookie  = "nimbus_oauth_state"
+	// oauthIntentCookie distinguishes a sign-in OAuth dance from a
+	// link-to-existing-account dance. Set alongside the state cookie at
+	// /api/auth/{provider}/start (intent="signin") or
+	// /api/auth/{provider}/link-start (intent="link"); read by the
+	// shared callback so it can either upsert-by-email or attach the
+	// identity to the current session's user.
+	oauthIntentCookie = "nimbus_oauth_intent"
 )
 
 // loginReconciler is the small interface the Auth handler uses to kick a
@@ -115,18 +122,29 @@ func (a *Auth) googleProvider() oauth.Provider {
 	}
 }
 
-// Providers handles GET /api/auth/providers — public endpoint that tells the
-// frontend which OAuth providers have credentials configured in the DB.
+// Providers handles GET /api/auth/providers — public endpoint the
+// sign-in page consumes. Returns which OAuth providers have
+// credentials configured AND whether the password form should still
+// render. Password sign-in stays available unless the admin has
+// turned on RequirePasswordlessAuth and zero users still depend on
+// password access — see service.IsPasswordSignInActive for the rule.
 func (a *Auth) Providers(w http.ResponseWriter, r *http.Request) {
 	settings, err := a.auth.GetOAuthSettings()
-	if err != nil {
-		response.Success(w, map[string]bool{"github": false, "google": false})
-		return
+	out := map[string]any{
+		"github":            false,
+		"google":            false,
+		"password":          true,
+		"passwordless_goal": false,
 	}
-	response.Success(w, map[string]bool{
-		"github": settings.GitHubClientID != "" && settings.GitHubClientSecret != "",
-		"google": settings.GoogleClientID != "" && settings.GoogleClientSecret != "",
-	})
+	if err == nil {
+		out["github"] = settings.GitHubClientID != "" && settings.GitHubClientSecret != ""
+		out["google"] = settings.GoogleClientID != "" && settings.GoogleClientSecret != ""
+		out["passwordless_goal"] = settings.RequirePasswordlessAuth
+	}
+	if active, err := a.auth.IsPasswordSignInActive(); err == nil {
+		out["password"] = active
+	}
+	response.Success(w, out)
 }
 
 // --- cookie helpers ---------------------------------------------------------
@@ -433,6 +451,121 @@ func (a *Auth) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	response.Success(w, map[string]any{"id": targetID, "vm_action": body.VMAction, "vms_handled": len(owned)})
 }
 
+// accountView is the shape returned by GET /api/account — what the
+// current user sees about themselves on the /account page. Includes
+// the linked-providers flags so the page can render Connect / Connected
+// pills without duplicating the heuristic.
+type accountView struct {
+	ID              uint   `json:"id"`
+	Name            string `json:"name"`
+	Email           string `json:"email"`
+	IsAdmin         bool   `json:"is_admin"`
+	HasPassword     bool   `json:"has_password"`
+	GoogleConnected bool   `json:"google_connected"`
+	GithubConnected bool   `json:"github_connected"`
+}
+
+// Account handles GET /api/account — current user's profile + the
+// linked-providers state so the /account page can decide which
+// Connect buttons to render.
+func (a *Auth) Account(w http.ResponseWriter, r *http.Request) {
+	user := ctxutil.User(r.Context())
+	if user == nil {
+		response.Error(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+	row, err := a.auth.GetUserByID(user.ID)
+	if err != nil {
+		response.InternalError(w, "Failed to load account")
+		return
+	}
+	response.Success(w, accountView{
+		ID:              row.ID,
+		Name:            row.Name,
+		Email:           row.Email,
+		IsAdmin:         row.IsAdmin,
+		HasPassword:     row.PasswordHash != "",
+		GoogleConnected: row.GoogleConnected,
+		GithubConnected: row.GitHubOrgs != "",
+	})
+}
+
+// SetPasswordlessAuth handles PUT /api/settings/oauth/passwordless —
+// admin-only toggle for the "remove password sign-in once everyone
+// has OAuth" intent. The service guards against the requester
+// locking themselves out (must have OAuth linked first).
+type passwordlessToggleRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (a *Auth) SetPasswordlessAuth(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	var body passwordlessToggleRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	if err := a.auth.SetRequirePasswordlessAuth(requester.ID, body.Enabled); err != nil {
+		if errors.Is(err, service.ErrRequesterNotLinked) {
+			response.Error(w, http.StatusConflict, err.Error())
+			return
+		}
+		log.Printf("set passwordless: %v", err)
+		response.InternalError(w, "failed to update setting")
+		return
+	}
+	stragglers, err := a.auth.CountUnlinkedUsers()
+	if err != nil {
+		log.Printf("set passwordless: count stragglers: %v", err)
+		stragglers = 0
+	}
+	active, err := a.auth.IsPasswordSignInActive()
+	if err != nil {
+		log.Printf("set passwordless: is password active: %v", err)
+		active = true
+	}
+	response.Success(w, map[string]any{
+		"passwordless_goal": body.Enabled,
+		"stragglers":        stragglers,
+		"password_active":   active,
+	})
+}
+
+// PasswordlessStatus handles GET /api/settings/oauth/passwordless —
+// admin-only read of the current setting + straggler count, so the
+// /users page can render the toggle and the explanatory banner.
+func (a *Auth) PasswordlessStatus(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	settings, err := a.auth.GetOAuthSettings()
+	if err != nil {
+		response.InternalError(w, "Failed to load settings")
+		return
+	}
+	stragglers, err := a.auth.CountUnlinkedUsers()
+	if err != nil {
+		log.Printf("passwordless status: count stragglers: %v", err)
+		stragglers = 0
+	}
+	active, err := a.auth.IsPasswordSignInActive()
+	if err != nil {
+		log.Printf("passwordless status: active: %v", err)
+		active = true
+	}
+	response.Success(w, map[string]any{
+		"passwordless_goal": settings.RequirePasswordlessAuth,
+		"stragglers":        stragglers,
+		"password_active":   active,
+	})
+}
+
 // VerifyStatus handles GET /api/access-code/status — returns whether the
 // authenticated user is verified against the current access code version.
 func (a *Auth) VerifyStatus(w http.ResponseWriter, r *http.Request) {
@@ -490,9 +623,11 @@ func (a *Auth) Logout(w http.ResponseWriter, r *http.Request) {
 
 // --- shared OAuth helpers ---------------------------------------------------
 
-// oauthStart generates a CSRF state, stores it in a short-lived cookie, and
-// redirects the browser to the provider's authorization URL.
-func (a *Auth) oauthStart(provider oauth.Provider) http.HandlerFunc {
+// oauthStart generates a CSRF state, stores it in a short-lived cookie
+// alongside the intent ("signin" or "link"), and redirects the browser
+// to the provider's authorization URL. The callback reads the intent
+// to decide whether to mint a new session or attach to the current one.
+func (a *Auth) oauthStart(provider oauth.Provider, intent string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if provider == nil {
 			response.Error(w, http.StatusServiceUnavailable, "OAuth provider not configured")
@@ -511,14 +646,67 @@ func (a *Auth) oauthStart(provider oauth.Provider) http.HandlerFunc {
 			SameSite: http.SameSiteLaxMode,
 			MaxAge:   600,
 		})
+		http.SetCookie(w, &http.Cookie{
+			Name:     oauthIntentCookie,
+			Value:    intent,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   600,
+		})
 		http.Redirect(w, r, provider.AuthURL(state), http.StatusTemporaryRedirect)
 	}
+}
+
+// currentSessionUser inspects the session cookie and returns the
+// matching user, or nil when the cookie is missing or invalid. The
+// OAuth callback routes are public (sign-in mode runs them with no
+// pre-existing session), so this lookup happens inside the handler
+// rather than via requireAuth middleware.
+func (a *Auth) currentSessionUser(r *http.Request) *service.UserView {
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil || c.Value == "" {
+		return nil
+	}
+	user, err := a.auth.GetUserBySessionID(c.Value)
+	if err != nil {
+		return nil
+	}
+	return user
+}
+
+// readOAuthIntent fetches the intent cookie. Falls back to "signin" if
+// the cookie is missing — backwards-compat for any in-flight OAuth
+// dances started before this code shipped.
+func readOAuthIntent(r *http.Request) string {
+	c, err := r.Cookie(oauthIntentCookie)
+	if err != nil {
+		return "signin"
+	}
+	if c.Value == "link" {
+		return "link"
+	}
+	return "signin"
+}
+
+// clearOAuthIntent zeroes the intent cookie alongside the state cookie
+// at the end of every callback.
+func clearOAuthIntent(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{Name: oauthIntentCookie, Value: "", Path: "/", MaxAge: -1})
 }
 
 // --- GitHub OAuth -----------------------------------------------------------
 
 func (a *Auth) GitHubStart(w http.ResponseWriter, r *http.Request) {
-	a.oauthStart(a.githubProvider())(w, r)
+	a.oauthStart(a.githubProvider(), "signin")(w, r)
+}
+
+// GitHubLinkStart kicks off a GitHub OAuth dance whose callback will
+// attach the resulting identity to the current session's user instead
+// of creating/finding a user by email. Requires an authenticated
+// session — middleware enforces that at the route level.
+func (a *Auth) GitHubLinkStart(w http.ResponseWriter, r *http.Request) {
+	a.oauthStart(a.githubProvider(), "link")(w, r)
 }
 
 // GitHubCallback wraps the OAuth flow with the authorized-orgs check. New
@@ -585,6 +773,38 @@ func (a *Auth) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	intent := readOAuthIntent(r)
+	clearOAuthIntent(w)
+
+	// Link mode attaches the just-completed identity to the
+	// already-signed-in user — UpsertGitHubOAuthUser still runs (it's
+	// idempotent for existing accounts and refreshes the org snapshot)
+	// but we route success through the /account page instead of the
+	// sign-in callback. A link request with no current session is a
+	// misuse — the route requires auth — but check defensively.
+	if intent == "link" {
+		current := a.currentSessionUser(r)
+		if current == nil {
+			http.Redirect(w, r, "/auth/callback?error=link_unauthenticated&provider=github", http.StatusTemporaryRedirect)
+			return
+		}
+		// Update the user's org snapshot (so the dynamic org bypass
+		// reflects this login) without minting a session. We touch the
+		// row directly rather than going through UpsertGitHubOAuthUser
+		// so we can't accidentally split the user record by email.
+		orgs := strings.Join(userInfo.Orgs, ",")
+		if orgs == "" {
+			orgs = "-" // sentinel — distinguishes "linked, no orgs" from "never linked"
+		}
+		if err := a.auth.UpdateGitHubLinkSnapshot(current.ID, orgs); err != nil {
+			log.Printf("github link: update snapshot: %v", err)
+			http.Redirect(w, r, "/auth/callback?error=link_failed&provider=github", http.StatusTemporaryRedirect)
+			return
+		}
+		http.Redirect(w, r, "/account?linked=github", http.StatusTemporaryRedirect)
+		return
+	}
+
 	// allowCreate is intentionally permissive here — the gate above already
 	// rejected unauthorized users when the gate is on. When the gate is off,
 	// new accounts are allowed (and will fall into the access code flow).
@@ -612,7 +832,14 @@ func (a *Auth) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 // --- Google OAuth -----------------------------------------------------------
 
 func (a *Auth) GoogleStart(w http.ResponseWriter, r *http.Request) {
-	a.oauthStart(a.googleProvider())(w, r)
+	a.oauthStart(a.googleProvider(), "signin")(w, r)
+}
+
+// GoogleLinkStart is the link-mode counterpart of GoogleStart; the
+// callback attaches the identity to the current session's user. See
+// GitHubLinkStart for the rationale.
+func (a *Auth) GoogleLinkStart(w http.ResponseWriter, r *http.Request) {
+	a.oauthStart(a.googleProvider(), "link")(w, r)
 }
 
 // GoogleCallback wraps the shared OAuth callback flow with the
@@ -673,10 +900,36 @@ func (a *Auth) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	intent := readOAuthIntent(r)
+	clearOAuthIntent(w)
+
+	if intent == "link" {
+		current := a.currentSessionUser(r)
+		if current == nil {
+			http.Redirect(w, r, "/auth/callback?error=link_unauthenticated&provider=google", http.StatusTemporaryRedirect)
+			return
+		}
+		if err := a.auth.MarkGoogleConnected(current.ID); err != nil {
+			log.Printf("google link: mark connected: %v", err)
+			http.Redirect(w, r, "/auth/callback?error=link_failed&provider=google", http.StatusTemporaryRedirect)
+			return
+		}
+		http.Redirect(w, r, "/account?linked=google", http.StatusTemporaryRedirect)
+		return
+	}
+
 	user, err := a.auth.UpsertOAuthUser(userInfo.Name, userInfo.Email)
 	if err != nil {
 		http.Redirect(w, r, "/auth/callback?error=user_failed&provider=google", http.StatusTemporaryRedirect)
 		return
+	}
+
+	// Sign-in mode also records the connection — every Google login,
+	// new or returning, sets google_connected=true so the /account
+	// page and the passwordless straggler check see consistent state.
+	if err := a.auth.MarkGoogleConnected(user.ID); err != nil {
+		log.Printf("google sign-in: mark connected: %v", err)
+		// Non-fatal; sign-in continues.
 	}
 
 	// No DB write for the domain bypass — IsUserVerified consults the

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -599,8 +599,10 @@ func (a *Auth) SetSuspended(w http.ResponseWriter, r *http.Request) {
 }
 
 // PasswordlessStatus handles GET /api/settings/oauth/passwordless —
-// admin-only read of the current setting + straggler count, so the
-// /users page can render the toggle and the explanatory banner.
+// admin-only read of the current setting, straggler count, and SMTP
+// readiness. The Users page uses these to render the toggle, the
+// straggler explanation, the bulk-suspend button, and the (currently
+// disabled) "Email N unlinked users" button.
 func (a *Auth) PasswordlessStatus(w http.ResponseWriter, r *http.Request) {
 	requester := ctxutil.User(r.Context())
 	if requester == nil || !requester.IsAdmin {
@@ -622,11 +624,63 @@ func (a *Auth) PasswordlessStatus(w http.ResponseWriter, r *http.Request) {
 		log.Printf("passwordless status: active: %v", err)
 		active = true
 	}
+	smtp, err := a.auth.GetSMTPSettings()
+	if err != nil {
+		log.Printf("passwordless status: smtp: %v", err)
+	}
+	smtpReady := smtp != nil && smtp.Configured && smtp.Enabled
 	response.Success(w, map[string]any{
 		"passwordless_goal": settings.RequirePasswordlessAuth,
 		"stragglers":        stragglers,
 		"password_active":   active,
+		"smtp_ready":        smtpReady,
 	})
+}
+
+// GetSMTP handles GET /api/settings/smtp. Admin-only. Returns the
+// SMTPSettingsView (no ciphertext, just `has_password: bool` so the
+// /email form can render "(unchanged)" placeholder copy).
+func (a *Auth) GetSMTP(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	view, err := a.auth.GetSMTPSettings()
+	if err != nil {
+		log.Printf("get smtp: %v", err)
+		response.InternalError(w, "failed to load SMTP settings")
+		return
+	}
+	response.Success(w, view)
+}
+
+// SaveSMTP handles PUT /api/settings/smtp. Admin-only. The request
+// body's password field follows the standard "edit secrets" pattern:
+// omitting the field leaves the existing ciphertext untouched, sending
+// an empty string clears it, sending a non-empty string replaces it.
+func (a *Auth) SaveSMTP(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	var body service.SaveSMTPRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	view, err := a.auth.SaveSMTPSettings(body)
+	if err != nil {
+		if errors.Is(err, service.ErrCipherUnavailable) {
+			response.Error(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		log.Printf("save smtp: %v", err)
+		response.InternalError(w, "failed to save SMTP settings")
+		return
+	}
+	response.Success(w, view)
 }
 
 // VerifyStatus handles GET /api/access-code/status — returns whether the

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -183,6 +183,8 @@ func NewRouter(d Deps) http.Handler {
 				// members see themselves); these mutations are admin
 				// only.
 				r.Post("/users/{id}/promote", auth.PromoteUser)
+				r.Post("/users/{id}/suspend-status", auth.SetSuspended)
+				r.Post("/users/suspend-unlinked", auth.SuspendUnlinked)
 				r.Delete("/users/{id}", auth.DeleteUser)
 				r.Get("/settings/oauth/passwordless", auth.PasswordlessStatus)
 				r.Put("/settings/oauth/passwordless", auth.SetPasswordlessAuth)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -144,6 +144,13 @@ func NewRouter(d Deps) http.Handler {
 		r.Get("/auth/google", auth.GoogleStart)
 		r.Get("/auth/google/callback", auth.GoogleCallback)
 		r.Get("/auth/providers", auth.Providers)
+		// Link-mode entry points share the OAuth callback handlers
+		// above; they're separate endpoints only at the start to set
+		// the link-intent cookie. Callbacks consult that cookie to
+		// branch behavior. Auth check is inline (the dance returns
+		// here mid-flight, before the new session would exist).
+		r.Get("/auth/github/link", auth.GitHubLinkStart)
+		r.Get("/auth/google/link", auth.GoogleLinkStart)
 
 		// Protected routes — require a valid session cookie
 		r.Group(func(r chi.Router) {
@@ -151,6 +158,7 @@ func NewRouter(d Deps) http.Handler {
 
 			r.Get("/me", auth.Me)
 			r.Get("/users", auth.ListUsers)
+			r.Get("/account", auth.Account)
 
 			// Access-code endpoints — must be reachable WITHOUT being verified,
 			// so the unverified user can submit their code from the Verify page.
@@ -176,6 +184,8 @@ func NewRouter(d Deps) http.Handler {
 				// only.
 				r.Post("/users/{id}/promote", auth.PromoteUser)
 				r.Delete("/users/{id}", auth.DeleteUser)
+				r.Get("/settings/oauth/passwordless", auth.PasswordlessStatus)
+				r.Put("/settings/oauth/passwordless", auth.SetPasswordlessAuth)
 
 				r.Get("/nodes", nodes.List)
 				r.Get("/ips", ips.List)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -188,6 +188,8 @@ func NewRouter(d Deps) http.Handler {
 				r.Delete("/users/{id}", auth.DeleteUser)
 				r.Get("/settings/oauth/passwordless", auth.PasswordlessStatus)
 				r.Put("/settings/oauth/passwordless", auth.SetPasswordlessAuth)
+				r.Get("/settings/smtp", auth.GetSMTP)
+				r.Put("/settings/smtp", auth.SaveSMTP)
 
 				r.Get("/nodes", nodes.List)
 				r.Get("/ips", ips.List)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -91,6 +91,39 @@ type OAuthSettings struct {
 	RequirePasswordlessAuth bool `gorm:"default:false"`
 }
 
+// SMTPSettings holds outbound-mail configuration. Singleton (ID=1).
+// Used by the planned magic-link recovery flow that emails password-only
+// users when an admin moves the workspace to OAuth-only sign-in. The
+// admin populates host/port/from/credentials on the /email page; the
+// password is encrypted at rest via the same secrets.Cipher used for
+// SSH key vault entries (NIMBUS_ENCRYPTION_KEY-derived AES-256-GCM).
+//
+// Today the saved config is dormant — no code reads it for sending yet.
+// The "Email N unlinked users" button on the Sign-in providers card
+// stays disabled until both this is configured AND the send pipeline
+// lands in a follow-up release. Storing now (vs. later) guarantees the
+// schema doesn't need a destructive migration when send arrives.
+type SMTPSettings struct {
+	ID            uint   `gorm:"primaryKey"`
+	Host          string `gorm:"default:''"`
+	Port          int    `gorm:"default:587"`
+	Username      string `gorm:"default:''"`
+	PasswordCT    []byte `gorm:"column:password_ct"`
+	PasswordNonce []byte `gorm:"column:password_nonce"`
+	// FromAddress is the envelope sender. Required for sending — until
+	// it's set we treat SMTP as "not configured" regardless of host.
+	FromAddress string `gorm:"default:''"`
+	// Encryption is "starttls" / "tls" / "none". starttls is the right
+	// default for port 587 (submission); tls for 465 (smtps); none is
+	// only for unauthenticated relays inside trusted networks.
+	Encryption string `gorm:"default:'starttls'"`
+	// Enabled is the admin's manual on/off switch — flipping it off
+	// keeps the credentials but stops the (future) send pipeline from
+	// using them. Useful for temporary outages or migrations without
+	// wiping the form.
+	Enabled bool `gorm:"default:false"`
+}
+
 // GopherSettings stores the Gopher tunnel-gateway credentials. Only a single
 // row (ID=1) is used. Empty APIURL means tunnel integration is disabled.
 //

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -29,9 +29,27 @@ type User struct {
 	GitHubOrgs string `gorm:"default:''" json:"-"`
 	// GoogleConnected is a boolean flag set on every successful Google
 	// OAuth login. Used as the "Google account linked" marker on the
-	// /account page and by the passwordless-mode straggler check. We
-	// don't store the Google email/sub today — just the yes/no.
-	GoogleConnected bool `gorm:"default:false" json:"-"`
+	// /account page and by the passwordless-mode straggler check.
+	// GoogleSub holds the Google account's stable per-user identifier
+	// (the JWT `sub` claim) so subsequent sign-ins match by identity
+	// rather than email — needed when the user's Google email differs
+	// from their Nimbus email.
+	GoogleConnected bool   `gorm:"default:false" json:"-"`
+	GoogleSub       string `gorm:"column:google_sub;index;default:''" json:"-"`
+	// GitHubID is the GitHub account's stable numeric user id (stored
+	// as a string for uniformity with GoogleSub). Same role: identity
+	// matching across email changes. GitHubOrgs continues to track org
+	// membership for the dynamic bypass; GitHubID is purely about
+	// "who is this Nimbus user."
+	GitHubID string `gorm:"column:github_id;index;default:''" json:"-"`
+	// Suspended locks an account out of every sign-in path (password,
+	// Google, GitHub) without deleting their data. Used by the
+	// passwordless transition: an admin can suspend password-only
+	// users in bulk so the OAuth-only toggle stops being blocked,
+	// then unsuspend later (or the user recovers via a future
+	// email-based flow). Suspended users' sessions are revoked at
+	// suspend time.
+	Suspended bool `gorm:"default:false;index" json:"-"`
 }
 
 // Session ties a browser cookie to a user for a limited duration.

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -22,8 +22,16 @@ type User struct {
 	// user belonged to at their last GitHub OAuth login. Used by the
 	// authorized-orgs bypass: IsUserVerified intersects this against the
 	// admin's current authorized-orgs list dynamically. Empty for users who
-	// have never signed in via GitHub.
+	// have never signed in via GitHub. Also doubles as the
+	// GitHub-connected indicator — a non-empty string means the user has
+	// completed at least one GitHub OAuth login (org list may be "-" if
+	// they belong to no orgs).
 	GitHubOrgs string `gorm:"default:''" json:"-"`
+	// GoogleConnected is a boolean flag set on every successful Google
+	// OAuth login. Used as the "Google account linked" marker on the
+	// /account page and by the passwordless-mode straggler check. We
+	// don't store the Google email/sub today — just the yes/no.
+	GoogleConnected bool `gorm:"default:false" json:"-"`
 }
 
 // Session ties a browser cookie to a user for a limited duration.
@@ -56,6 +64,13 @@ type OAuthSettings struct {
 	// org logins. Members of any of these orgs bypass the access code on
 	// GitHub OAuth sign-in. Empty list disables the GitHub bypass.
 	AuthorizedGitHubOrgs string `gorm:"default:''"`
+	// RequirePasswordlessAuth is the admin's declared intent to remove
+	// password sign-in once every user has linked an OAuth provider. The
+	// flag itself doesn't immediately disable the password form — that
+	// would lock out users who still need to link. Instead it gates a
+	// dynamic check: when this is true AND no users still have only
+	// password access, the sign-in page hides the password form.
+	RequirePasswordlessAuth bool `gorm:"default:false"`
 }
 
 // GopherSettings stores the Gopher tunnel-gateway credentials. Only a single

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -26,8 +26,12 @@ var (
 	ErrAccessCodeNotPresent = errors.New("access code not configured")
 	ErrDomainNotAuthorized  = errors.New("email domain not authorized")
 	ErrOrgNotAuthorized     = errors.New("github org not authorized")
-	ErrUserNotFound         = errors.New("user not found")
-	ErrRequesterNotLinked   = errors.New("link an OAuth provider on your own account before requiring passwordless sign-in")
+	ErrUserNotFound           = errors.New("user not found")
+	ErrRequesterNotLinked     = errors.New("link an OAuth provider on your own account before requiring passwordless sign-in")
+	ErrUserSuspended          = errors.New("account suspended")
+	ErrCannotSuspendSelf      = errors.New("cannot suspend yourself")
+	ErrCannotSuspendLastAdmin = errors.New("cannot suspend the last unsuspended admin")
+	ErrStragglersBlock        = errors.New("password-only accounts must be suspended or removed before passwordless sign-in can be required")
 )
 
 const sessionDuration = 7 * 24 * time.Hour
@@ -75,6 +79,10 @@ type UserManagementView struct {
 	// then the explicit access-code match.
 	Verified  bool     `json:"verified"`
 	Providers []string `json:"providers"`
+	// Suspended echoes the user row's flag so the table can render a
+	// muted row + a Suspended pill, and the actions menu can swap
+	// "Suspend" for "Unsuspend".
+	Suspended bool `json:"suspended"`
 }
 
 func userToManagementView(u *db.User, settings *db.OAuthSettings) *UserManagementView {
@@ -82,26 +90,26 @@ func userToManagementView(u *db.User, settings *db.OAuthSettings) *UserManagemen
 		UserView:  userToView(u),
 		CreatedAt: u.CreatedAt,
 		Providers: detectProviders(u),
+		Suspended: u.Suspended,
 	}
 	v.Verified = isUserVerifiedFromSettings(u, settings)
 	return v
 }
 
-// detectProviders is a best-effort sniff of how the user has signed in
-// at least once. PasswordHash != "" means email/password registration;
-// GitHubOrgs is set (even to "-") on every successful GitHub OAuth login.
-// A user with neither is presumed Google-only — we don't store a
-// per-user Google marker today, so the heuristic is "neither password
-// nor github → google". Order is stable: password, github, google.
+// detectProviders reports every sign-in path the user has at least
+// touched. PasswordHash != "" means an email/password registration;
+// GitHubOrgs != "" means a GitHub OAuth handshake (the "-" sentinel is
+// non-empty so it counts); GoogleConnected is set on every successful
+// Google handshake. Order is stable: password, github, google.
 func detectProviders(u *db.User) []string {
-	out := make([]string, 0, 2)
+	out := make([]string, 0, 3)
 	if u.PasswordHash != "" {
 		out = append(out, "password")
 	}
 	if u.GitHubOrgs != "" {
 		out = append(out, "github")
 	}
-	if len(out) == 0 {
+	if u.GoogleConnected {
 		out = append(out, "google")
 	}
 	return out
@@ -174,6 +182,10 @@ func (s *AuthService) Login(email, password string) (string, *UserView, error) {
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
 		return "", nil, ErrInvalidCredentials
+	}
+
+	if user.Suspended {
+		return "", nil, ErrUserSuspended
 	}
 
 	sessionID, err := s.CreateSession(user.ID)
@@ -287,31 +299,51 @@ func (s *AuthService) DeleteUserRecord(targetID uint) error {
 	return nil
 }
 
-// UpsertOAuthUser finds a user by email or creates one if none exists.
-// Used by OAuth providers where a password hash is not applicable.
-func (s *AuthService) UpsertOAuthUser(name, email string) (*UserView, error) {
-	view, _, err := s.UpsertOAuthUserWithCheck(name, email, nil)
+// UpsertOAuthUser finds a user by Google sub (when supplied) or email,
+// creating one if neither matches. Used by the Google sign-in path
+// where there's no domain gate; pass the sub through so the lookup
+// matches on stable identity even if the user's Google email later
+// differs from their Nimbus email.
+func (s *AuthService) UpsertOAuthUser(name, email, providerSub string) (*UserView, error) {
+	view, _, err := s.UpsertOAuthUserWithCheck(name, email, providerSub, nil)
 	return view, err
 }
 
 // UpsertOAuthUserWithCheck behaves like UpsertOAuthUser but invokes
 // allowCreate before creating a brand-new account. Returns
-// ErrDomainNotAuthorized when allowCreate returns false. The bool return
-// indicates whether the user already existed prior to this call.
+// ErrDomainNotAuthorized when allowCreate returns false, or
+// ErrUserSuspended when the matched account is suspended. The bool
+// return indicates whether the user already existed prior to this
+// call.
+//
+// providerSub, when non-empty, lets the lookup match on google_sub
+// before falling back to email. That gives a user whose Google email
+// differs from their Nimbus email a stable binding once they've linked
+// their Google account from /account.
 func (s *AuthService) UpsertOAuthUserWithCheck(
-	name, email string,
+	name, email, providerSub string,
 	allowCreate func(email string) bool,
 ) (*UserView, bool, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
 	name = strings.TrimSpace(name)
 
 	var user db.User
+	if providerSub != "" {
+		if err := s.db.Where("google_sub = ?", providerSub).First(&user).Error; err == nil {
+			if user.Suspended {
+				return nil, true, ErrUserSuspended
+			}
+			return userToView(&user), true, nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, err
+		}
+	}
 	err := s.db.Where("email = ?", email).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		if allowCreate != nil && !allowCreate(email) {
 			return nil, false, ErrDomainNotAuthorized
 		}
-		user = db.User{Name: name, Email: email}
+		user = db.User{Name: name, Email: email, GoogleSub: providerSub}
 		if err := s.db.Create(&user).Error; err != nil {
 			return nil, false, err
 		}
@@ -319,6 +351,9 @@ func (s *AuthService) UpsertOAuthUserWithCheck(
 	}
 	if err != nil {
 		return nil, false, err
+	}
+	if user.Suspended {
+		return nil, true, ErrUserSuspended
 	}
 	return userToView(&user), true, nil
 }
@@ -354,14 +389,157 @@ func (s *AuthService) GetUserByID(id uint) (*db.User, error) {
 	return &u, nil
 }
 
-// MarkGoogleConnected flips the user's google_connected flag to true.
-// Idempotent. Called on every successful Google OAuth login (sign-in
-// or link), giving the /account page and the passwordless-mode
-// straggler check a single source of truth: "this user has completed
-// at least one Google OAuth dance against this Nimbus instance."
-func (s *AuthService) MarkGoogleConnected(userID uint) error {
-	res := s.db.Model(&db.User{}).Where("id = ?", userID).Update("google_connected", true)
+// MarkGoogleConnected flips google_connected and stores the Google
+// `sub` so subsequent sign-ins can match by identity rather than email.
+// Idempotent — re-marking with the same sub is fine; calling with an
+// empty sub leaves the column untouched (so a partial provider response
+// can't wipe an existing binding).
+func (s *AuthService) MarkGoogleConnected(userID uint, sub string) error {
+	updates := map[string]interface{}{"google_connected": true}
+	if sub != "" {
+		updates["google_sub"] = sub
+	}
+	res := s.db.Model(&db.User{}).Where("id = ?", userID).Updates(updates)
 	return res.Error
+}
+
+// MarkGitHubConnected stores the GitHub user id so subsequent sign-ins
+// match by identity. The orgs snapshot is updated separately via
+// UpdateGitHubLinkSnapshot since it changes on every login regardless
+// of whether this is the first link or the hundredth.
+func (s *AuthService) MarkGitHubConnected(userID uint, githubID string) error {
+	if githubID == "" {
+		return nil
+	}
+	return s.db.Model(&db.User{}).Where("id = ?", userID).Update("github_id", githubID).Error
+}
+
+// FindUserByOAuthIdentity looks up a user by the provider-side stable
+// identifier — Google `sub` or GitHub user id. Returns nil + nil error
+// when no user matches (caller falls back to email-based lookup).
+// Returns the row directly rather than UserView because callers need
+// the suspended flag too.
+func (s *AuthService) FindUserByOAuthIdentity(provider, providerID string) (*db.User, error) {
+	if providerID == "" {
+		return nil, nil
+	}
+	var col string
+	switch provider {
+	case "google":
+		col = "google_sub"
+	case "github":
+		col = "github_id"
+	default:
+		return nil, nil
+	}
+	var u db.User
+	err := s.db.Where(col+" = ?", providerID).First(&u).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+// IsUserSuspended returns true when the named user's suspended flag is
+// set. Used by the login + OAuth callback paths so a suspended account
+// can't sign in regardless of how they authenticate.
+func (s *AuthService) IsUserSuspended(userID uint) (bool, error) {
+	var u db.User
+	if err := s.db.Select("suspended").First(&u, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, ErrUserNotFound
+		}
+		return false, err
+	}
+	return u.Suspended, nil
+}
+
+// SetUserSuspended flips the target's suspended flag. Suspending also
+// deletes every session the target had so the change takes effect on
+// the next request rather than waiting for sessions to expire.
+// Unsuspending leaves any other state untouched — the user just signs
+// in normally next time.
+//
+// Refuses to suspend the requester themselves (would log the admin
+// out mid-call) and refuses to suspend the last remaining un-suspended
+// admin (no admin coverage = nobody can unsuspend later).
+func (s *AuthService) SetUserSuspended(targetID, requesterID uint, suspended bool) error {
+	if targetID == requesterID && suspended {
+		return ErrCannotSuspendSelf
+	}
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		var target db.User
+		if err := tx.First(&target, targetID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrUserNotFound
+			}
+			return err
+		}
+		if suspended && target.IsAdmin {
+			var others int64
+			if err := tx.Model(&db.User{}).
+				Where("is_admin = ? AND suspended = ? AND id <> ?", true, false, target.ID).
+				Count(&others).Error; err != nil {
+				return err
+			}
+			if others == 0 {
+				return ErrCannotSuspendLastAdmin
+			}
+		}
+		if err := tx.Model(&db.User{}).Where("id = ?", targetID).Update("suspended", suspended).Error; err != nil {
+			return err
+		}
+		if suspended {
+			if err := tx.Where("user_id = ?", targetID).Delete(&db.Session{}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// SuspendUnlinkedUsers suspends every active (non-suspended) user who
+// has no OAuth provider linked, EXCEPT the requester themselves. Used
+// by the passwordless toggle's "suspend stragglers" affordance — the
+// admin clicks once to clear the path to OAuth-only sign-in, and the
+// system bulk-suspends in a single transaction. Returns the count of
+// users actually suspended (so the UI can confirm "N accounts
+// suspended").
+//
+// The requester is excluded from the bulk action even if they
+// themselves have no OAuth — they'll be caught by the explicit
+// per-toggle pre-check elsewhere (SetRequirePasswordlessAuth requires
+// the requester have OAuth linked) and we never want a bulk action to
+// log out the admin issuing it.
+func (s *AuthService) SuspendUnlinkedUsers(requesterID uint) (int64, error) {
+	var count int64
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		var targets []db.User
+		if err := tx.
+			Where("google_connected = ? AND github_orgs = ? AND suspended = ? AND id <> ?", false, "", false, requesterID).
+			Find(&targets).Error; err != nil {
+			return err
+		}
+		if len(targets) == 0 {
+			return nil
+		}
+		ids := make([]uint, len(targets))
+		for i, t := range targets {
+			ids[i] = t.ID
+		}
+		if err := tx.Model(&db.User{}).Where("id IN ?", ids).Update("suspended", true).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("user_id IN ?", ids).Delete(&db.Session{}).Error; err != nil {
+			return err
+		}
+		count = int64(len(targets))
+		return nil
+	})
+	return count, err
 }
 
 // HasOAuthLinked reports whether the named user has completed at
@@ -379,25 +557,28 @@ func (s *AuthService) HasOAuthLinked(userID uint) (bool, error) {
 	return u.GoogleConnected || u.GitHubOrgs != "", nil
 }
 
-// CountUnlinkedUsers returns how many accounts have no OAuth provider
-// linked — i.e. would be locked out if password sign-in disappeared
-// today. The admin sees this number on /users so they know how many
-// stragglers stand between them and a clean OAuth-only login page.
+// CountUnlinkedUsers returns how many *active* accounts have no OAuth
+// provider linked — i.e. accounts that would be locked out if password
+// sign-in disappeared. Suspended users are excluded: they're already
+// locked out and don't block the passwordless toggle. The admin sees
+// this number on /users alongside the toggle so they know how many
+// stragglers stand between them and OAuth-only sign-in.
 func (s *AuthService) CountUnlinkedUsers() (int64, error) {
 	var n int64
 	err := s.db.Model(&db.User{}).
-		Where("google_connected = ? AND github_orgs = ?", false, "").
+		Where("google_connected = ? AND github_orgs = ? AND suspended = ?", false, "", false).
 		Count(&n).Error
 	return n, err
 }
 
 // IsPasswordSignInActive returns true when the login page should still
-// show the password form. The form stays available until two
-// conditions are both met: the admin has set
-// RequirePasswordlessAuth=true *and* every account has linked at
-// least one OAuth provider. Otherwise we'd lock out password-only
-// users from ever being able to sign in to add OAuth — exactly the
-// bootstrap problem the user flagged.
+// show the password form. With the hard-gate semantics
+// SetRequirePasswordlessAuth enforces, this is now a simple read of
+// the persisted flag — we can trust that a true value means every
+// active user has OAuth linked, because the setter rejected the
+// transition otherwise. The function still exists (rather than reading
+// the flag everywhere) so a future relaxation of the semantics has a
+// single point of change.
 func (s *AuthService) IsPasswordSignInActive() (bool, error) {
 	settings, err := s.GetOAuthSettings()
 	if err != nil {
@@ -406,6 +587,9 @@ func (s *AuthService) IsPasswordSignInActive() (bool, error) {
 	if !settings.RequirePasswordlessAuth {
 		return true, nil
 	}
+	// Defence in depth — even though the setter blocks the toggle
+	// when stragglers exist, also verify here so a hand-edited DB
+	// can't lock the cluster out.
 	stragglers, err := s.CountUnlinkedUsers()
 	if err != nil {
 		return true, err
@@ -413,10 +597,17 @@ func (s *AuthService) IsPasswordSignInActive() (bool, error) {
 	return stragglers > 0, nil
 }
 
-// SetRequirePasswordlessAuth flips the admin's stated intent. The
-// requester must have OAuth linked themselves — otherwise they'd hit
-// the locked-out gate the moment the last straggler clears. Toggling
-// off is unrestricted (you can always go back to allowing passwords).
+// SetRequirePasswordlessAuth flips the OAuth-only-sign-in setting.
+// Hard gate when enabling: the requester must have OAuth linked
+// themselves AND no active (non-suspended) user can be password-only.
+// Suspended users don't count — they're already locked out. Active
+// password-only users would be left un-recoverable, so the setter
+// rejects with ErrStragglersBlock and the admin must suspend or
+// delete them first (see SuspendUnlinkedUsers and the existing
+// /api/users delete endpoint).
+//
+// Toggling off is unrestricted; you can always re-enable password
+// sign-in.
 func (s *AuthService) SetRequirePasswordlessAuth(requesterID uint, enabled bool) error {
 	if enabled {
 		linked, err := s.HasOAuthLinked(requesterID)
@@ -425,6 +616,13 @@ func (s *AuthService) SetRequirePasswordlessAuth(requesterID uint, enabled bool)
 		}
 		if !linked {
 			return ErrRequesterNotLinked
+		}
+		stragglers, err := s.CountUnlinkedUsers()
+		if err != nil {
+			return err
+		}
+		if stragglers > 0 {
+			return ErrStragglersBlock
 		}
 	}
 	settings, err := s.GetOAuthSettings()
@@ -515,16 +713,45 @@ func (s *AuthService) SaveAuthorizedGitHubOrgs(orgs []string) error {
 }
 
 // UpsertGitHubOAuthUser is the GitHub-specific upsert that also snapshots
-// the user's current org memberships into the user row. Mirrors
-// UpsertOAuthUserWithCheck for the allowCreate semantics.
+// the user's current org memberships into the user row and binds the
+// stable GitHub user id (githubID) for identity-based sign-in. Mirrors
+// UpsertOAuthUserWithCheck for the allowCreate semantics. Returns
+// ErrUserSuspended when a matching account is suspended so the caller
+// can short-circuit the OAuth dance.
 func (s *AuthService) UpsertGitHubOAuthUser(
-	name, email string,
+	name, email, githubID string,
 	orgs []string,
 	allowCreate func(orgs []string) bool,
 ) (*UserView, bool, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
 	name = strings.TrimSpace(name)
 	orgsCSV := joinDomains(normalizeDomains(orgs))
+	if orgsCSV == "" {
+		// "-" sentinel marks "linked but no orgs" so the connected
+		// flag isn't ambiguous with "never linked." Match the link
+		// path that records the same value.
+		orgsCSV = "-"
+	}
+
+	// Identity-first lookup: if we've stored this GitHub user id
+	// before, route to that account regardless of email changes.
+	if githubID != "" {
+		var hit db.User
+		err := s.db.Where("github_id = ?", githubID).First(&hit).Error
+		if err == nil {
+			if hit.Suspended {
+				return nil, true, ErrUserSuspended
+			}
+			if err := s.db.Model(&hit).UpdateColumn("git_hub_orgs", orgsCSV).Error; err != nil {
+				return nil, true, err
+			}
+			hit.GitHubOrgs = orgsCSV
+			return userToView(&hit), true, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, err
+		}
+	}
 
 	var user db.User
 	err := s.db.Where("email = ?", email).First(&user).Error
@@ -532,7 +759,7 @@ func (s *AuthService) UpsertGitHubOAuthUser(
 		if allowCreate != nil && !allowCreate(orgs) {
 			return nil, false, ErrOrgNotAuthorized
 		}
-		user = db.User{Name: name, Email: email, GitHubOrgs: orgsCSV}
+		user = db.User{Name: name, Email: email, GitHubOrgs: orgsCSV, GitHubID: githubID}
 		if err := s.db.Create(&user).Error; err != nil {
 			return nil, false, err
 		}
@@ -541,15 +768,23 @@ func (s *AuthService) UpsertGitHubOAuthUser(
 	if err != nil {
 		return nil, false, err
 	}
+	if user.Suspended {
+		return nil, true, ErrUserSuspended
+	}
 	// Refresh the org snapshot on every login so the bypass tracks the
-	// user's current memberships. Using UpdateColumn with the actual DB
-	// column (git_hub_orgs — GORM splits on each uppercase boundary) avoids
-	// hooks and zero-value skipping; an empty orgsCSV is a legitimate value
-	// when the user has no orgs.
-	if err := s.db.Model(&user).UpdateColumn("git_hub_orgs", orgsCSV).Error; err != nil {
+	// user's current memberships, and stamp the github_id so future
+	// sign-ins find this user by identity.
+	updates := map[string]interface{}{"git_hub_orgs": orgsCSV}
+	if githubID != "" && user.GitHubID == "" {
+		updates["github_id"] = githubID
+	}
+	if err := s.db.Model(&user).Updates(updates).Error; err != nil {
 		return nil, true, err
 	}
 	user.GitHubOrgs = orgsCSV
+	if githubID != "" && user.GitHubID == "" {
+		user.GitHubID = githubID
+	}
 	return userToView(&user), true, nil
 }
 
@@ -629,6 +864,9 @@ func (s *AuthService) CreateSession(userID uint) (string, error) {
 }
 
 // GetUserBySessionID returns the user for a valid, non-expired session.
+// Suspended users get treated as no-session — middleware will surface
+// the same 401 they'd see for an expired cookie, kicking them back to
+// the sign-in page.
 func (s *AuthService) GetUserBySessionID(sessionID string) (*UserView, error) {
 	var session db.Session
 	err := s.db.Where("id = ? AND expires_at > ?", sessionID, time.Now()).First(&session).Error
@@ -642,6 +880,9 @@ func (s *AuthService) GetUserBySessionID(sessionID string) (*UserView, error) {
 	var user db.User
 	if err := s.db.First(&user, session.UserID).Error; err != nil {
 		return nil, err
+	}
+	if user.Suspended {
+		return nil, ErrSessionNotFound
 	}
 
 	return userToView(&user), nil

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"nimbus/internal/db"
+	"nimbus/internal/secrets"
 
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -32,18 +33,29 @@ var (
 	ErrCannotSuspendSelf      = errors.New("cannot suspend yourself")
 	ErrCannotSuspendLastAdmin = errors.New("cannot suspend the last unsuspended admin")
 	ErrStragglersBlock        = errors.New("password-only accounts must be suspended or removed before passwordless sign-in can be required")
+	ErrCipherUnavailable      = errors.New("encryption cipher not available; restart the server with NIMBUS_ENCRYPTION_KEY configured")
 )
 
 const sessionDuration = 7 * 24 * time.Hour
 
 // AuthService handles account creation and credential verification.
 type AuthService struct {
-	db *db.DB
+	db     *db.DB
+	cipher *secrets.Cipher
 }
 
 // NewAuthService creates a new AuthService.
 func NewAuthService(database *db.DB) *AuthService {
 	return &AuthService{db: database}
+}
+
+// WithCipher attaches the secrets.Cipher used to encrypt SMTP
+// credentials at rest. Optional — services that don't store
+// secret-bearing settings (tests, the setup wizard) leave it nil.
+// SMTP save returns ErrCipherUnavailable when called without one.
+func (s *AuthService) WithCipher(c *secrets.Cipher) *AuthService {
+	s.cipher = c
+	return s
 }
 
 // RegisterParams holds the input for creating a new account.
@@ -925,6 +937,101 @@ func subtleConstantTimeEq(a, b string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// SMTPSettingsView is the safe-to-serialize projection of SMTPSettings.
+// The encrypted password ciphertext stays inside the service; the UI
+// only sees whether a password is set, not the value.
+type SMTPSettingsView struct {
+	Host         string `json:"host"`
+	Port         int    `json:"port"`
+	Username     string `json:"username"`
+	HasPassword  bool   `json:"has_password"`
+	FromAddress  string `json:"from_address"`
+	Encryption   string `json:"encryption"`
+	Enabled      bool   `json:"enabled"`
+	Configured   bool   `json:"configured"`
+}
+
+// SaveSMTPRequest mirrors the form on /email. An empty password leaves
+// the existing ciphertext intact (so the admin can edit host/port
+// without re-entering credentials); a non-empty password is encrypted
+// and replaces the stored value.
+type SaveSMTPRequest struct {
+	Host        string  `json:"host"`
+	Port        int     `json:"port"`
+	Username    string  `json:"username"`
+	Password    *string `json:"password,omitempty"`
+	FromAddress string  `json:"from_address"`
+	Encryption  string  `json:"encryption"`
+	Enabled     bool    `json:"enabled"`
+}
+
+// GetSMTPSettings returns the persisted SMTP configuration as a view.
+// Creates a default empty row on first call so /email loads with sane
+// defaults instead of a nil shape. Configured = "host + from address
+// are filled" — that's the bare minimum to attempt a send.
+func (s *AuthService) GetSMTPSettings() (*SMTPSettingsView, error) {
+	var row db.SMTPSettings
+	if err := s.db.FirstOrCreate(&row, db.SMTPSettings{ID: 1}).Error; err != nil {
+		return nil, err
+	}
+	return &SMTPSettingsView{
+		Host:        row.Host,
+		Port:        row.Port,
+		Username:    row.Username,
+		HasPassword: len(row.PasswordCT) > 0,
+		FromAddress: row.FromAddress,
+		Encryption:  row.Encryption,
+		Enabled:     row.Enabled,
+		Configured:  row.Host != "" && row.FromAddress != "",
+	}, nil
+}
+
+// SaveSMTPSettings persists the SMTP form. The password (when supplied)
+// is encrypted with the service's secrets.Cipher before storage —
+// callers without a cipher get ErrCipherUnavailable. Encryption mode
+// defaults to "starttls" when blank; port defaults to 587.
+func (s *AuthService) SaveSMTPSettings(req SaveSMTPRequest) (*SMTPSettingsView, error) {
+	var row db.SMTPSettings
+	if err := s.db.FirstOrCreate(&row, db.SMTPSettings{ID: 1}).Error; err != nil {
+		return nil, err
+	}
+	row.Host = strings.TrimSpace(req.Host)
+	row.Username = strings.TrimSpace(req.Username)
+	row.FromAddress = strings.TrimSpace(req.FromAddress)
+	row.Port = req.Port
+	if row.Port == 0 {
+		row.Port = 587
+	}
+	row.Encryption = req.Encryption
+	if row.Encryption == "" {
+		row.Encryption = "starttls"
+	}
+	row.Enabled = req.Enabled
+	if req.Password != nil {
+		if *req.Password == "" {
+			// Explicit empty password → clear the stored ciphertext.
+			// (Distinct from omitting the field, which leaves it
+			// untouched — the *string omitempty distinguishes them.)
+			row.PasswordCT = nil
+			row.PasswordNonce = nil
+		} else {
+			if s.cipher == nil {
+				return nil, ErrCipherUnavailable
+			}
+			ct, nonce, err := s.cipher.Encrypt([]byte(*req.Password))
+			if err != nil {
+				return nil, fmt.Errorf("encrypt smtp password: %w", err)
+			}
+			row.PasswordCT = ct
+			row.PasswordNonce = nonce
+		}
+	}
+	if err := s.db.Save(&row).Error; err != nil {
+		return nil, err
+	}
+	return s.GetSMTPSettings()
 }
 
 // GetGopherSettings returns the stored Gopher tunnel credentials. Creates a

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -365,7 +365,12 @@ func (s *AuthService) UpsertOAuthUserWithCheck(
 // session's user is already established and we just want to record
 // "this user has now linked GitHub."
 func (s *AuthService) UpdateGitHubLinkSnapshot(userID uint, orgsCSV string) error {
-	res := s.db.Model(&db.User{}).Where("id = ?", userID).Update("github_orgs", orgsCSV)
+	// Column is git_hub_orgs — GORM splits on each uppercase boundary
+	// (GitHubOrgs → git_hub_orgs). Hard-coding the column name here
+	// matches the rest of the file (UpsertGitHubOAuthUser does the
+	// same) so we sidestep a UpdateColumn-vs-Update gotcha if the
+	// struct field ever gets renamed.
+	res := s.db.Model(&db.User{}).Where("id = ?", userID).UpdateColumn("git_hub_orgs", orgsCSV)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -519,7 +524,7 @@ func (s *AuthService) SuspendUnlinkedUsers(requesterID uint) (int64, error) {
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var targets []db.User
 		if err := tx.
-			Where("google_connected = ? AND github_orgs = ? AND suspended = ? AND id <> ?", false, "", false, requesterID).
+			Where("google_connected = ? AND git_hub_orgs = ? AND suspended = ? AND id <> ?", false, "", false, requesterID).
 			Find(&targets).Error; err != nil {
 			return err
 		}
@@ -566,7 +571,7 @@ func (s *AuthService) HasOAuthLinked(userID uint) (bool, error) {
 func (s *AuthService) CountUnlinkedUsers() (int64, error) {
 	var n int64
 	err := s.db.Model(&db.User{}).
-		Where("google_connected = ? AND github_orgs = ? AND suspended = ?", false, "", false).
+		Where("google_connected = ? AND git_hub_orgs = ? AND suspended = ?", false, "", false).
 		Count(&n).Error
 	return n, err
 }

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -27,6 +27,7 @@ var (
 	ErrDomainNotAuthorized  = errors.New("email domain not authorized")
 	ErrOrgNotAuthorized     = errors.New("github org not authorized")
 	ErrUserNotFound         = errors.New("user not found")
+	ErrRequesterNotLinked   = errors.New("link an OAuth provider on your own account before requiring passwordless sign-in")
 )
 
 const sessionDuration = 7 * 24 * time.Hour
@@ -320,6 +321,118 @@ func (s *AuthService) UpsertOAuthUserWithCheck(
 		return nil, false, err
 	}
 	return userToView(&user), true, nil
+}
+
+// UpdateGitHubLinkSnapshot writes the user's GitHub orgs snapshot
+// without going through UpsertGitHubOAuthUser, which keys on email
+// and would risk splitting the row if the GitHub email differs from
+// the Nimbus email. Used by the /account link flow where the current
+// session's user is already established and we just want to record
+// "this user has now linked GitHub."
+func (s *AuthService) UpdateGitHubLinkSnapshot(userID uint, orgsCSV string) error {
+	res := s.db.Model(&db.User{}).Where("id = ?", userID).Update("github_orgs", orgsCSV)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// GetUserByID returns the raw User row by primary key. Used by the
+// /account endpoint which needs fields beyond UserView (password hash
+// presence + Google connected flag) to render the Connect buttons.
+func (s *AuthService) GetUserByID(id uint) (*db.User, error) {
+	var u db.User
+	if err := s.db.First(&u, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrUserNotFound
+		}
+		return nil, err
+	}
+	return &u, nil
+}
+
+// MarkGoogleConnected flips the user's google_connected flag to true.
+// Idempotent. Called on every successful Google OAuth login (sign-in
+// or link), giving the /account page and the passwordless-mode
+// straggler check a single source of truth: "this user has completed
+// at least one Google OAuth dance against this Nimbus instance."
+func (s *AuthService) MarkGoogleConnected(userID uint) error {
+	res := s.db.Model(&db.User{}).Where("id = ?", userID).Update("google_connected", true)
+	return res.Error
+}
+
+// HasOAuthLinked reports whether the named user has completed at
+// least one OAuth dance — Google flag set or GitHub orgs snapshot
+// non-empty. The signal both /account and the passwordless setter use
+// to decide "is this user reachable without a password."
+func (s *AuthService) HasOAuthLinked(userID uint) (bool, error) {
+	var u db.User
+	if err := s.db.First(&u, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, ErrUserNotFound
+		}
+		return false, err
+	}
+	return u.GoogleConnected || u.GitHubOrgs != "", nil
+}
+
+// CountUnlinkedUsers returns how many accounts have no OAuth provider
+// linked — i.e. would be locked out if password sign-in disappeared
+// today. The admin sees this number on /users so they know how many
+// stragglers stand between them and a clean OAuth-only login page.
+func (s *AuthService) CountUnlinkedUsers() (int64, error) {
+	var n int64
+	err := s.db.Model(&db.User{}).
+		Where("google_connected = ? AND github_orgs = ?", false, "").
+		Count(&n).Error
+	return n, err
+}
+
+// IsPasswordSignInActive returns true when the login page should still
+// show the password form. The form stays available until two
+// conditions are both met: the admin has set
+// RequirePasswordlessAuth=true *and* every account has linked at
+// least one OAuth provider. Otherwise we'd lock out password-only
+// users from ever being able to sign in to add OAuth — exactly the
+// bootstrap problem the user flagged.
+func (s *AuthService) IsPasswordSignInActive() (bool, error) {
+	settings, err := s.GetOAuthSettings()
+	if err != nil {
+		return true, err
+	}
+	if !settings.RequirePasswordlessAuth {
+		return true, nil
+	}
+	stragglers, err := s.CountUnlinkedUsers()
+	if err != nil {
+		return true, err
+	}
+	return stragglers > 0, nil
+}
+
+// SetRequirePasswordlessAuth flips the admin's stated intent. The
+// requester must have OAuth linked themselves — otherwise they'd hit
+// the locked-out gate the moment the last straggler clears. Toggling
+// off is unrestricted (you can always go back to allowing passwords).
+func (s *AuthService) SetRequirePasswordlessAuth(requesterID uint, enabled bool) error {
+	if enabled {
+		linked, err := s.HasOAuthLinked(requesterID)
+		if err != nil {
+			return err
+		}
+		if !linked {
+			return ErrRequesterNotLinked
+		}
+	}
+	settings, err := s.GetOAuthSettings()
+	if err != nil {
+		return err
+	}
+	settings.RequirePasswordlessAuth = enabled
+	return s.db.Save(&settings).Error
 }
 
 // HasAuthorizedGoogleDomains reports whether the admin has configured at


### PR DESCRIPTION
## Stacked on #225 (which is stacked on #224)

Targets \`feat/user-controls-and-per-provider-edit\` because this work needs the Users page surface from #225 + the /users route from #224. Merge order: **#224 → #225 → #226**, then this rebases cleanly onto main.

## The bootstrap problem this solves

We can't just have an admin flip a switch to "OAuth only" — password-only users would be locked out before they could ever link Google/GitHub. So:

1. **Every signed-in user can link Google/GitHub** from a new \`/account\` page (in the navbar dropdown for admins and members). Linking reuses the existing OAuth machinery with an \`intent=link\` cookie; the same callback either signs the user in (existing behaviour) or attaches the identity to the current session's user.
2. **Admins set passwordless as a goal**, not an immediate kill switch. The login page hides the password form only when (a) the admin has set the goal AND (b) zero users still have only password access. Until the last straggler links or is deleted (via #225's delete-with-VM-disposition flow), the password form stays available.

## Backend

- New service helpers: \`GetUserByID\`, \`UpdateGitHubLinkSnapshot\`, \`MarkGoogleConnected\`, \`HasOAuthLinked\`, \`CountUnlinkedUsers\`, \`IsPasswordSignInActive\`, \`SetRequirePasswordlessAuth\` (with the only guardrail: requester must have OAuth linked themselves — \`ErrRequesterNotLinked\`).
- New handlers: link-start variants (\`GitHubLinkStart\`, \`GoogleLinkStart\`), \`Account\`, \`PasswordlessStatus\`, \`SetPasswordlessAuth\`. \`Providers\` response grew \`password\` and \`passwordless_goal\` fields.
- OAuth callbacks now branch on the link-intent cookie (set alongside state). Sign-in mode is unchanged; link mode looks up the session via inline \`currentSessionUser\`, attaches the identity, redirects to \`/account?linked=...\`.
- New routes: \`GET /api/auth/{provider}/link\`, \`GET /api/account\`, \`GET\`/\`PUT /api/settings/oauth/passwordless\`.
- DB: \`User.GoogleConnected\` (set on every Google login, sign-in or link); \`OAuthSettings.RequirePasswordlessAuth\`.

## Frontend

- **New \`/account\` page** with Profile + Linked-providers cards. Connect buttons drop you into the OAuth flow; on return you land back on \`/account?linked=google|github\` with a brief confirmation pill.
- **Layout dropdown** now has an Account entry for everyone (members also got promoted from \"name + Sign out\" into a proper dropdown).
- **SignIn page** hides the email/password form when \`providers.password\` is false. Falls back to a one-liner: \"This workspace requires sign-in via Google or GitHub. Pick a provider above.\"
- **Users page** gains a \`PasswordlessPanel\` alongside the providers summary — the toggle plus a derived one-liner: \"N users still need to link OAuth or be removed before password sign-in disappears\" (or \"All users have linked OAuth. Password sign-in is hidden on the login page\" once stragglers reach zero).

## Test plan

- [ ] As admin (no OAuth linked), try to enable the toggle: 409 \`ErrRequesterNotLinked\`, surfaced inline. Visit \`/account\`, click Connect Google, complete OAuth — redirected to \`/account?linked=google\` with the connected pill. Re-try the toggle: succeeds.
- [ ] With one password-only user: enable the toggle, observe \"1 user still needs to link OAuth or be removed.\" The sign-in page still shows the password form.
- [ ] Link the straggler's account from their session: banner clears, sign-in page now hides the password form (one-liner replaces it).
- [ ] As a password-only member, log in via password, visit \`/account\`, click Connect GitHub, complete the OAuth dance: GitHub pill flips to connected and the user's GitHub orgs are captured for the dynamic bypass.
- [ ] As a member, the user dropdown shows Account + Sign out (not just the name).
- [ ] Delete user (from #225) still works: removing a password-only straggler also clears them from the count.
- [ ] \`go test ./...\`, \`npm run type-check\`, \`npm run lint\`, \`npm run build\` all clean.