### PR TITLE
feat: SMTP send pipeline + magic-link recovery + live Email-stragglers button

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,7 +115,8 @@ func main() {
 	}
 
 	database, err := db.New(cfg.DBPath,
-		&db.User{}, &db.Session{}, &db.OAuthSettings{}, &db.SMTPSettings{},
+		&db.User{}, &db.Session{}, &db.LoginToken{},
+		&db.OAuthSettings{}, &db.SMTPSettings{},
 		&db.GopherSettings{},
 		&db.GPUSettings{}, &db.GPUJob{}, &db.NetworkSettings{},
 		&db.VM{}, &db.NodeTemplate{}, &db.SSHKey{}, &db.S3Storage{},
@@ -151,6 +152,17 @@ func main() {
 		log.Printf("warning: admin backfill check failed: %v", err)
 	} else if promoted {
 		log.Printf("backfill: promoted oldest user to admin (no admin existed)")
+	}
+
+	// Sweep expired magic-link / recovery tokens on every boot. Cheap
+	// (one DELETE WHERE expires_at < now) and keeps the table from
+	// growing unbounded between server restarts. Failures are
+	// non-fatal — the consumer also rejects expired rows at redeem
+	// time, so the table just stays a bit dirtier.
+	if removed, err := authSvc.PurgeExpiredLoginTokens(); err != nil {
+		log.Printf("warning: purge expired login tokens: %v", err)
+	} else if removed > 0 {
+		log.Printf("startup: purged %d expired login tokens", removed)
 	}
 
 	// Network settings: env vars seed the DB row on first boot; after that the

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -573,6 +573,33 @@ export async function saveSMTPSettings(req: SaveSMTPRequest): Promise<SMTPSettin
   return data
 }
 
+// sendTestEmail dials the configured SMTP server and delivers a short
+// test message to the calling admin's own email address. Useful as a
+// confidence check after filling in the form on /email — verifies host,
+// auth, and TLS handshake without committing to a bulk send.
+export async function sendTestEmail(): Promise<{ sent: boolean; to: string }> {
+  // SMTP timeouts are 30s on the server; give axios a hair more so the
+  // retry path surfaces a useful error rather than a generic axios timeout.
+  const { data } = await api.post<{ sent: boolean; to: string }>('/settings/smtp/test', null, { timeout: 35_000 })
+  return data
+}
+
+export interface EmailUnlinkedResult {
+  sent: number
+  failed: number
+  failures?: string[]
+}
+
+// emailUnlinkedUsers mints magic-link tokens for every active password-only
+// account and sends each user a recovery email. Returns the per-user
+// counts; failures are descriptive strings (`alice@example.com: ...`).
+export async function emailUnlinkedUsers(): Promise<EmailUnlinkedResult> {
+  // Long timeout: with N stragglers the server makes N synchronous SMTP
+  // sessions. Give it room to finish a small batch.
+  const { data } = await api.post<EmailUnlinkedResult>('/users/email-unlinked', null, { timeout: 120_000 })
+  return data
+}
+
 export async function getPasswordlessStatus(): Promise<PasswordlessStatus> {
   const { data } = await api.get<PasswordlessStatus>('/settings/oauth/passwordless')
   return data

--- a/frontend/src/pages/Email.tsx
+++ b/frontend/src/pages/Email.tsx
@@ -1,13 +1,8 @@
 import { useEffect, useState } from 'react'
-import { getSMTPSettings, saveSMTPSettings } from '@/api/client'
+import { getSMTPSettings, saveSMTPSettings, sendTestEmail } from '@/api/client'
 import type { SMTPSettingsView, SaveSMTPRequest } from '@/api/client'
 
-// Email — admin-only SMTP configuration. Today the saved config is
-// dormant: nothing reads it for sending yet. The /users page's
-// "Email N unlinked users" button gates on this card's Configured +
-// Enabled state, but the actual recovery-email send pipeline lands in
-// a follow-up release. Storing now (vs. later) means the schema and
-// form scaffolding are ready when send wires up.
+// Email — admin-only SMTP configuration + test-send affordance.
 //
 // Password handling follows the standard "edit secrets" pattern:
 // leave the field blank to keep the existing stored value (the
@@ -15,6 +10,12 @@ import type { SMTPSettingsView, SaveSMTPRequest } from '@/api/client'
 // request omits `password` when blank, sends the new value otherwise.
 // Backend encrypts at rest with the same secrets.Cipher used for the
 // SSH key vault.
+//
+// "Send test email" delivers a short message to the calling admin's
+// own address — useful for verifying the saved credentials before
+// triggering the bulk recovery send from /users. The button is the
+// only way to learn whether host/auth/TLS actually work end to end;
+// the form save just persists the values.
 export default function Email() {
   const [view, setView] = useState<SMTPSettingsView | null>(null)
   const [host, setHost] = useState('')
@@ -27,6 +28,8 @@ export default function Email() {
   const [busy, setBusy] = useState(false)
   const [saved, setSaved] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [testBusy, setTestBusy] = useState(false)
+  const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
 
   useEffect(() => {
     getSMTPSettings()
@@ -245,7 +248,7 @@ export default function Email() {
                 </span>
               </label>
 
-              <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 4 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 4, flexWrap: 'wrap' }}>
                 <button
                   type="submit"
                   className="n-btn n-btn-primary"
@@ -254,7 +257,36 @@ export default function Email() {
                 >
                   {busy ? 'Saving…' : 'Save'}
                 </button>
+                <button
+                  type="button"
+                  className="n-btn"
+                  disabled={testBusy || !view?.configured}
+                  title={
+                    view?.configured
+                      ? 'Sends a short test message to your own email address using the saved settings.'
+                      : 'Save host + from-address first.'
+                  }
+                  onClick={async () => {
+                    setTestResult(null)
+                    setTestBusy(true)
+                    try {
+                      const r = await sendTestEmail()
+                      setTestResult({ ok: true, msg: `Test email sent to ${r.to}.` })
+                    } catch (err) {
+                      setTestResult({ ok: false, msg: err instanceof Error ? err.message : 'failed' })
+                    } finally {
+                      setTestBusy(false)
+                    }
+                  }}
+                >
+                  {testBusy ? 'Sending…' : 'Send test email'}
+                </button>
                 {saved && <span style={{ fontSize: 13, color: 'var(--ok)' }}>Saved.</span>}
+                {testResult && (
+                  <span style={{ fontSize: 13, color: testResult.ok ? 'var(--ok)' : 'var(--err)' }}>
+                    {testResult.msg}
+                  </span>
+                )}
               </div>
             </form>
           </div>

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -15,6 +15,7 @@ import {
   saveAuthorizedGoogleDomains,
   saveOAuthSettings,
   setPasswordlessAuth,
+  emailUnlinkedUsers,
   setUserSuspended,
   suspendUnlinkedUsers,
 } from '@/api/client'
@@ -1648,6 +1649,27 @@ function ProvidersSummary({
     }
   }
 
+  const emailUnlinked = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      const r = await emailUnlinkedUsers()
+      // Surface the result in the panel's existing status slot — the
+      // bulk-action button reuses the suspend-result text style so we
+      // don't introduce a third success/failure UI per panel.
+      const failuresSummary =
+        r.failed > 0 && r.failures && r.failures.length > 0
+          ? ` Failures: ${r.failures.slice(0, 3).join('; ')}${r.failures.length > 3 ? `; +${r.failures.length - 3} more` : ''}`
+          : ''
+      setError(`Sent ${r.sent}${r.failed > 0 ? `, failed ${r.failed}.${failuresSummary}` : '.'}`)
+      onMutated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
       <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
@@ -1733,25 +1755,25 @@ function ProvidersSummary({
           >
             {busy ? 'Working…' : `Suspend ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
           </button>
-          {/* Email-stragglers button. Always disabled today — the send
-              pipeline ships in a follow-up release. Tooltip routes the
-              admin to /email so they can configure SMTP in the meantime;
-              once SMTP is configured + enabled the button stays disabled
-              but shows "Email coming soon" instead of the configure
-              prompt. The first version of the click action will mint
-              magic-link tokens and send recovery emails. */}
+          {/* Email-stragglers button. Enabled once SMTP is configured
+              + enabled on /email; click mints magic-link tokens and
+              sends each unlinked user a recovery email. Synchronous —
+              the request waits on N SMTP roundtrips, but client and
+              server both run with a generous timeout so a small batch
+              completes in a single shot. */}
           <button
             type="button"
             className="n-btn"
-            disabled
-            style={{ fontSize: 12, padding: '6px 12px', height: 32, cursor: 'not-allowed' }}
+            disabled={busy || !status.smtp_ready}
+            onClick={emailUnlinked}
+            style={{ fontSize: 12, padding: '6px 12px', height: 32, cursor: status.smtp_ready ? 'pointer' : 'not-allowed' }}
             title={
               status.smtp_ready
-                ? 'Email recovery is in preview — magic-link send lands in a follow-up release.'
+                ? `Sends a magic-link recovery email to each unlinked user. Each link expires in 24h.`
                 : 'SMTP not configured — set up Email in the Control Panel to enable.'
             }
           >
-            Email {status.stragglers} unlinked user{status.stragglers === 1 ? '' : 's'}
+            {busy ? 'Sending…' : `Email ${status.stragglers} unlinked user${status.stragglers === 1 ? '' : 's'}`}
           </button>
         </div>
       )}

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -20,6 +20,7 @@ import (
 	"nimbus/internal/ctxutil"
 	"nimbus/internal/db"
 	"nimbus/internal/ippool"
+	"nimbus/internal/mail"
 	"nimbus/internal/oauth"
 	"nimbus/internal/service"
 )
@@ -681,6 +682,236 @@ func (a *Auth) SaveSMTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response.Success(w, view)
+}
+
+// magicLinkPurpose tags magic-link tokens. Single value today; the
+// purpose column on db.LoginToken keeps room for future flows
+// (password reset, invite) without colliding.
+const magicLinkPurpose = "magic_link"
+
+// magicLinkTTL is how long a recovery email's link stays valid. 24h
+// balances "user might not check email immediately" against "we've
+// kept a sign-in token live for too long." Longer than typical
+// password-reset tokens because the linked user already has an
+// account; the worst case of a stolen link is that an attacker who
+// reads the user's mailbox can sign in as them, which they could
+// already do via password reset on most sites.
+const magicLinkTTL = 24 * time.Hour
+
+// SendTestEmail handles POST /api/settings/smtp/test — admin-only
+// dry-run that delivers a short test message to the admin's own email
+// address. Used as a confidence check after filling in the /email
+// form: if the dial / auth / TLS handshake works for the requester,
+// the bulk magic-link send will too.
+func (a *Auth) SendTestEmail(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	if requester.Email == "" {
+		response.BadRequest(w, "your account has no email address to send to")
+		return
+	}
+	row, err := a.auth.LoadSMTPRow()
+	if err != nil {
+		log.Printf("smtp test: load row: %v", err)
+		response.InternalError(w, "failed to load SMTP settings")
+		return
+	}
+	cfg, err := mail.Resolve(row, a.auth.Cipher())
+	if err != nil {
+		if errors.Is(err, mail.ErrNotConfigured) {
+			response.Error(w, http.StatusConflict, "configure SMTP host and from-address first")
+			return
+		}
+		if errors.Is(err, mail.ErrCipherUnavailable) {
+			response.Error(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		log.Printf("smtp test: resolve: %v", err)
+		response.InternalError(w, "failed to resolve SMTP config")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	msg := mail.Message{
+		To:      requester.Email,
+		Subject: "Nimbus SMTP test",
+		Body: fmt.Sprintf(
+			"This is a test email from Nimbus.\r\n\r\nIf you're seeing this, %s:%d is configured correctly and outbound mail is reaching your inbox.\r\n",
+			row.Host, row.Port,
+		),
+	}
+	if err := mail.Send(ctx, cfg, msg); err != nil {
+		// Surface the dial / auth error string verbatim — admins
+		// debugging SMTP need the underlying message ("authentication
+		// failed", "no such host", etc.) more than a sanitised one.
+		response.Error(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	response.Success(w, map[string]any{"sent": true, "to": requester.Email})
+}
+
+// MagicLinkSignIn handles GET /api/auth/magic/{token} — public,
+// single-use entry point for password-only users recovering their
+// account. Validates the token, mints a session, unsuspends the user
+// if needed, and redirects them to /account so they can connect an
+// OAuth provider. Bad/expired/used tokens redirect to a sign-in page
+// with an explanatory query param.
+func (a *Auth) MagicLinkSignIn(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		http.Redirect(w, r, "/login?magic=invalid", http.StatusTemporaryRedirect)
+		return
+	}
+	userID, err := a.auth.ConsumeLoginToken(token, magicLinkPurpose)
+	if err != nil {
+		var reason string
+		switch {
+		case errors.Is(err, service.ErrLoginTokenExpired):
+			reason = "expired"
+		case errors.Is(err, service.ErrLoginTokenUsed):
+			reason = "used"
+		case errors.Is(err, service.ErrLoginTokenInvalid):
+			reason = "invalid"
+		default:
+			log.Printf("magic-link: consume: %v", err)
+			reason = "error"
+		}
+		http.Redirect(w, r, "/login?magic="+reason, http.StatusTemporaryRedirect)
+		return
+	}
+	// If the user was suspended (e.g. caught by the bulk-suspend that
+	// preceded the email send), unsuspend them now so the freshly
+	// minted session isn't immediately rejected by GetUserBySessionID's
+	// suspended check.
+	if err := a.auth.SetUserSuspended(userID, userID, false); err != nil {
+		// Self-target self-unsuspend isn't a cannot-suspend-self case
+		// (that gate only fires for `suspended=true`), but log just
+		// in case the gate evolves.
+		log.Printf("magic-link: unsuspend uid=%d: %v", userID, err)
+	}
+	sessionID, err := a.auth.CreateSession(userID)
+	if err != nil {
+		log.Printf("magic-link: create session uid=%d: %v", userID, err)
+		http.Redirect(w, r, "/login?magic=error", http.StatusTemporaryRedirect)
+		return
+	}
+	setSessionCookie(w, sessionID)
+	http.Redirect(w, r, "/account?from=magic", http.StatusTemporaryRedirect)
+}
+
+// EmailUnlinkedResult is the response shape for POST
+// /api/users/email-unlinked. Counts let the UI render
+// "Sent N · failed M" without a second round-trip, and Failures
+// carries the bad-recipient list so the admin can decide whether to
+// retry or investigate (most failures are transient SMTP rejects).
+type EmailUnlinkedResult struct {
+	Sent     int      `json:"sent"`
+	Failed   int      `json:"failed"`
+	Failures []string `json:"failures,omitempty"`
+}
+
+// EmailUnlinked handles POST /api/users/email-unlinked — mints a
+// magic-link token per active password-only user (excluding the
+// requester) and sends each one a recovery email. Returns the per-
+// user result. The first SMTP failure aborts the whole batch on the
+// theory that "host unreachable" or "auth failed" affects everyone
+// equally, but per-recipient rejects (mailbox doesn't exist, etc.)
+// are recorded and we move on.
+func (a *Auth) EmailUnlinked(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	row, err := a.auth.LoadSMTPRow()
+	if err != nil {
+		log.Printf("email unlinked: load row: %v", err)
+		response.InternalError(w, "failed to load SMTP settings")
+		return
+	}
+	if !row.Enabled {
+		response.Error(w, http.StatusConflict, "SMTP is configured but disabled — flip Enable on /email first")
+		return
+	}
+	cfg, err := mail.Resolve(row, a.auth.Cipher())
+	if err != nil {
+		if errors.Is(err, mail.ErrNotConfigured) {
+			response.Error(w, http.StatusConflict, "configure SMTP host and from-address first")
+			return
+		}
+		if errors.Is(err, mail.ErrCipherUnavailable) {
+			response.Error(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		log.Printf("email unlinked: resolve: %v", err)
+		response.InternalError(w, "failed to resolve SMTP config")
+		return
+	}
+	targets, err := a.auth.ListUnlinkedActiveUsers(requester.ID)
+	if err != nil {
+		log.Printf("email unlinked: list: %v", err)
+		response.InternalError(w, "failed to list unlinked users")
+		return
+	}
+	if len(targets) == 0 {
+		response.Success(w, EmailUnlinkedResult{})
+		return
+	}
+
+	out := EmailUnlinkedResult{}
+	for i := range targets {
+		t := &targets[i]
+		if t.Email == "" {
+			out.Failed++
+			out.Failures = append(out.Failures, fmt.Sprintf("uid %d: no email", t.ID))
+			continue
+		}
+		token, err := a.auth.MintLoginToken(t.ID, magicLinkPurpose, magicLinkTTL)
+		if err != nil {
+			out.Failed++
+			out.Failures = append(out.Failures, fmt.Sprintf("%s: mint token: %v", t.Email, err))
+			continue
+		}
+		link := strings.TrimRight(a.appURL, "/") + "/api/auth/magic/" + url.PathEscape(token)
+		body := buildMagicLinkBody(t.Name, link)
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		err = mail.Send(ctx, cfg, mail.Message{
+			To:      t.Email,
+			Subject: "Connect Google or GitHub to your Nimbus account",
+			Body:    body,
+		})
+		cancel()
+		if err != nil {
+			out.Failed++
+			out.Failures = append(out.Failures, fmt.Sprintf("%s: %v", t.Email, err))
+			// Continue rather than abort — one bad mailbox shouldn't
+			// hold up the rest. The admin can retry-with-failures
+			// after triaging the failed list.
+			continue
+		}
+		out.Sent++
+	}
+	response.Success(w, out)
+}
+
+// buildMagicLinkBody composes the recovery-email body. Plain text
+// only; the link is on its own line so receivers that auto-linkify
+// pick it up cleanly.
+func buildMagicLinkBody(displayName, link string) string {
+	greeting := "Hi,"
+	if displayName != "" {
+		greeting = "Hi " + displayName + ","
+	}
+	return greeting + "\r\n\r\n" +
+		"Your Nimbus admin asked you to connect a Google or GitHub account to your sign-in. " +
+		"Click the link below within 24 hours to sign in and link a provider:\r\n\r\n" +
+		link + "\r\n\r\n" +
+		"After you've connected, you can sign in by clicking 'Continue with Google' " +
+		"or 'Continue with GitHub' on the sign-in page — no password needed.\r\n\r\n" +
+		"If you didn't expect this email, ignore it. The link expires in 24 hours and works only once.\r\n"
 }
 
 // VerifyStatus handles GET /api/access-code/status — returns whether the

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -151,6 +151,11 @@ func NewRouter(d Deps) http.Handler {
 		// here mid-flight, before the new session would exist).
 		r.Get("/auth/github/link", auth.GitHubLinkStart)
 		r.Get("/auth/google/link", auth.GoogleLinkStart)
+		// Magic-link sign-in for password-only users coming back from
+		// a recovery email. Public — the token in the URL IS the auth.
+		// Validation is inside the handler; bad/expired/used tokens
+		// redirect to /login with an explanatory query param.
+		r.Get("/auth/magic/{token}", auth.MagicLinkSignIn)
 
 		// Protected routes — require a valid session cookie
 		r.Group(func(r chi.Router) {
@@ -190,6 +195,8 @@ func NewRouter(d Deps) http.Handler {
 				r.Put("/settings/oauth/passwordless", auth.SetPasswordlessAuth)
 				r.Get("/settings/smtp", auth.GetSMTP)
 				r.Put("/settings/smtp", auth.SaveSMTP)
+				r.Post("/settings/smtp/test", auth.SendTestEmail)
+				r.Post("/users/email-unlinked", auth.EmailUnlinked)
 
 				r.Get("/nodes", nodes.List)
 				r.Get("/ips", ips.List)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -91,6 +91,31 @@ type OAuthSettings struct {
 	RequirePasswordlessAuth bool `gorm:"default:false"`
 }
 
+// LoginToken is a single-use, short-lived token that signs a user in
+// when redeemed. Currently minted by the magic-link recovery flow
+// that emails password-only users (so they can come connect
+// Google/GitHub on their /account page) and consumed by
+// /api/auth/magic/{token}.
+//
+// Token is the opaque random-hex string and the primary key. Purpose
+// tags what flow minted it so the consumer can refuse cross-purpose
+// tokens — today only "magic_link" exists, but the column is here so
+// future single-use tokens (password reset, invite) don't need
+// another schema bump.
+//
+// Single-use is enforced by an UPDATE ... SET used_at = ? WHERE
+// token = ? AND used_at IS NULL inside ConsumeLoginToken: the row
+// can only flip from unused to used once, and a concurrent second
+// redeem hits zero rows affected.
+type LoginToken struct {
+	Token     string     `gorm:"primaryKey"`
+	UserID    uint       `gorm:"not null;index"`
+	Purpose   string     `gorm:"not null;default:''"`
+	ExpiresAt time.Time  `gorm:"not null;index"`
+	UsedAt    *time.Time `gorm:"index"`
+	CreatedAt time.Time
+}
+
 // SMTPSettings holds outbound-mail configuration. Singleton (ID=1).
 // Used by the planned magic-link recovery flow that emails password-only
 // users when an admin moves the workspace to OAuth-only sign-in. The

--- a/internal/mail/mailer.go
+++ b/internal/mail/mailer.go
@@ -1,0 +1,232 @@
+// Package mail is a focused SMTP client for outbound transactional
+// email. Today the only callers are the admin-side "send test email"
+// affordance on /email and the magic-link recovery flow that emails
+// password-only users when the workspace is moving to OAuth-only
+// sign-in.
+//
+// All sends are synchronous and one-shot — there's no queue, no
+// background worker, no retry. Volume is low enough that a request
+// can wait on the SMTP roundtrip; the caller is expected to set a
+// context deadline appropriate for their use case (10–30s).
+//
+// Encryption modes match the values stored on db.SMTPSettings:
+//   - "tls"      — direct TLS dial, port 465 / SMTPS.
+//   - "starttls" — plain dial then STARTTLS, port 587 / submission.
+//   - "none"     — plain unencrypted SMTP. Only safe inside trusted
+//     networks; net/smtp's PlainAuth refuses to run
+//     over non-TLS unless the server is localhost.
+package mail
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/smtp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"nimbus/internal/db"
+	"nimbus/internal/secrets"
+)
+
+// Encryption is the wire mode this mailer uses to dial the server.
+// String values match the values persisted on db.SMTPSettings.
+type Encryption string
+
+const (
+	EncryptionStartTLS Encryption = "starttls"
+	EncryptionTLS      Encryption = "tls"
+	EncryptionNone     Encryption = "none"
+)
+
+// ErrNotConfigured is returned by Resolve when host or from-address are
+// blank — the bare minimum to attempt a send. The caller is expected
+// to surface this as a 4xx so the admin understands they need to
+// finish the /email form first.
+var ErrNotConfigured = errors.New("smtp not configured")
+
+// ErrCipherUnavailable is returned by Resolve when the SMTP row has a
+// non-empty password ciphertext but the cipher needed to decrypt it
+// wasn't supplied. Distinct from ErrNotConfigured because the admin's
+// remediation is different: this means the server didn't load
+// NIMBUS_ENCRYPTION_KEY at startup, not that the form is empty.
+var ErrCipherUnavailable = errors.New("encryption cipher unavailable; cannot decrypt smtp password")
+
+// Config is the resolved (decrypted-password) shape passed to Send.
+// Distinct from db.SMTPSettings because that struct holds ciphertext;
+// nothing outside this package decrypts.
+type Config struct {
+	Host       string
+	Port       int
+	Username   string
+	Password   string
+	From       string
+	Encryption Encryption
+}
+
+// Message is a single plain-text email. We don't ship HTML in v1 —
+// magic-link recovery is short enough that a hyperlink rendered as a
+// URL on its own line is fine, and HTML email comes with multipart
+// + content-encoding fiddly bits we don't need yet.
+type Message struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+// Resolve decrypts the SMTP password ciphertext and returns a Config
+// ready to pass to Send. Returns ErrNotConfigured when the form is
+// empty, ErrCipherUnavailable when the password is set but no cipher
+// was supplied. Defaults port to 587 and encryption to starttls when
+// the row left them blank — matches what the /email form does on save.
+func Resolve(s *db.SMTPSettings, cipher *secrets.Cipher) (*Config, error) {
+	if s == nil || s.Host == "" || s.FromAddress == "" {
+		return nil, ErrNotConfigured
+	}
+	cfg := &Config{
+		Host:       s.Host,
+		Port:       s.Port,
+		Username:   s.Username,
+		From:       s.FromAddress,
+		Encryption: Encryption(s.Encryption),
+	}
+	if cfg.Port == 0 {
+		cfg.Port = 587
+	}
+	if cfg.Encryption == "" {
+		cfg.Encryption = EncryptionStartTLS
+	}
+	if len(s.PasswordCT) > 0 {
+		if cipher == nil {
+			return nil, ErrCipherUnavailable
+		}
+		plain, err := cipher.Decrypt(s.PasswordCT, s.PasswordNonce)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt smtp password: %w", err)
+		}
+		cfg.Password = string(plain)
+	}
+	return cfg, nil
+}
+
+// Send dials the SMTP server, authenticates if credentials are set,
+// and delivers msg. The TLS strategy is picked from cfg.Encryption.
+func Send(ctx context.Context, cfg *Config, msg Message) error {
+	if cfg == nil {
+		return errors.New("smtp: nil config")
+	}
+	if msg.To == "" {
+		return errors.New("smtp: empty recipient")
+	}
+	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+
+	c, err := dialClient(ctx, cfg, addr)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	if cfg.Username != "" {
+		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+		if err := c.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+
+	if err := c.Mail(cfg.From); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
+	}
+	if err := c.Rcpt(msg.To); err != nil {
+		return fmt.Errorf("smtp RCPT TO %q: %w", msg.To, err)
+	}
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp DATA: %w", err)
+	}
+	if _, err := w.Write([]byte(BuildMessage(cfg.From, msg))); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("smtp body write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("smtp body close: %w", err)
+	}
+	return c.Quit()
+}
+
+// dialClient handles the three encryption modes and returns a ready
+// *smtp.Client. tls and starttls share a server-name check so a
+// misconfigured DNS / cert mismatch surfaces as a TLS error rather
+// than a silent downgrade.
+func dialClient(ctx context.Context, cfg *Config, addr string) (*smtp.Client, error) {
+	switch cfg.Encryption {
+	case EncryptionTLS:
+		d := &tls.Dialer{Config: &tls.Config{ServerName: cfg.Host, MinVersion: tls.VersionTLS12}}
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("smtp tls dial %s: %w", addr, err)
+		}
+		c, err := smtp.NewClient(conn, cfg.Host)
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("smtp client init: %w", err)
+		}
+		return c, nil
+	case EncryptionNone, EncryptionStartTLS, "":
+		d := &net.Dialer{}
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, fmt.Errorf("smtp dial %s: %w", addr, err)
+		}
+		c, err := smtp.NewClient(conn, cfg.Host)
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("smtp client init: %w", err)
+		}
+		if cfg.Encryption == EncryptionStartTLS || cfg.Encryption == "" {
+			if err := c.StartTLS(&tls.Config{ServerName: cfg.Host, MinVersion: tls.VersionTLS12}); err != nil {
+				_ = c.Close()
+				return nil, fmt.Errorf("smtp starttls: %w", err)
+			}
+		}
+		return c, nil
+	default:
+		return nil, fmt.Errorf("smtp: unknown encryption mode %q", cfg.Encryption)
+	}
+}
+
+// BuildMessage formats msg as RFC 5322 plain-text bytes ready to feed
+// to smtp.Client.Data. Exported so handlers can preview the body in
+// logs / dry-run paths without dialing the server. Headers are
+// sorted alphabetically — order is irrelevant to receivers but a
+// stable ordering makes the unit test deterministic.
+func BuildMessage(from string, msg Message) string {
+	headers := map[string]string{
+		"From":                      from,
+		"To":                        msg.To,
+		"Subject":                   msg.Subject,
+		"Date":                      time.Now().UTC().Format(time.RFC1123Z),
+		"MIME-Version":              "1.0",
+		"Content-Type":              "text/plain; charset=UTF-8",
+		"Content-Transfer-Encoding": "8bit",
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString(": ")
+		b.WriteString(headers[k])
+		b.WriteString("\r\n")
+	}
+	b.WriteString("\r\n")
+	b.WriteString(msg.Body)
+	return b.String()
+}

--- a/internal/mail/mailer_test.go
+++ b/internal/mail/mailer_test.go
@@ -1,0 +1,115 @@
+package mail_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"nimbus/internal/db"
+	"nimbus/internal/mail"
+	"nimbus/internal/secrets"
+)
+
+// BuildMessage's exact byte layout is what hits the SMTP server's
+// DATA command; getting it wrong (missing CRLFs, missing required
+// headers, Subject buried in the body) results in mail that providers
+// reject or quarantine. This test pins the contract.
+func TestBuildMessage_ContainsRequiredHeaders(t *testing.T) {
+	t.Parallel()
+	out := mail.BuildMessage("nimbus@example.com", mail.Message{
+		To:      "user@example.com",
+		Subject: "hello",
+		Body:    "hi there\r\n",
+	})
+
+	for _, want := range []string{
+		"From: nimbus@example.com\r\n",
+		"To: user@example.com\r\n",
+		"Subject: hello\r\n",
+		"MIME-Version: 1.0\r\n",
+		"Content-Type: text/plain; charset=UTF-8\r\n",
+		"Content-Transfer-Encoding: 8bit\r\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+
+	// Body separator: blank line (CRLF) between headers and body.
+	if !strings.Contains(out, "\r\n\r\nhi there") {
+		t.Errorf("missing CRLF separator before body:\n%s", out)
+	}
+}
+
+// Resolve refuses to hand back a Config when the form is empty. The
+// /email page's "Send test email" button gates on `view.configured`
+// to avoid hitting this; the path exists so a hand-crafted curl can't
+// trigger a dial against a blank host.
+func TestResolve_ErrNotConfiguredOnEmpty(t *testing.T) {
+	t.Parallel()
+	_, err := mail.Resolve(&db.SMTPSettings{}, nil)
+	if !errors.Is(err, mail.ErrNotConfigured) {
+		t.Fatalf("err = %v, want ErrNotConfigured", err)
+	}
+}
+
+// Cipher is required when password ciphertext is present. The auth
+// service guards against this at write time too (saving with a
+// password requires a cipher), but a server that lost its env file
+// post-write could still hit this on the read path.
+func TestResolve_ErrCipherUnavailableWhenPasswordSet(t *testing.T) {
+	t.Parallel()
+	row := &db.SMTPSettings{
+		Host:        "smtp.example.com",
+		FromAddress: "nimbus@example.com",
+		PasswordCT:  []byte("ciphertext-bytes"),
+	}
+	_, err := mail.Resolve(row, nil)
+	if !errors.Is(err, mail.ErrCipherUnavailable) {
+		t.Fatalf("err = %v, want ErrCipherUnavailable", err)
+	}
+}
+
+// Resolve fills in the documented defaults: port 587 + starttls when
+// the row left them blank. Matches the /email form's defaults so the
+// admin's mental model lines up with what's actually used to dial.
+func TestResolve_AppliesDefaults(t *testing.T) {
+	t.Parallel()
+	row := &db.SMTPSettings{Host: "smtp.example.com", FromAddress: "nimbus@example.com"}
+	cfg, err := mail.Resolve(row, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Port != 587 {
+		t.Errorf("port = %d, want 587 default", cfg.Port)
+	}
+	if cfg.Encryption != mail.EncryptionStartTLS {
+		t.Errorf("encryption = %q, want %q default", cfg.Encryption, mail.EncryptionStartTLS)
+	}
+}
+
+// Resolve actually decrypts when both the cipher and ciphertext are
+// supplied — confirms the round-trip across the secrets layer works
+// in the same shape /email's save path stores it.
+func TestResolve_DecryptsPassword(t *testing.T) {
+	t.Parallel()
+	c, err := secrets.New(make([]byte, secrets.KeyLen))
+	if err != nil {
+		t.Fatalf("secrets.New: %v", err)
+	}
+	ct, nonce, err := c.Encrypt([]byte("hunter2"))
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	row := &db.SMTPSettings{
+		Host: "smtp.example.com", FromAddress: "nimbus@example.com",
+		PasswordCT: ct, PasswordNonce: nonce,
+	}
+	cfg, err := mail.Resolve(row, c)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Password != "hunter2" {
+		t.Errorf("password = %q, want %q", cfg.Password, "hunter2")
+	}
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -18,15 +18,15 @@ import (
 )
 
 var (
-	ErrEmailTaken           = errors.New("email already registered")
-	ErrInvalidCredentials   = errors.New("invalid credentials")
-	ErrSessionNotFound      = errors.New("session not found or expired")
-	ErrAdminAlreadyClaimed  = errors.New("admin already claimed")
-	ErrUsersExist           = errors.New("users already exist")
-	ErrInvalidAccessCode    = errors.New("invalid access code")
-	ErrAccessCodeNotPresent = errors.New("access code not configured")
-	ErrDomainNotAuthorized  = errors.New("email domain not authorized")
-	ErrOrgNotAuthorized     = errors.New("github org not authorized")
+	ErrEmailTaken             = errors.New("email already registered")
+	ErrInvalidCredentials     = errors.New("invalid credentials")
+	ErrSessionNotFound        = errors.New("session not found or expired")
+	ErrAdminAlreadyClaimed    = errors.New("admin already claimed")
+	ErrUsersExist             = errors.New("users already exist")
+	ErrInvalidAccessCode      = errors.New("invalid access code")
+	ErrAccessCodeNotPresent   = errors.New("access code not configured")
+	ErrDomainNotAuthorized    = errors.New("email domain not authorized")
+	ErrOrgNotAuthorized       = errors.New("github org not authorized")
 	ErrUserNotFound           = errors.New("user not found")
 	ErrRequesterNotLinked     = errors.New("link an OAuth provider on your own account before requiring passwordless sign-in")
 	ErrUserSuspended          = errors.New("account suspended")
@@ -34,6 +34,9 @@ var (
 	ErrCannotSuspendLastAdmin = errors.New("cannot suspend the last unsuspended admin")
 	ErrStragglersBlock        = errors.New("password-only accounts must be suspended or removed before passwordless sign-in can be required")
 	ErrCipherUnavailable      = errors.New("encryption cipher not available; restart the server with NIMBUS_ENCRYPTION_KEY configured")
+	ErrLoginTokenInvalid      = errors.New("login token invalid")
+	ErrLoginTokenExpired      = errors.New("login token expired")
+	ErrLoginTokenUsed         = errors.New("login token already used")
 )
 
 const sessionDuration = 7 * 24 * time.Hour
@@ -943,14 +946,14 @@ func subtleConstantTimeEq(a, b string) bool {
 // The encrypted password ciphertext stays inside the service; the UI
 // only sees whether a password is set, not the value.
 type SMTPSettingsView struct {
-	Host         string `json:"host"`
-	Port         int    `json:"port"`
-	Username     string `json:"username"`
-	HasPassword  bool   `json:"has_password"`
-	FromAddress  string `json:"from_address"`
-	Encryption   string `json:"encryption"`
-	Enabled      bool   `json:"enabled"`
-	Configured   bool   `json:"configured"`
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	Username    string `json:"username"`
+	HasPassword bool   `json:"has_password"`
+	FromAddress string `json:"from_address"`
+	Encryption  string `json:"encryption"`
+	Enabled     bool   `json:"enabled"`
+	Configured  bool   `json:"configured"`
 }
 
 // SaveSMTPRequest mirrors the form on /email. An empty password leaves
@@ -1032,6 +1035,109 @@ func (s *AuthService) SaveSMTPSettings(req SaveSMTPRequest) (*SMTPSettingsView, 
 		return nil, err
 	}
 	return s.GetSMTPSettings()
+}
+
+// LoadSMTPRow returns the raw SMTPSettings row including encrypted
+// password ciphertext. Used by the mail subsystem at send time so it
+// can decrypt the password through the cipher attached to AuthService.
+// The view-returning GetSMTPSettings deliberately strips ciphertext;
+// this method is the back-channel.
+func (s *AuthService) LoadSMTPRow() (*db.SMTPSettings, error) {
+	var row db.SMTPSettings
+	if err := s.db.FirstOrCreate(&row, db.SMTPSettings{ID: 1}).Error; err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+// Cipher returns the secrets.Cipher attached via WithCipher, or nil if
+// none was set. Exposed so a peer service (e.g. the mail handler) can
+// decrypt SMTP credentials without re-implementing the bootstrap
+// dance.
+func (s *AuthService) Cipher() *secrets.Cipher {
+	return s.cipher
+}
+
+// MintLoginToken creates a single-use, opaque token bound to userID
+// for the named purpose with the given TTL. The token is 32 hex chars
+// (128 bits of entropy) — enough collision-resistance that we don't
+// also key on user_id at lookup time. Returns the token string.
+func (s *AuthService) MintLoginToken(userID uint, purpose string, ttl time.Duration) (string, error) {
+	if ttl <= 0 {
+		return "", errors.New("login token ttl must be positive")
+	}
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("mint login token: %w", err)
+	}
+	token := hex.EncodeToString(buf)
+	row := db.LoginToken{
+		Token:     token,
+		UserID:    userID,
+		Purpose:   purpose,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+	if err := s.db.Create(&row).Error; err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// ConsumeLoginToken atomically marks a token used and returns the
+// associated userID. Refuses tokens that don't exist, are expired,
+// have a different purpose, or have already been consumed. Single-use
+// is enforced by `WHERE used_at IS NULL` in the UPDATE — a concurrent
+// second redeem hits zero rows affected.
+func (s *AuthService) ConsumeLoginToken(token, purpose string) (uint, error) {
+	var row db.LoginToken
+	err := s.db.Where("token = ?", token).First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, ErrLoginTokenInvalid
+	}
+	if err != nil {
+		return 0, err
+	}
+	if row.Purpose != purpose {
+		return 0, ErrLoginTokenInvalid
+	}
+	if row.UsedAt != nil {
+		return 0, ErrLoginTokenUsed
+	}
+	if time.Now().After(row.ExpiresAt) {
+		return 0, ErrLoginTokenExpired
+	}
+	now := time.Now()
+	res := s.db.Model(&db.LoginToken{}).
+		Where("token = ? AND used_at IS NULL", token).
+		Update("used_at", now)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	if res.RowsAffected == 0 {
+		// Lost a race against another redeem — treat as already-used.
+		return 0, ErrLoginTokenUsed
+	}
+	return row.UserID, nil
+}
+
+// PurgeExpiredLoginTokens deletes tokens whose expires_at is in the
+// past. Idempotent; safe to call from a startup sweep.
+func (s *AuthService) PurgeExpiredLoginTokens() (int64, error) {
+	res := s.db.Where("expires_at < ?", time.Now()).Delete(&db.LoginToken{})
+	return res.RowsAffected, res.Error
+}
+
+// ListUnlinkedActiveUsers returns every active (non-suspended) account
+// without OAuth — the same straggler set CountUnlinkedUsers counts.
+// Used by the bulk email-stragglers handler to know whom to mint
+// magic-links for. Excludes the requester so an admin issuing the
+// command doesn't email themselves a recovery link.
+func (s *AuthService) ListUnlinkedActiveUsers(excludeID uint) ([]db.User, error) {
+	var users []db.User
+	err := s.db.
+		Where("google_connected = ? AND git_hub_orgs = ? AND suspended = ? AND id <> ?", false, "", false, excludeID).
+		Find(&users).Error
+	return users, err
 }
 
 // GetGopherSettings returns the stored Gopher tunnel credentials. Creates a

--- a/internal/service/tokens_test.go
+++ b/internal/service/tokens_test.go
@@ -1,0 +1,172 @@
+package service_test
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"nimbus/internal/db"
+	"nimbus/internal/service"
+)
+
+// newTokenAuthService is a helper specific to LoginToken tests; the
+// shared helper in auth_test.go doesn't AutoMigrate the LoginToken
+// table because it predates this feature. Adding LoginToken to that
+// helper would also work, but a focused helper here keeps the blast
+// radius narrow and lets these tests evolve their own fixtures
+// independently.
+func newTokenAuthService(t *testing.T) *service.AuthService {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tokens.db")
+	database, err := db.New(path, &db.User{}, &db.LoginToken{})
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	if err := database.Create(&db.User{Name: "alice", Email: "a@x"}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return service.NewAuthService(database)
+}
+
+func TestMintAndConsumeLoginToken_HappyPath(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	tok, err := svc.MintLoginToken(1, "magic_link", time.Minute)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if len(tok) != 32 {
+		t.Fatalf("token length = %d, want 32 hex chars (16 bytes)", len(tok))
+	}
+
+	uid, err := svc.ConsumeLoginToken(tok, "magic_link")
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if uid != 1 {
+		t.Errorf("uid = %d, want 1", uid)
+	}
+}
+
+func TestConsumeLoginToken_RejectsSecondUse(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	tok, err := svc.MintLoginToken(1, "magic_link", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ConsumeLoginToken(tok, "magic_link"); err != nil {
+		t.Fatalf("first Consume: %v", err)
+	}
+	_, err = svc.ConsumeLoginToken(tok, "magic_link")
+	if !errors.Is(err, service.ErrLoginTokenUsed) {
+		t.Fatalf("second Consume: err = %v, want ErrLoginTokenUsed", err)
+	}
+}
+
+func TestConsumeLoginToken_RejectsExpired(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	// Mint with an absurdly short TTL, then sleep past it. Avoids
+	// reaching into the DB to backdate expires_at, which would
+	// require unexported test seams.
+	tok, err := svc.MintLoginToken(1, "magic_link", 5*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	_, err = svc.ConsumeLoginToken(tok, "magic_link")
+	if !errors.Is(err, service.ErrLoginTokenExpired) {
+		t.Fatalf("Consume after expiry: err = %v, want ErrLoginTokenExpired", err)
+	}
+}
+
+func TestConsumeLoginToken_RejectsWrongPurpose(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	tok, err := svc.MintLoginToken(1, "magic_link", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = svc.ConsumeLoginToken(tok, "password_reset")
+	if !errors.Is(err, service.ErrLoginTokenInvalid) {
+		t.Fatalf("Consume with wrong purpose: err = %v, want ErrLoginTokenInvalid", err)
+	}
+}
+
+func TestConsumeLoginToken_RejectsUnknown(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	_, err := svc.ConsumeLoginToken("0000000000000000", "magic_link")
+	if !errors.Is(err, service.ErrLoginTokenInvalid) {
+		t.Fatalf("Consume with unknown token: err = %v, want ErrLoginTokenInvalid", err)
+	}
+}
+
+// Single-use under concurrency: 50 goroutines race to redeem the same
+// token; exactly one wins, the rest get ErrLoginTokenUsed (or
+// ErrLoginTokenInvalid via the WHERE used_at IS NULL guard, depending
+// on which path the loser takes). Verifies the atomic UPDATE actually
+// is atomic on top of SQLite's single-writer setup.
+func TestConsumeLoginToken_SingleUseUnderConcurrency(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	tok, err := svc.MintLoginToken(1, "magic_link", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	var winners atomic.Int32
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := svc.ConsumeLoginToken(tok, "magic_link"); err == nil {
+				winners.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := winners.Load(); got != 1 {
+		t.Errorf("winners = %d, want exactly 1", got)
+	}
+}
+
+func TestPurgeExpiredLoginTokens(t *testing.T) {
+	t.Parallel()
+	svc := newTokenAuthService(t)
+
+	// Live: ttl=10s. Should NOT be purged.
+	live, _ := svc.MintLoginToken(1, "magic_link", 10*time.Second)
+	// Expiring: ttl=5ms; sleep past it before purge.
+	dead, _ := svc.MintLoginToken(1, "magic_link", 5*time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+
+	removed, err := svc.PurgeExpiredLoginTokens()
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+	// Live token still consumable.
+	if _, err := svc.ConsumeLoginToken(live, "magic_link"); err != nil {
+		t.Errorf("live token rejected after purge: %v", err)
+	}
+	// Dead token gone.
+	if _, err := svc.ConsumeLoginToken(dead, "magic_link"); !errors.Is(err, service.ErrLoginTokenInvalid) {
+		t.Errorf("dead token after purge: err = %v, want ErrLoginTokenInvalid", err)
+	}
+}


### PR DESCRIPTION
## Stacked on #226

Targets \`feat/oauth-linking-and-passwordless\` because the SMTP form, /email page, and disabled button it builds on live there. Merge order: **#226 → this PR**, then this rebases cleanly onto main.

## What's new

### \`internal/mail\` — focused SMTP client
- \`Resolve(SMTPSettings, *secrets.Cipher)\` decrypts the saved password through the cipher \`AuthService\` now exposes via \`Cipher()\`.
- \`Send(ctx, *Config, Message)\` dials via \`tls\` (465) / \`starttls\` (587) / \`none\`, with a TLS server-name check so DNS/cert mismatch surfaces as a TLS error rather than a silent downgrade.
- Plain-text bodies only. Magic-link recovery is short enough an HTML multipart isn't worth the complexity yet.
- Errors propagated verbatim — admins debugging SMTP need the underlying \"authentication failed\" / \"no such host\" text more than a sanitised generic message.

### \`db.LoginToken\` — single-use recovery token
- 32-hex-char primary key (16 bytes of \`crypto/rand\` entropy), \`UserID\`, \`Purpose\`, \`ExpiresAt\`, \`UsedAt\`.
- Single-use enforced by atomic \`UPDATE ... SET used_at = ? WHERE token = ? AND used_at IS NULL\`. Tested under 50-goroutine concurrency: exactly one winner, the rest get \`ErrLoginTokenUsed\`.
- Startup sweep purges expired rows (idempotent; Consume rejects expired tokens too as defence-in-depth).

### Endpoints
- \`POST /api/settings/smtp/test\` (admin): dial + auth + send a short test message to the requester's email. Surfaces SMTP error strings verbatim.
- \`GET  /api/auth/magic/{token}\` (public): validates token, unsuspends user, mints session, \`302 → /account?from=magic\`. Bad/expired/used tokens \`302 → /login?magic=<reason>\`.
- \`POST /api/users/email-unlinked\` (admin): mints magic-link token + sends recovery email per active password-only user (excluding the requester). Returns \`{sent, failed, failures[]}\`. Per-recipient failures don't abort the batch.

### Frontend
- /email: \`Send test email\` button next to Save. Disabled until host + from-address are filled.
- /users: \`Email N unlinked users\` button is now live — enabled when \`smtp_ready\` (configured + Enabled). Click runs the bulk send; result renders inline in the panel's existing status slot (\`Sent N\`, or \`Sent N, failed M. Failures: ...\`).

### Tests
- \`service/tokens_test.go\` — happy path, double-redeem rejection, expiry, cross-purpose rejection, concurrent single-use across 50 goroutines.
- \`mail/mailer_test.go\` — Resolve defaults + decrypt round-trip + the error sentinels; BuildMessage RFC-5322 layout (headers + CRLF separator).

## Test plan

- [x] \`go test -race ./...\` (mail + service + everything else)
- [x] \`go vet\`, \`gofmt -l .\` clean
- [x] \`npm run type-check\`, \`npm run lint\`, \`npm run build\` clean
- [ ] On a deployment with SMTP creds: \`Send test email\` reaches the admin's inbox; \`Email N unlinked users\` mints + delivers a recovery link; clicking the link signs the user in (and unsuspends them if needed) and lands on \`/account\`.
- [ ] Wrong SMTP password → test send returns the underlying \"authentication failed\" string, not a generic error.
- [ ] Disable SMTP on /email → bulk send returns \`409 \"SMTP is configured but disabled\"\`; /users button becomes disabled.