### PR TITLE
fix: retry ResizeDisk on transient pvedaemon worker-spawn failures

### DIFF
--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -515,12 +516,58 @@ func (c *Client) SetClusterTagStyle(ctx context.Context, tagStyle string) error 
 // time because it doesn't bake in an assumption about the cloud image's
 // base size. Shrinking is rejected by Proxmox — passing a value smaller
 // than the current size returns an error.
+//
+// Retries on transient pvedaemon worker-spawn failures (HTTP 500 with
+// "got no worker upid - start worker failed" in the body) up to twice,
+// with 1s and 3s backoff. That class of failure means Proxmox couldn't
+// fork the task-runner — no work happened, so a retry can't double-
+// resize. Other 4xx/5xx still fail fast; we only retry the exact
+// signature we've seen clear up on its own.
 func (c *Client) ResizeDisk(ctx context.Context, node string, vmid int, disk, size string) error {
 	params := url.Values{}
 	params.Set("disk", disk)
 	params.Set("size", size)
 	path := fmt.Sprintf("/nodes/%s/qemu/%d/resize", url.PathEscape(node), vmid)
-	return c.do(ctx, http.MethodPut, path, params, nil)
+
+	backoffs := []time.Duration{0, time.Second, 3 * time.Second}
+	var lastErr error
+	for attempt, wait := range backoffs {
+		if wait > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+		err := c.do(ctx, http.MethodPut, path, params, nil)
+		if err == nil {
+			if attempt > 0 {
+				log.Printf("proxmox resize: vmid=%d succeeded on attempt %d after transient worker-spawn failure", vmid, attempt+1)
+			}
+			return nil
+		}
+		if !isTransientWorkerSpawnFailure(err) {
+			return err
+		}
+		log.Printf("proxmox resize: vmid=%d attempt %d hit transient worker-spawn failure, retrying", vmid, attempt+1)
+		lastErr = err
+	}
+	return fmt.Errorf("resize disk after %d retries: %w", len(backoffs)-1, lastErr)
+}
+
+// isTransientWorkerSpawnFailure matches the specific "got no worker upid -
+// start worker failed" error pvedaemon returns when it can't fork a
+// task-runner process. The condition is brief (usually clears in
+// seconds) and means the worker never started — so any side effects we
+// might be worried about retrying around can't have happened. Other
+// 500s (e.g. "no need to extend disk") fall through unwrapped.
+func isTransientWorkerSpawnFailure(err error) bool {
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	return httpErr.Status == http.StatusInternalServerError &&
+		strings.Contains(httpErr.Body, "got no worker upid")
 }
 
 // StartVM powers on a VM. Returns the task UPID for the start task.

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -897,3 +897,58 @@ func TestClient_DestroyVM(t *testing.T) {
 		t.Errorf("taskID = %q", taskID)
 	}
 }
+
+// TestClient_ResizeDisk_RetriesWorkerSpawn verifies the targeted retry
+// for "got no worker upid" failures: a flaky pvedaemon should produce
+// at most one user-facing failure when the second attempt succeeds.
+// The mock server fails the first PUT with the specific Proxmox error
+// signature, then succeeds on the second.
+//
+// Note: the retry backoff sleeps 1s before the second attempt, so this
+// test takes ~1s. Acceptable for CI; skipped under `-short`.
+func TestClient_ResizeDisk_RetriesWorkerSpawn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping retry test in short mode (sleeps 1s between attempts)")
+	}
+	t.Parallel()
+	var attempts atomic.Int32
+	_, c := newMockPVE(t, func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"data":null,"message":"got no worker upid - start worker failed\n"}`)
+			return
+		}
+		writeEnvelope(w, nil)
+	})
+
+	if err := c.ResizeDisk(context.Background(), "node1", 156, "scsi0", "15G"); err != nil {
+		t.Fatalf("ResizeDisk: want nil after retry, got %v", err)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("attempts = %d, want 2 (1 transient + 1 success)", got)
+	}
+}
+
+// TestClient_ResizeDisk_NonRetriableErrorFailsFast verifies the retry
+// is targeted: 500s that aren't the worker-spawn signature (e.g.
+// "no need to extend disk to same size") propagate after a single
+// attempt without a retry. Otherwise we'd burn 4 seconds and a couple
+// of redundant API calls on every legitimate Proxmox error.
+func TestClient_ResizeDisk_NonRetriableErrorFailsFast(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	_, c := newMockPVE(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"data":null,"message":"500 no need to extend disk to same size or smaller"}`)
+	})
+
+	err := c.ResizeDisk(context.Background(), "node1", 156, "scsi0", "5G")
+	if err == nil {
+		t.Fatal("ResizeDisk: want error for non-retriable 500, got nil")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on non-matching 500)", got)
+	}
+}


### PR DESCRIPTION
## What broke

A real provision crashed at \`Configuring cloud-init & disk\` with:
\`\`\`
resize disk: proxmox: PUT /nodes/sixseven/qemu/156/resize returned 500:
  {\"data\":null,\"message\":\"got no worker upid - start worker failed\\n\"}
\`\`\`
The IP reservation was rolled back and the operator had to start over. Investigation:

- Node \`sixseven\` was healthy: 5.4 GB / 16 GB memory used, 47 GB free disk, CPU 0%, in cluster quorum.
- \`qmclone:115 → 156\` and three \`qmconfig:156\` calls succeeded *seconds before* this failure.
- Worker-spawning probes (\`/qemu/156/status/current\`, \`/rrddata\`) succeeded seconds *after*.
- The failed task's log on Proxmox is empty (\`no content\`) — Proxmox didn't even start a worker.

Diagnosis: classic transient \`pvedaemon\` fork failure. \`pvedaemon\` couldn't fork a task-runner to handle the resize for a moment; it cleared within seconds; nimbus's single-shot PUT became a user-facing failure.

## Fix

Targeted retry on \`ResizeDisk\` only:
- Up to 2 retries with 1s and 3s backoff.
- Triggers only when Proxmox returns HTTP 500 with \`got no worker upid\` in the body. Other 5xx (e.g. \"no need to extend disk\") fail fast.
- Safe to retry: the matched failure means Proxmox didn't start any work, so no side effects to worry about.
- Respects ctx cancellation between attempts.

\`isTransientWorkerSpawnFailure(err)\` is the matcher; pinning to the exact error signature keeps the blast radius narrow. Other \`*HTTPError\` cases pass through unchanged.

## Test plan

- [x] \`TestClient_ResizeDisk_RetriesWorkerSpawn\` — mock returns 500-worker on attempt 1, 200 on attempt 2; ResizeDisk returns nil after exactly 2 calls. Sleeps 1s for backoff, skipped under \`-short\`.
- [x] \`TestClient_ResizeDisk_NonRetriableErrorFailsFast\` — mock returns 500 with \"no need to extend disk\"; ResizeDisk fails after exactly 1 call.
- [x] \`go test -race ./...\`, \`go vet\`, \`gofmt -l .\` clean.