### PR TITLE
feat: configurable user quotas + per-user overrides + /quotas system overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,15 @@ so any backfill in `main()` runs on the first post-upgrade boot for free.
   ground-truth column names. The new fields added in the same schema
   bump (`google_sub`, `github_id`) are pinned with explicit `column:`
   tags for that reason.
+- **`FirstOrCreate` with non-zero conditions filters by them.** Calling
+  `db.FirstOrCreate(&row, db.X{ID: 1, Foo: 5})` builds a
+  `WHERE id = 1 AND foo = 5` clause, *not* "find id=1, default Foo to 5
+  on create." After any subsequent UPDATE that changes Foo, the next
+  call's WHERE no longer matches the row → it attempts an INSERT with
+  `id = 1` and trips the uniqueness constraint. Use the explicit form
+  for any column that has a useful default but is also writable
+  afterwards: `db.Where(&db.X{ID: 1}).Attrs(&db.X{Foo: 5}).FirstOrCreate(&row)`.
+  `Attrs` only applies on create, never narrows the read.
 
 ## When you change reconciliation, verification, or the IP pool
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -116,7 +116,7 @@ func main() {
 
 	database, err := db.New(cfg.DBPath,
 		&db.User{}, &db.Session{}, &db.LoginToken{},
-		&db.OAuthSettings{}, &db.SMTPSettings{},
+		&db.OAuthSettings{}, &db.SMTPSettings{}, &db.QuotaSettings{},
 		&db.GopherSettings{},
 		&db.GPUSettings{}, &db.GPUJob{}, &db.NetworkSettings{},
 		&db.VM{}, &db.NodeTemplate{}, &db.SSHKey{}, &db.S3Storage{},
@@ -351,6 +351,11 @@ func main() {
 	// the candidate IP and verifyAndRetryReserve leapfrogs to the next free
 	// address.
 	provSvc.SetIPVerifier(chainVerifier{reconciler, netscan.NewVerifier(netscan.New(netscanCfg))})
+	// Wire the quota resolver so the member gate consults per-user
+	// overrides + workspace default. Without this the gate falls back
+	// to the legacy provision.MemberMaxVMs constant — fine for tests,
+	// not what we want in production.
+	provSvc.SetQuotaResolver(authSvc)
 
 	// Resolve Gopher settings. The DB row is the source of truth (admin can
 	// edit it live from the Settings page); env vars are a one-shot seed for
@@ -500,7 +505,7 @@ func main() {
 		// need root to write under /var/lib.
 		gpuLogDir = "./gpu-jobs"
 	}
-	gpuSvc, err := gpu.New(database.DB, gpuLogDir)
+	gpuSvc, err := gpu.New(database.DB, gpuLogDir, gpu.WithQuotaResolver(authSvc))
 	if err != nil {
 		log.Fatalf("failed to init gpu service: %v", err)
 	}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import Keys from '@/pages/Keys'
 import Network from '@/pages/Network'
 import Provision from '@/pages/Provision'
 import MyVMs from '@/pages/MyVMs'
+import Quotas from '@/pages/Quotas'
 import S3 from '@/pages/S3'
 import Users from '@/pages/Users'
 import SignIn from '@/pages/auth/SignIn'
@@ -91,6 +92,7 @@ export default function App() {
                       <Route path="/gpu" element={<GPU />} />
                       <Route path="/users" element={<RequireAdmin><Users /></RequireAdmin>} />
                       <Route path="/email" element={<RequireAdmin><Email /></RequireAdmin>} />
+                      <Route path="/quotas" element={<RequireAdmin><Quotas /></RequireAdmin>} />
                       <Route path="/account" element={<Account />} />
                       {/* Old /settings URL kept around so any existing
                           bookmarks / pasted links still resolve to the

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -668,10 +668,55 @@ export interface UserManagementView {
   // handshakes). Now derived from explicit per-provider flags rather
   // than absence-inference.
   providers: string[]
+  // Per-user quota overrides — null when the user inherits the
+  // workspace default. effective_* folds the override + default into
+  // the number that actually applies, so the UI can render either
+  // "default · 5" or "override · 10" without re-implementing the
+  // resolution.
+  vm_quota_override: number | null
+  gpu_job_quota_override: number | null
+  effective_vm_quota: number
+  effective_gpu_job_quota: number
 }
 
 export async function listUsers(): Promise<UserManagementView[]> {
   const { data } = await api.get<UserManagementView[]>('/users')
+  return data
+}
+
+export interface QuotaSettingsView {
+  member_max_vms: number
+  member_max_active_jobs: number
+}
+
+// getQuotaSettings returns the workspace-wide default caps. Members
+// hit these unless they have a per-user override; admins always
+// bypass.
+export async function getQuotaSettings(): Promise<QuotaSettingsView> {
+  const { data } = await api.get<QuotaSettingsView>('/settings/quotas')
+  return data
+}
+
+// saveQuotaSettings updates one or both workspace defaults. Either
+// field can be omitted (undefined) to leave it unchanged. The server
+// rejects negative values.
+export async function saveQuotaSettings(
+  req: { member_max_vms?: number; member_max_active_jobs?: number },
+): Promise<QuotaSettingsView> {
+  const { data } = await api.put<QuotaSettingsView>('/settings/quotas', req)
+  return data
+}
+
+// setUserQuota patches one user's quota override columns. Each field
+// has three states:
+//   - undefined → leave that override alone
+//   - null      → clear the override (revert to workspace default)
+//   - number    → set an explicit cap (zero is allowed)
+export async function setUserQuota(
+  id: number,
+  req: { vm_quota_override?: number | null; gpu_job_quota_override?: number | null },
+): Promise<{ id: number; ok: boolean }> {
+  const { data } = await api.put<{ id: number; ok: boolean }>(`/users/${id}/quota`, req)
   return data
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -152,6 +152,9 @@ export default function Layout({ children, showNav = true }: LayoutProps) {
                   <NavLink to="/users" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
                     Users
                   </NavLink>
+                  <NavLink to="/quotas" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
+                    Quotas
+                  </NavLink>
                   <NavLink to="/email" className={controlPanelItemClass} style={{ cursor: 'pointer' }}>
                     <span className="inline-flex items-center gap-1.5">
                       Email

--- a/frontend/src/pages/Quotas.tsx
+++ b/frontend/src/pages/Quotas.tsx
@@ -1,0 +1,554 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  getClusterStats,
+  getQuotaSettings,
+  listClusterVMs,
+  listIPs,
+  listNodes,
+  listUsers,
+  saveQuotaSettings,
+  setUserQuota,
+} from '@/api/client'
+import type {
+  ClusterStats,
+  ClusterVM,
+  IPAllocation,
+  NodeView,
+} from '@/types'
+import type { QuotaSettingsView, UserManagementView } from '@/api/client'
+
+// Quotas — admin-only sysadmin landing page. Two halves:
+//
+//  1. System overview — read-only at-a-glance stats fanned out across
+//     existing endpoints (/api/nodes, /api/cluster/stats, /api/ips,
+//     /api/cluster/vms, /api/users). No new backend endpoint; we just
+//     compose what's already there. Cheap because /api/nodes and the
+//     cluster snapshots are cached server-side, and we render whatever
+//     loads first rather than blocking on the slowest fetch.
+//
+//  2. Quota controls — editable workspace defaults for VMs + GPU jobs,
+//     plus a per-user override table. The override table is the same
+//     user list /users uses (richer shape now includes effective +
+//     override fields), filtered to non-admins because admins bypass
+//     the gate entirely.
+//
+// Today the page is admin-only. /admin already covers cluster
+// observability for fleet operators; /quotas is meant as the *single*
+// place a sysadmin lands when asking "what does this Nimbus look like
+// at a glance, and where are the knobs?"
+export default function Quotas() {
+  // Each fetch is independent; surface its own loaded state so a slow
+  // /api/cluster/vms doesn't black out the rest of the page.
+  const [nodes, setNodes] = useState<NodeView[] | null>(null)
+  const [stats, setStats] = useState<ClusterStats | null>(null)
+  const [ips, setIPs] = useState<IPAllocation[] | null>(null)
+  const [vms, setVMs] = useState<ClusterVM[] | null>(null)
+  const [users, setUsers] = useState<UserManagementView[] | null>(null)
+  const [defaults, setDefaults] = useState<QuotaSettingsView | null>(null)
+
+  const [error, setError] = useState<string | null>(null)
+  const [tick, setTick] = useState(0)
+
+  const reload = () => setTick((t) => t + 1)
+
+  useEffect(() => {
+    let cancelled = false
+    const ok = <T,>(set: (v: T) => void) => (v: T) => { if (!cancelled) set(v) }
+    const fail = (label: string) => (e: unknown) => {
+      if (!cancelled) setError((prev) => prev ?? `${label}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+    listNodes().then(ok(setNodes)).catch(fail('nodes'))
+    getClusterStats().then(ok(setStats)).catch(fail('cluster stats'))
+    listIPs().then(ok(setIPs)).catch(fail('ip pool'))
+    listClusterVMs().then(ok(setVMs)).catch(fail('cluster vms'))
+    listUsers().then(ok(setUsers)).catch(fail('users'))
+    getQuotaSettings().then(ok(setDefaults)).catch(fail('quotas'))
+    return () => { cancelled = true }
+  }, [tick])
+
+  // Aggregate NodeView rows into the overview's headline numbers.
+  // Memoized so the cards don't recompute on unrelated state changes.
+  const fleet = useMemo(() => {
+    if (!nodes) return null
+    const online = nodes.filter((n) => n.status === 'online')
+    const offline = nodes.length - online.length
+    let cpuUsed = 0
+    let cpuTotal = 0
+    let memUsed = 0
+    let memTotal = 0
+    for (const n of online) {
+      cpuUsed += (n.cpu ?? 0) * n.max_cpu
+      cpuTotal += n.max_cpu
+      memUsed += n.mem_used
+      memTotal += n.mem_total
+    }
+    return { online: online.length, offline, cpuUsed, cpuTotal, memUsed, memTotal }
+  }, [nodes])
+
+  const ipUsage = useMemo(() => {
+    if (!ips) return null
+    let used = 0
+    for (const ip of ips) if (ip.status !== 'free') used++
+    return { used, total: ips.length }
+  }, [ips])
+
+  const vmCounts = useMemo(() => {
+    if (!vms) return null
+    let running = 0
+    let stopped = 0
+    for (const vm of vms) {
+      if (vm.status === 'running') running++
+      else stopped++
+    }
+    return { running, stopped, total: vms.length }
+  }, [vms])
+
+  const userCounts = useMemo(() => {
+    if (!users) return null
+    let admins = 0
+    let suspended = 0
+    for (const u of users) {
+      if (u.is_admin) admins++
+      if (u.suspended) suspended++
+    }
+    return { admins, suspended, total: users.length }
+  }, [users])
+
+  // Override table only shows non-admin, non-suspended users — admins
+  // bypass the gate entirely (showing them confuses the data) and
+  // suspended users can't sign in to consume quota anyway.
+  const overrideTargets = useMemo(() => {
+    if (!users) return []
+    return users.filter((u) => !u.is_admin && !u.suspended)
+  }, [users])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+      <div>
+        <h1 className="n-display" style={{ fontSize: 28, margin: '0 0 6px' }}>
+          Quotas
+        </h1>
+        <p style={{ margin: 0, fontSize: 14, color: 'var(--ink-body)' }}>
+          System overview and per-user quota controls. Members hit the workspace
+          defaults unless they have an override; admins bypass quotas entirely.
+        </p>
+      </div>
+
+      {error && (
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--err)' }}>{error}</p>
+      )}
+
+      <div>
+        <div className="eyebrow" style={{ marginBottom: 10 }}>System overview</div>
+        <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+          <StatCard
+            label="Cluster nodes"
+            value={fleet ? `${fleet.online}` : '—'}
+            sub={fleet ? (fleet.offline > 0 ? `${fleet.offline} offline` : 'all online') : 'loading…'}
+          />
+          <StatCard
+            label="CPU cores in use"
+            value={fleet ? `${fleet.cpuUsed.toFixed(1)} / ${fleet.cpuTotal}` : '—'}
+            sub={fleet && fleet.cpuTotal > 0 ? `${pct(fleet.cpuUsed, fleet.cpuTotal)}% utilised` : 'across online nodes'}
+          />
+          <StatCard
+            label="RAM in use"
+            value={fleet ? `${formatBytes(fleet.memUsed)} / ${formatBytes(fleet.memTotal)}` : '—'}
+            sub={fleet && fleet.memTotal > 0 ? `${pct(fleet.memUsed, fleet.memTotal)}% utilised` : 'across online nodes'}
+          />
+          <StatCard
+            label="Storage"
+            value={stats ? `${formatBytes(stats.storage_used)} / ${formatBytes(stats.storage_total)}` : '—'}
+            sub={stats && stats.storage_total > 0 ? `${pct(stats.storage_used, stats.storage_total)}% utilised` : 'shared + local pools'}
+          />
+          <StatCard
+            label="IP pool"
+            value={ipUsage ? `${ipUsage.used} / ${ipUsage.total}` : '—'}
+            sub={ipUsage && ipUsage.total > 0 ? `${pct(ipUsage.used, ipUsage.total)}% allocated` : 'reserved + allocated'}
+          />
+          <StatCard
+            label="VMs"
+            value={vmCounts ? `${vmCounts.total}` : '—'}
+            sub={vmCounts ? `${vmCounts.running} running · ${vmCounts.stopped} stopped` : 'cluster-wide'}
+          />
+          <StatCard
+            label="Users"
+            value={userCounts ? `${userCounts.total}` : '—'}
+            sub={userCounts ? `${userCounts.admins} admin · ${userCounts.suspended} suspended` : 'all accounts'}
+          />
+        </div>
+      </div>
+
+      <DefaultsCard defaults={defaults} onSaved={(next) => { setDefaults(next); reload() }} />
+
+      <OverridesCard
+        users={overrideTargets}
+        defaults={defaults}
+        onSaved={reload}
+      />
+    </div>
+  )
+}
+
+function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="glass" style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <span style={{ fontSize: 11, color: 'var(--ink-mute)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        {label}
+      </span>
+      <span style={{ fontSize: 22, fontWeight: 500, color: 'var(--ink)', fontFamily: 'Geist Mono, monospace' }}>
+        {value}
+      </span>
+      {sub && <span style={{ fontSize: 12, color: 'var(--ink-mute)' }}>{sub}</span>}
+    </div>
+  )
+}
+
+// DefaultsCard — workspace VM + GPU caps in two narrow inputs. Saves
+// independently from the overrides table; pressing Save persists both
+// numbers in one PUT, so the admin can't end up with a half-saved
+// pair if they navigated away mid-edit.
+function DefaultsCard({
+  defaults,
+  onSaved,
+}: {
+  defaults: QuotaSettingsView | null
+  onSaved: (next: QuotaSettingsView) => void
+}) {
+  const [vms, setVMs] = useState<string>('')
+  const [jobs, setJobs] = useState<string>('')
+  const [busy, setBusy] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (defaults) {
+      setVMs(String(defaults.member_max_vms))
+      setJobs(String(defaults.member_max_active_jobs))
+    }
+  }, [defaults])
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSaved(false)
+    setBusy(true)
+    try {
+      const next = await saveQuotaSettings({
+        member_max_vms: Number(vms),
+        member_max_active_jobs: Number(jobs),
+      })
+      onSaved(next)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'save failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div>
+      <div className="eyebrow" style={{ marginBottom: 10 }}>Workspace defaults</div>
+      <form onSubmit={submit} className="glass" style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--ink-mute)', lineHeight: 1.55 }}>
+          Caps applied to non-admin users without a per-user override.
+          Zero is allowed and means &quot;members can&apos;t provision / submit
+          at all&quot;. Admins are unaffected.
+        </p>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <div className="n-field" style={{ flex: '0 0 200px' }}>
+            <label className="n-label" htmlFor="quota-vms">VMs per member</label>
+            <input
+              id="quota-vms"
+              className="n-input"
+              type="number"
+              min={0}
+              value={vms}
+              disabled={busy || defaults === null}
+              onChange={(e) => setVMs(e.target.value)}
+            />
+          </div>
+          <div className="n-field" style={{ flex: '0 0 200px' }}>
+            <label className="n-label" htmlFor="quota-jobs">Active GPU jobs per member</label>
+            <input
+              id="quota-jobs"
+              className="n-input"
+              type="number"
+              min={0}
+              value={jobs}
+              disabled={busy || defaults === null}
+              onChange={(e) => setJobs(e.target.value)}
+            />
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button type="submit" className="n-btn n-btn-primary" disabled={busy || defaults === null} style={{ minWidth: 100 }}>
+            {busy ? 'Saving…' : 'Save defaults'}
+          </button>
+          {saved && <span style={{ fontSize: 13, color: 'var(--ok)' }}>Saved.</span>}
+          {error && <span style={{ fontSize: 13, color: 'var(--err)' }}>{error}</span>}
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// OverridesCard — table of non-admin, non-suspended users with their
+// effective caps and per-user override controls. Saves are
+// independent per row + dimension (VM / GPU); a clear-to-default
+// button resets just that dimension. We don't show admins because
+// the gate doesn't apply, and don't show suspended because they
+// can't consume quota anyway.
+function OverridesCard({
+  users,
+  defaults,
+  onSaved,
+}: {
+  users: UserManagementView[]
+  defaults: QuotaSettingsView | null
+  onSaved: () => void
+}) {
+  return (
+    <div>
+      <div className="eyebrow" style={{ marginBottom: 10 }}>Per-user overrides</div>
+      <div className="glass" style={{ padding: '18px 22px' }}>
+        {users.length === 0 ? (
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-mute)' }}>
+            No active members yet. New users inherit the workspace defaults
+            until you override here.
+          </p>
+        ) : (
+          <div style={{ overflowX: 'auto', margin: '0 -8px' }}>
+            <table className="w-full text-left" style={{ fontSize: 13, borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ color: 'var(--ink-mute)', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                  <th style={{ padding: '8px 8px', fontWeight: 500 }}>User</th>
+                  <th style={{ padding: '8px 8px', fontWeight: 500 }}>VMs</th>
+                  <th style={{ padding: '8px 8px', fontWeight: 500 }}>GPU jobs</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.id} style={{ borderTop: '1px solid var(--line)' }}>
+                    <td style={{ padding: '10px 8px' }}>
+                      <div style={{ color: 'var(--ink)', fontWeight: 500 }}>{u.name || '—'}</div>
+                      <div style={{ color: 'var(--ink-body)', fontFamily: 'Geist Mono, monospace', fontSize: 11 }}>
+                        {u.email}
+                      </div>
+                    </td>
+                    <td style={{ padding: '10px 8px', verticalAlign: 'top' }}>
+                      <QuotaCell
+                        userID={u.id}
+                        dimension="vm"
+                        override={u.vm_quota_override}
+                        defaultValue={defaults?.member_max_vms ?? 0}
+                        effective={u.effective_vm_quota}
+                        onSaved={onSaved}
+                      />
+                    </td>
+                    <td style={{ padding: '10px 8px', verticalAlign: 'top' }}>
+                      <QuotaCell
+                        userID={u.id}
+                        dimension="gpu"
+                        override={u.gpu_job_quota_override}
+                        defaultValue={defaults?.member_max_active_jobs ?? 0}
+                        effective={u.effective_gpu_job_quota}
+                        onSaved={onSaved}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// QuotaCell — one (user, dimension) override widget. Three states:
+//   - inheriting default — shows "default · N", typing flips it to
+//     edit mode with a Save button.
+//   - overridden — shows "override · N" + an inline edit input that
+//     saves on blur/enter, plus a "↺ default" link to clear the override.
+function QuotaCell({
+  userID,
+  dimension,
+  override,
+  defaultValue,
+  effective,
+  onSaved,
+}: {
+  userID: number
+  dimension: 'vm' | 'gpu'
+  override: number | null
+  defaultValue: number
+  effective: number
+  onSaved: () => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState<string>(String(override ?? defaultValue))
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setDraft(String(override ?? defaultValue))
+    setError(null)
+  }, [override, defaultValue])
+
+  const save = async () => {
+    const n = Number(draft)
+    if (!Number.isInteger(n) || n < 0) {
+      setError('non-negative integer')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      await setUserQuota(userID, dimension === 'vm' ? { vm_quota_override: n } : { gpu_job_quota_override: n })
+      setEditing(false)
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'save failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const clear = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await setUserQuota(userID, dimension === 'vm' ? { vm_quota_override: null } : { gpu_job_quota_override: null })
+      setEditing(false)
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'clear failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const isOverridden = override !== null
+
+  if (!editing) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span
+          style={{
+            fontSize: 12,
+            fontFamily: 'Geist Mono, monospace',
+            padding: '3px 8px',
+            borderRadius: 4,
+            border: '1px solid var(--line)',
+            background: isOverridden ? 'rgba(20,18,28,0.05)' : 'transparent',
+            color: 'var(--ink)',
+            cursor: 'pointer',
+          }}
+          onClick={() => setEditing(true)}
+          title={isOverridden ? `override (default: ${defaultValue})` : 'inheriting workspace default — click to override'}
+        >
+          {isOverridden ? `override · ${effective}` : `default · ${effective}`}
+        </span>
+        {error && <span style={{ fontSize: 11, color: 'var(--err)' }}>{error}</span>}
+      </div>
+    )
+  }
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <input
+        type="number"
+        min={0}
+        autoFocus
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') void save()
+          if (e.key === 'Escape') setEditing(false)
+        }}
+        disabled={busy}
+        style={{
+          width: 64,
+          height: 26,
+          fontSize: 12,
+          padding: '0 8px',
+          borderRadius: 6,
+          border: '1px solid var(--line-strong)',
+          background: 'var(--surface)',
+          color: 'var(--ink)',
+          outline: 'none',
+        }}
+      />
+      <button
+        type="button"
+        className="n-btn"
+        onClick={save}
+        disabled={busy}
+        style={{ height: 26, fontSize: 11, padding: '0 8px' }}
+      >
+        Save
+      </button>
+      {isOverridden && (
+        <button
+          type="button"
+          className="n-btn-ghost"
+          onClick={clear}
+          disabled={busy}
+          style={{
+            height: 26,
+            fontSize: 11,
+            padding: '0 6px',
+            color: 'var(--ink-mute)',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+          }}
+          title={`Clear override and revert to workspace default (${defaultValue})`}
+        >
+          ↺ default
+        </button>
+      )}
+      <button
+        type="button"
+        className="n-btn-ghost"
+        onClick={() => setEditing(false)}
+        disabled={busy}
+        style={{
+          height: 26,
+          fontSize: 11,
+          padding: '0 6px',
+          color: 'var(--ink-mute)',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+        }}
+      >
+        Cancel
+      </button>
+      {error && <span style={{ fontSize: 11, color: 'var(--err)' }}>{error}</span>}
+    </div>
+  )
+}
+
+function formatBytes(n: number): string {
+  if (!n || n < 0) return '0 B'
+  if (n < 1024) return `${n} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let v = n / 1024
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(v >= 100 ? 0 : 1)} ${units[i]}`
+}
+
+function pct(used: number, total: number): string {
+  if (total <= 0) return '0'
+  const r = (used / total) * 100
+  if (r >= 10) return r.toFixed(0)
+  return r.toFixed(1)
+}

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -972,6 +972,176 @@ func buildMagicLinkBody(displayName, link string) string {
 		"If you didn't expect this email, ignore it. The link expires in 24 hours and works only once.\r\n"
 }
 
+// QuotaSettingsView is the JSON shape for the /api/settings/quotas
+// endpoints. Same field names the frontend uses; the backend struct
+// (db.QuotaSettings) exposes ID we don't need to leak.
+type QuotaSettingsView struct {
+	MemberMaxVMs        int `json:"member_max_vms"`
+	MemberMaxActiveJobs int `json:"member_max_active_jobs"`
+}
+
+// GetQuotas handles GET /api/settings/quotas — admin-only read of
+// the workspace quota defaults (caps that apply when a user has no
+// per-row override set).
+func (a *Auth) GetQuotas(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	row, err := a.auth.GetQuotaSettings()
+	if err != nil {
+		log.Printf("get quotas: %v", err)
+		response.InternalError(w, "failed to load quota settings")
+		return
+	}
+	response.Success(w, QuotaSettingsView{
+		MemberMaxVMs:        row.MemberMaxVMs,
+		MemberMaxActiveJobs: row.MemberMaxActiveJobs,
+	})
+}
+
+// SaveQuotas handles PUT /api/settings/quotas — admin-only update of
+// the workspace defaults. Request body matches QuotaSettingsView.
+// Either field can be omitted to leave it untouched, but a field
+// present with a negative value is a 400 (the service rejects).
+func (a *Auth) SaveQuotas(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	// Use pointers so a missing field stays at the persisted value.
+	var body struct {
+		MemberMaxVMs        *int `json:"member_max_vms"`
+		MemberMaxActiveJobs *int `json:"member_max_active_jobs"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+	current, err := a.auth.GetQuotaSettings()
+	if err != nil {
+		log.Printf("save quotas: load current: %v", err)
+		response.InternalError(w, "failed to load quota settings")
+		return
+	}
+	maxVMs := current.MemberMaxVMs
+	maxJobs := current.MemberMaxActiveJobs
+	if body.MemberMaxVMs != nil {
+		maxVMs = *body.MemberMaxVMs
+	}
+	if body.MemberMaxActiveJobs != nil {
+		maxJobs = *body.MemberMaxActiveJobs
+	}
+	updated, err := a.auth.SaveQuotaSettings(maxVMs, maxJobs)
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	response.Success(w, QuotaSettingsView{
+		MemberMaxVMs:        updated.MemberMaxVMs,
+		MemberMaxActiveJobs: updated.MemberMaxActiveJobs,
+	})
+}
+
+// userQuotaRequest is the body of PUT /api/users/{id}/quota. Each
+// field is *int: nil means "leave that override alone"; setting it
+// to a JSON null clears the override (revert to workspace default);
+// a number sets an explicit cap. JSON's distinction between
+// "null" / absent / value lines up with the three semantics — we
+// use json.RawMessage to preserve null vs absent.
+type userQuotaRequest struct {
+	VMQuotaOverride     json.RawMessage `json:"vm_quota_override"`
+	GPUJobQuotaOverride json.RawMessage `json:"gpu_job_quota_override"`
+}
+
+// SetUserQuota handles PUT /api/users/{id}/quota — admin-only patch
+// of one user's quota override columns. See userQuotaRequest for the
+// three-state JSON semantics.
+func (a *Auth) SetUserQuota(w http.ResponseWriter, r *http.Request) {
+	requester := ctxutil.User(r.Context())
+	if requester == nil || !requester.IsAdmin {
+		response.Error(w, http.StatusForbidden, "admin only")
+		return
+	}
+	targetID, err := parseUserID(r)
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	var body userQuotaRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		response.BadRequest(w, "invalid JSON")
+		return
+	}
+
+	setVM, vmVal, clearVM, err := decodeQuotaPatch(body.VMQuotaOverride, "vm_quota_override")
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+	setGPU, gpuVal, clearGPU, err := decodeQuotaPatch(body.GPUJobQuotaOverride, "gpu_job_quota_override")
+	if err != nil {
+		response.BadRequest(w, err.Error())
+		return
+	}
+
+	// Apply set + clear separately. Set first so a request that does
+	// {clear vm, set gpu} ends with both intents recognised even if
+	// the user wrote them in reverse order.
+	if setVM || setGPU {
+		var vmPtr, gpuPtr *int
+		if setVM {
+			vmPtr = &vmVal
+		}
+		if setGPU {
+			gpuPtr = &gpuVal
+		}
+		if err := a.auth.SetUserQuotaOverride(targetID, vmPtr, gpuPtr); err != nil {
+			if errors.Is(err, service.ErrUserNotFound) {
+				response.NotFound(w, "user not found")
+				return
+			}
+			log.Printf("set user quota: %v", err)
+			response.InternalError(w, "failed to set quota")
+			return
+		}
+	}
+	if clearVM || clearGPU {
+		if err := a.auth.ClearUserQuotaOverride(targetID, clearVM, clearGPU); err != nil {
+			if errors.Is(err, service.ErrUserNotFound) {
+				response.NotFound(w, "user not found")
+				return
+			}
+			log.Printf("clear user quota: %v", err)
+			response.InternalError(w, "failed to clear quota")
+			return
+		}
+	}
+	response.Success(w, map[string]any{"id": targetID, "ok": true})
+}
+
+// decodeQuotaPatch reduces the three-state JSON to a (set, value,
+// clear) triple. Returns (false, 0, false, nil) when the field was
+// absent — caller should leave the column untouched.
+func decodeQuotaPatch(raw json.RawMessage, field string) (set bool, value int, clear bool, err error) {
+	if len(raw) == 0 {
+		return false, 0, false, nil
+	}
+	if string(raw) == "null" {
+		return false, 0, true, nil
+	}
+	var n int
+	if e := json.Unmarshal(raw, &n); e != nil {
+		return false, 0, false, fmt.Errorf("%s must be a non-negative integer or null", field)
+	}
+	if n < 0 {
+		return false, 0, false, fmt.Errorf("%s must be non-negative", field)
+	}
+	return true, n, false, nil
+}
+
 // VerifyStatus handles GET /api/access-code/status — returns whether the
 // authenticated user is verified against the current access code version.
 func (a *Auth) VerifyStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -198,6 +198,9 @@ func NewRouter(d Deps) http.Handler {
 				r.Put("/settings/smtp", auth.SaveSMTP)
 				r.Post("/settings/smtp/test", auth.SendTestEmail)
 				r.Post("/users/email-unlinked", auth.EmailUnlinked)
+				r.Get("/settings/quotas", auth.GetQuotas)
+				r.Put("/settings/quotas", auth.SaveQuotas)
+				r.Put("/users/{id}/quota", auth.SetUserQuota)
 
 				r.Get("/nodes", nodes.List)
 				r.Get("/ips", ips.List)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -50,6 +50,17 @@ type User struct {
 	// email-based flow). Suspended users' sessions are revoked at
 	// suspend time.
 	Suspended bool `gorm:"default:false;index" json:"-"`
+	// VMQuotaOverride and GPUJobQuotaOverride let an admin grant a
+	// specific user a quota above (or below) the workspace default
+	// stored on QuotaSettings. Both are nullable pointers: nil means
+	// "use the workspace default," a value means "use this number"
+	// (zero is allowed and means "this user can't provision/submit").
+	// Pointers rather than int with a sentinel because GORM's
+	// AutoMigrate fills new columns on existing rows with the zero
+	// value, and we'd then have no way to distinguish "no override"
+	// from "explicit zero override."
+	VMQuotaOverride     *int `gorm:"column:vm_quota_override" json:"-"`
+	GPUJobQuotaOverride *int `gorm:"column:gpu_job_quota_override" json:"-"`
 }
 
 // Session ties a browser cookie to a user for a limited duration.
@@ -147,6 +158,23 @@ type SMTPSettings struct {
 	// using them. Useful for temporary outages or migrations without
 	// wiping the form.
 	Enabled bool `gorm:"default:false"`
+}
+
+// QuotaSettings stores workspace-wide quota defaults. Singleton (ID=1).
+// Members hit these caps; admins bypass via Request.RequesterIsAdmin.
+// Per-user overrides on db.User.VMQuotaOverride /
+// db.User.GPUJobQuotaOverride layer on top — the effective cap is the
+// override when present, else the value here.
+//
+// Seeded on first boot from the legacy hardcoded constants
+// (provision.MemberMaxVMs, gpu.MemberMaxActiveJobs) so an upgrade
+// doesn't change observed behaviour. Future schema bumps that add new
+// quota dimensions (CPU cores, RAM, etc.) extend this row rather than
+// introducing parallel tables.
+type QuotaSettings struct {
+	ID                  uint `gorm:"primaryKey"`
+	MemberMaxVMs        int  `gorm:"default:5"`
+	MemberMaxActiveJobs int  `gorm:"default:5"`
 }
 
 // GopherSettings stores the Gopher tunnel-gateway credentials. Only a single

--- a/internal/gpu/service.go
+++ b/internal/gpu/service.go
@@ -68,6 +68,15 @@ type Service struct {
 	db     *gorm.DB
 	logDir string
 	clock  func() time.Time
+	quota  QuotaResolver // optional; nil falls back to MemberMaxActiveJobs
+}
+
+// QuotaResolver is the slice of service.AuthService the GPU enqueue
+// gate consults. Same shape and contract as
+// provision.QuotaResolver — defined here so the GPU package doesn't
+// take a cross-package dependency.
+type QuotaResolver interface {
+	EffectiveGPUJobQuota(userID uint) (int, error)
 }
 
 // Option tunes a Service at construction.
@@ -79,6 +88,17 @@ func WithClock(f func() time.Time) Option {
 		if f != nil {
 			s.clock = f
 		}
+	}
+}
+
+// WithQuotaResolver wires a QuotaResolver onto the Service so
+// EnqueueJob's member gate consults per-user overrides + the
+// workspace default rather than the legacy MemberMaxActiveJobs
+// constant. main.go passes service.AuthService here; tests can
+// leave it unset and rely on the constant.
+func WithQuotaResolver(q QuotaResolver) Option {
+	return func(s *Service) {
+		s.quota = q
 	}
 }
 
@@ -139,9 +159,17 @@ func (s *Service) EnqueueJob(ctx context.Context, req EnqueueRequest) (*db.GPUJo
 			Count(&active).Error; err != nil {
 			return nil, fmt.Errorf("count active gpu jobs: %w", err)
 		}
-		if int(active) >= MemberMaxActiveJobs {
+		quotaCap := MemberMaxActiveJobs
+		if s.quota != nil {
+			c, err := s.quota.EffectiveGPUJobQuota(req.OwnerID)
+			if err != nil {
+				return nil, fmt.Errorf("resolve effective gpu job quota: %w", err)
+			}
+			quotaCap = c
+		}
+		if int(active) >= quotaCap {
 			return nil, &internalerrors.ConflictError{
-				Message: fmt.Sprintf("GPU job quota reached: members may have at most %d queued or running jobs at once", MemberMaxActiveJobs),
+				Message: fmt.Sprintf("GPU job quota reached: members may have at most %d queued or running jobs at once", quotaCap),
 			}
 		}
 	}

--- a/internal/provision/quota.go
+++ b/internal/provision/quota.go
@@ -1,24 +1,31 @@
 package provision
 
-// Quota defaults. Members hit these caps; admins bypass via Request.
-// RequesterIsAdmin. They're vars (not consts) so tests can override; once a
-// QuotaSettings table lands, swap these for a settings-backed lookup.
-//
-// MemberMaxVMs caps how many active VMs a single non-admin user can own
-// concurrently. Beyond this, Provision returns ConflictError before any
-// hypervisor work begins. Soft-deleted rows do not count.
-//
-// MemberAllowedTiers is the allowlist (not blocklist) of tiers non-admins
-// may request. New tiers added to nodescore.Tiers are member-denied by
-// default — the operator must explicitly opt them in here.
-var (
-	MemberMaxVMs       = 5
-	MemberAllowedTiers = map[string]struct{}{
-		"small":  {},
-		"medium": {},
-		"large":  {},
-	}
-)
+// MemberMaxVMs is the legacy fallback cap used when no QuotaResolver
+// has been wired onto the Service. Tests rely on it being a var so
+// they can override via the package-level binding without booting an
+// auth service. Production wires service.AuthService through
+// SetQuotaResolver and per-user overrides take precedence.
+var MemberMaxVMs = 5
+
+// MemberAllowedTiers is the allowlist (not blocklist) of tiers
+// non-admins may request. New tiers added to nodescore.Tiers are
+// member-denied by default — the operator must explicitly opt them in.
+var MemberAllowedTiers = map[string]struct{}{
+	"small":  {},
+	"medium": {},
+	"large":  {},
+}
+
+// QuotaResolver is the slice of service.AuthService the provision
+// gate consults to find a user's effective VM cap (per-user override
+// or workspace default). Defined here at the consumer per the
+// "small interfaces, accept interfaces" convention; main.go wires
+// AuthService in via Service.SetQuotaResolver. Nil falls back to
+// the legacy MemberMaxVMs constant — keeps the test-only paths that
+// don't construct a full auth stack working.
+type QuotaResolver interface {
+	EffectiveVMQuota(userID uint) (int, error)
+}
 
 // IsTierMemberAllowed reports whether the given tier is in the member
 // allowlist. Admins should bypass this check via Request.RequesterIsAdmin.

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -175,6 +175,20 @@ type Service struct {
 	// guards concurrent provisions from racing on cluster/nextid by
 	// serializing the clone path. SQLite already serializes ippool.Reserve.
 	cloneMu sync.Mutex
+
+	// quota resolves a user's effective VM cap (per-user override or
+	// workspace default) at gate-time. nil falls back to the package
+	// constant MemberMaxVMs — preserves the path tests use without
+	// booting auth.
+	quota QuotaResolver
+}
+
+// SetQuotaResolver wires a QuotaResolver onto the Service so the
+// member quota gate can consult per-user overrides + workspace
+// defaults rather than the legacy MemberMaxVMs constant. Idempotent;
+// pass nil to revert to the constant fallback.
+func (s *Service) SetQuotaResolver(q QuotaResolver) {
+	s.quota = q
 }
 
 // New constructs a Service. The verifier defaults to a noop that always
@@ -334,9 +348,17 @@ func (s *Service) Provision(ctx context.Context, req Request, progress ProgressR
 		if err := s.db.WithContext(ctx).Model(&db.VM{}).Where("owner_id = ?", *req.OwnerID).Count(&owned).Error; err != nil {
 			return nil, fmt.Errorf("count owned vms: %w", err)
 		}
-		if int(owned) >= MemberMaxVMs {
+		quotaCap := MemberMaxVMs
+		if s.quota != nil {
+			c, err := s.quota.EffectiveVMQuota(*req.OwnerID)
+			if err != nil {
+				return nil, fmt.Errorf("resolve effective vm quota: %w", err)
+			}
+			quotaCap = c
+		}
+		if int(owned) >= quotaCap {
 			return nil, &internalerrors.ConflictError{
-				Message: fmt.Sprintf("VM quota reached: members may own at most %d VMs at once", MemberMaxVMs),
+				Message: fmt.Sprintf("VM quota reached: members may own at most %d VMs at once", quotaCap),
 			}
 		}
 	}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -98,16 +98,38 @@ type UserManagementView struct {
 	// muted row + a Suspended pill, and the actions menu can swap
 	// "Suspend" for "Unsuspend".
 	Suspended bool `json:"suspended"`
+	// VMQuotaOverride / GPUJobQuotaOverride are nullable: nil means
+	// "use the workspace default." EffectiveVMQuota and
+	// EffectiveGPUJobQuota fold the override + default into the
+	// number that actually applies, so the UI can render either
+	// "default · 5" or "override · 10" without the frontend
+	// re-implementing the resolution.
+	VMQuotaOverride      *int `json:"vm_quota_override"`
+	GPUJobQuotaOverride  *int `json:"gpu_job_quota_override"`
+	EffectiveVMQuota     int  `json:"effective_vm_quota"`
+	EffectiveGPUJobQuota int  `json:"effective_gpu_job_quota"`
 }
 
-func userToManagementView(u *db.User, settings *db.OAuthSettings) *UserManagementView {
+func userToManagementView(u *db.User, settings *db.OAuthSettings, quotas *db.QuotaSettings) *UserManagementView {
 	v := &UserManagementView{
-		UserView:  userToView(u),
-		CreatedAt: u.CreatedAt,
-		Providers: detectProviders(u),
-		Suspended: u.Suspended,
+		UserView:            userToView(u),
+		CreatedAt:           u.CreatedAt,
+		Providers:           detectProviders(u),
+		Suspended:           u.Suspended,
+		VMQuotaOverride:     u.VMQuotaOverride,
+		GPUJobQuotaOverride: u.GPUJobQuotaOverride,
 	}
 	v.Verified = isUserVerifiedFromSettings(u, settings)
+	if u.VMQuotaOverride != nil {
+		v.EffectiveVMQuota = *u.VMQuotaOverride
+	} else if quotas != nil {
+		v.EffectiveVMQuota = quotas.MemberMaxVMs
+	}
+	if u.GPUJobQuotaOverride != nil {
+		v.EffectiveGPUJobQuota = *u.GPUJobQuotaOverride
+	} else if quotas != nil {
+		v.EffectiveGPUJobQuota = quotas.MemberMaxActiveJobs
+	}
 	return v
 }
 
@@ -1140,6 +1162,145 @@ func (s *AuthService) ListUnlinkedActiveUsers(excludeID uint) ([]db.User, error)
 	return users, err
 }
 
+// GetQuotaSettings returns the stored workspace quota defaults,
+// creating the singleton row on first call. Defaults match the legacy
+// hardcoded constants (MemberMaxVMs=5, MemberMaxActiveJobs=5) so an
+// upgrade against an existing DB doesn't change observed behaviour.
+//
+// The Where() + Attrs() split is load-bearing: passing the defaults
+// inside the conditions struct would make GORM filter by them too, so
+// after a SaveQuotaSettings(11, 12) the next read's WHERE wouldn't
+// match the now-updated row and FirstOrCreate would try to INSERT a
+// second id=1 row, hitting the uniqueness constraint.
+func (s *AuthService) GetQuotaSettings() (*db.QuotaSettings, error) {
+	var row db.QuotaSettings
+	err := s.db.Where(&db.QuotaSettings{ID: 1}).
+		Attrs(&db.QuotaSettings{MemberMaxVMs: 5, MemberMaxActiveJobs: 5}).
+		FirstOrCreate(&row).Error
+	return &row, err
+}
+
+// SaveQuotaSettings updates the workspace defaults. Both fields are
+// validated to be non-negative; zero is allowed and means "members
+// can't provision / submit." Negative values are rejected as a likely
+// caller bug.
+func (s *AuthService) SaveQuotaSettings(maxVMs, maxJobs int) (*db.QuotaSettings, error) {
+	if maxVMs < 0 || maxJobs < 0 {
+		return nil, fmt.Errorf("quota values must be non-negative")
+	}
+	if _, err := s.GetQuotaSettings(); err != nil {
+		return nil, err
+	}
+	if err := s.db.Model(&db.QuotaSettings{}).Where("id = ?", 1).Updates(map[string]any{
+		"member_max_vms":         maxVMs,
+		"member_max_active_jobs": maxJobs,
+	}).Error; err != nil {
+		return nil, err
+	}
+	return s.GetQuotaSettings()
+}
+
+// SetUserQuotaOverride writes per-user quota overrides. Pass a non-nil
+// pointer to set an explicit cap (zero is allowed and meaningful);
+// pass nil to clear the override and revert that user to the
+// workspace default. Either field can be nil to leave it untouched.
+//
+// The two fields are split (vs. a single struct) so the handler can
+// patch one dimension without requiring the caller to know the other's
+// current value.
+func (s *AuthService) SetUserQuotaOverride(userID uint, vmQuota, gpuJobQuota *int) error {
+	updates := map[string]any{}
+	if vmQuota != nil {
+		updates["vm_quota_override"] = *vmQuota
+	}
+	if gpuJobQuota != nil {
+		updates["gpu_job_quota_override"] = *gpuJobQuota
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	res := s.db.Model(&db.User{}).Where("id = ?", userID).Updates(updates)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// ClearUserQuotaOverride sets one or both override columns back to NULL,
+// reverting the user to the workspace default. GORM's Updates won't
+// write nil through the map[string]any path, so this uses a typed
+// struct write with explicit Select clauses to force the update.
+func (s *AuthService) ClearUserQuotaOverride(userID uint, clearVM, clearGPU bool) error {
+	cols := make([]string, 0, 2)
+	if clearVM {
+		cols = append(cols, "vm_quota_override")
+	}
+	if clearGPU {
+		cols = append(cols, "gpu_job_quota_override")
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	// Use Select + Updates with a struct of nil pointers so GORM sees
+	// "user wants to write NULL." map[string]any{"col": nil} also
+	// works on most drivers but the typed path is unambiguous.
+	res := s.db.Model(&db.User{}).
+		Where("id = ?", userID).
+		Select(cols).
+		Updates(db.User{VMQuotaOverride: nil, GPUJobQuotaOverride: nil})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// EffectiveVMQuota returns the cap that should apply to the named user
+// — override when set, workspace default otherwise. The user row is
+// loaded from the DB; passing pre-loaded user data isn't supported
+// because the typical caller (provision gate) only has a UserID.
+func (s *AuthService) EffectiveVMQuota(userID uint) (int, error) {
+	var user db.User
+	if err := s.db.Select("vm_quota_override").First(&user, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, ErrUserNotFound
+		}
+		return 0, err
+	}
+	if user.VMQuotaOverride != nil {
+		return *user.VMQuotaOverride, nil
+	}
+	settings, err := s.GetQuotaSettings()
+	if err != nil {
+		return 0, err
+	}
+	return settings.MemberMaxVMs, nil
+}
+
+// EffectiveGPUJobQuota mirrors EffectiveVMQuota for GPU jobs.
+func (s *AuthService) EffectiveGPUJobQuota(userID uint) (int, error) {
+	var user db.User
+	if err := s.db.Select("gpu_job_quota_override").First(&user, userID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return 0, ErrUserNotFound
+		}
+		return 0, err
+	}
+	if user.GPUJobQuotaOverride != nil {
+		return *user.GPUJobQuotaOverride, nil
+	}
+	settings, err := s.GetQuotaSettings()
+	if err != nil {
+		return 0, err
+	}
+	return settings.MemberMaxActiveJobs, nil
+}
+
 // GetGopherSettings returns the stored Gopher tunnel credentials. Creates a
 // default empty row on first call.
 func (s *AuthService) GetGopherSettings() (*db.GopherSettings, error) {
@@ -1664,9 +1825,9 @@ func (s *AuthService) ListAllUsers() ([]*UserView, error) {
 }
 
 // ListAllUsersForManagement returns the richer admin-facing shape:
-// CreatedAt + Verified + provider hints, computed against a single
-// OAuthSettings fetch so this stays O(1) DB reads regardless of user
-// count.
+// CreatedAt + Verified + provider hints + effective quotas, computed
+// against a single OAuthSettings + QuotaSettings fetch so the call
+// stays O(1) DB reads regardless of user count.
 func (s *AuthService) ListAllUsersForManagement() ([]*UserManagementView, error) {
 	var users []db.User
 	if err := s.db.Order("created_at DESC").Find(&users).Error; err != nil {
@@ -1676,9 +1837,13 @@ func (s *AuthService) ListAllUsersForManagement() ([]*UserManagementView, error)
 	if err != nil {
 		return nil, err
 	}
+	quotas, err := s.GetQuotaSettings()
+	if err != nil {
+		return nil, err
+	}
 	out := make([]*UserManagementView, len(users))
 	for i := range users {
-		out[i] = userToManagementView(&users[i], settings)
+		out[i] = userToManagementView(&users[i], settings, quotas)
 	}
 	return out, nil
 }

--- a/internal/service/quotas_test.go
+++ b/internal/service/quotas_test.go
@@ -1,0 +1,141 @@
+package service_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"nimbus/internal/db"
+	"nimbus/internal/service"
+)
+
+// newQuotaAuthService is a quota-test-specific helper. Adds the
+// QuotaSettings table to AutoMigrate so the FirstOrCreate-on-read
+// path doesn't trip; seeds one member user the tests can override.
+func newQuotaAuthService(t *testing.T) (*service.AuthService, uint) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "quotas.db")
+	database, err := db.New(path, &db.User{}, &db.OAuthSettings{}, &db.QuotaSettings{})
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	user := &db.User{Name: "alice", Email: "a@x"}
+	if err := database.Create(user).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return service.NewAuthService(database), user.ID
+}
+
+// Default-only path: with no override on the user, the workspace
+// default flows through to the effective cap. Confirms the seed
+// (MemberMaxVMs=5, MemberMaxActiveJobs=5) lands as the answer.
+func TestEffectiveQuota_FallsBackToWorkspaceDefault(t *testing.T) {
+	t.Parallel()
+	svc, uid := newQuotaAuthService(t)
+
+	got, err := svc.EffectiveVMQuota(uid)
+	if err != nil {
+		t.Fatalf("EffectiveVMQuota: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("VM quota = %d, want 5 (default seed)", got)
+	}
+	got, err = svc.EffectiveGPUJobQuota(uid)
+	if err != nil {
+		t.Fatalf("EffectiveGPUJobQuota: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("GPU quota = %d, want 5 (default seed)", got)
+	}
+}
+
+// Override path: per-user override beats the workspace default.
+// Seven > 5 verifies "above default" and zero verifies the explicit
+// "this user can't provision" semantic.
+func TestEffectiveQuota_OverrideTrumpsDefault(t *testing.T) {
+	t.Parallel()
+	svc, uid := newQuotaAuthService(t)
+
+	seven := 7
+	if err := svc.SetUserQuotaOverride(uid, &seven, nil); err != nil {
+		t.Fatalf("SetUserQuotaOverride: %v", err)
+	}
+	got, err := svc.EffectiveVMQuota(uid)
+	if err != nil {
+		t.Fatalf("EffectiveVMQuota: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("VM quota = %d, want 7 (override)", got)
+	}
+	// GPU dimension wasn't overridden; should still report the default.
+	if got, _ := svc.EffectiveGPUJobQuota(uid); got != 5 {
+		t.Errorf("GPU quota = %d, want 5 (untouched, defaults)", got)
+	}
+
+	// Explicit zero — this user can't provision.
+	zero := 0
+	if err := svc.SetUserQuotaOverride(uid, &zero, nil); err != nil {
+		t.Fatalf("SetUserQuotaOverride zero: %v", err)
+	}
+	if got, _ := svc.EffectiveVMQuota(uid); got != 0 {
+		t.Errorf("VM quota = %d, want 0 (explicit zero override)", got)
+	}
+}
+
+// Clear path: override flipped on, then off, reverts to default.
+// Critical because we use a typed Updates(nil-pointer) trick to write
+// NULL — easy to get wrong and end up writing zero instead.
+func TestEffectiveQuota_ClearRevertsToDefault(t *testing.T) {
+	t.Parallel()
+	svc, uid := newQuotaAuthService(t)
+
+	ten := 10
+	if err := svc.SetUserQuotaOverride(uid, &ten, &ten); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got, _ := svc.EffectiveVMQuota(uid); got != 10 {
+		t.Fatalf("pre-clear VM = %d, want 10", got)
+	}
+
+	if err := svc.ClearUserQuotaOverride(uid, true, true); err != nil {
+		t.Fatalf("ClearUserQuotaOverride: %v", err)
+	}
+	got, _ := svc.EffectiveVMQuota(uid)
+	if got != 5 {
+		t.Errorf("post-clear VM = %d, want 5 (back to default)", got)
+	}
+	got, _ = svc.EffectiveGPUJobQuota(uid)
+	if got != 5 {
+		t.Errorf("post-clear GPU = %d, want 5", got)
+	}
+}
+
+// Workspace default change propagates to a user without an override.
+// Confirms the resolver always reads the live row, not a snapshot.
+func TestEffectiveQuota_DefaultChangeFlowsThrough(t *testing.T) {
+	t.Parallel()
+	svc, uid := newQuotaAuthService(t)
+
+	if _, err := svc.SaveQuotaSettings(11, 12); err != nil {
+		t.Fatalf("SaveQuotaSettings: %v", err)
+	}
+	if got, _ := svc.EffectiveVMQuota(uid); got != 11 {
+		t.Errorf("VM quota = %d, want 11", got)
+	}
+	if got, _ := svc.EffectiveGPUJobQuota(uid); got != 12 {
+		t.Errorf("GPU quota = %d, want 12", got)
+	}
+}
+
+// Negative quota values are rejected at save — they never reach the
+// settings row, so an EffectiveVMQuota call won't return a negative.
+func TestSaveQuotaSettings_RejectsNegative(t *testing.T) {
+	t.Parallel()
+	svc, _ := newQuotaAuthService(t)
+
+	if _, err := svc.SaveQuotaSettings(-1, 5); err == nil {
+		t.Error("expected error on negative VM quota")
+	}
+	if _, err := svc.SaveQuotaSettings(5, -1); err == nil {
+		t.Error("expected error on negative GPU quota")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded \`MemberMaxVMs\` / \`MemberMaxActiveJobs\` constants with a settings-backed lookup, adds per-user override columns, and ships an admin-only \`/quotas\` page that doubles as the sysadmin's landing surface.

Members hit the workspace defaults unless they have a per-user override; admins always bypass.

## Backend

- **Schema** (AutoMigrate handles the column adds):
  - \`QuotaSettings\` singleton — workspace defaults, seeded 5/5 to match the legacy constants so an upgrade is a no-op behaviourally.
  - \`User.VMQuotaOverride\` / \`GPUJobQuotaOverride\` — \`*int\` columns. \`nil\` = inherit default, value = explicit cap (zero allowed and meaningful).

- **Service**:
  - \`GetQuotaSettings\` / \`SaveQuotaSettings\` (rejects negative).
  - \`SetUserQuotaOverride\` / \`ClearUserQuotaOverride\` (writes NULL via the typed-struct trick).
  - \`EffectiveVMQuota\` / \`EffectiveGPUJobQuota\` — single source of truth for "what cap applies."

- **Gate threading** via small \`QuotaResolver\` interfaces per consumer:
  - \`provision.Service.SetQuotaResolver\` and \`gpu.WithQuotaResolver\` accept \`service.AuthService\`. Nil falls back to the legacy constants — preserves test paths that don't construct an auth stack.

- **Routes** (admin only):
  - \`GET\`/\`PUT /api/settings/quotas\`
  - \`PUT /api/users/{id}/quota\` — per-user override with three-state JSON per dimension: absent (leave alone), null (clear), number (set).

- **\`UserManagementView\`** gained \`vm_quota_override\`, \`gpu_job_quota_override\`, \`effective_vm_quota\`, \`effective_gpu_job_quota\` so the UI can render either \"default · 5\" or \"override · 10\" without re-implementing the resolution. \`ListAllUsersForManagement\` fetches \`QuotaSettings\` once per call alongside \`OAuthSettings\` — no N+1.

## Frontend — \`/quotas\` page (admin only)

Three sections, in priority order:

1. **System overview** — 7 stat cards (cluster nodes, CPU / RAM / storage utilisation, IP pool, VM count, user count). Reuses existing endpoints (\`/api/nodes\`, \`/api/cluster/stats\`, \`/api/ips\`, \`/api/cluster/vms\`, \`/api/users\`); no new backend. Each fetch surfaces its own loaded state so a slow \`/api/cluster/vms\` doesn't black out the rest.
2. **Workspace defaults** — VMs + GPU jobs inputs, single Save.
3. **Per-user overrides** — table of non-admin, non-suspended users with an inline override widget per dimension. Click the chip to flip into edit mode; save / cancel / \"↺ default\" controls; saves are independent per (user, dimension).

Quotas link added to the Control Panel dropdown between Users and Email.

## Tests (\`service/quotas_test.go\`)

- Default fallback when no override set.
- Override trumps default (including explicit zero).
- Clear path reverts to default (defends the typed-struct NULL trick).
- Workspace default change flows through to no-override users.
- \`SaveQuotaSettings\` rejects negative values.

Found and documented one GORM gotcha during testing: \`FirstOrCreate\` with non-zero conditions filters by them, so after a save the WHERE no longer matches the row and a new INSERT trips the uniqueness constraint. Fix is \`Where(&X{ID:1}).Attrs(&X{...defaults}).FirstOrCreate(&row)\`. Note added to CLAUDE.md.

## Test plan

- [x] \`go test -race ./...\`, \`go vet\`, \`gofmt -l .\` clean
- [x] \`npm run type-check\`, \`npm run lint\`, \`npm run build\` clean
- [ ] Land on \`/quotas\` as admin: 7 cards populate; defaults form prefilled with current values.
- [ ] Bump VM default from 5 → 7 → save → confirm a member without override now shows \`default · 7\`.
- [ ] Click a member's VM cell, type 10, save → chip flips to \`override · 10\`. Click \"↺ default\" → reverts to \`default · 7\`.
- [ ] Member at quota tries to provision → \`409\` with the new effective number in the message.