### PR TITLE
feat(nodemgr): auto-bootstrap templates on new nodes + cleanup on Remove

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -583,6 +583,12 @@ func main() {
 		SelfHostName:        selfHost,
 		VMDiskStorage:       cfg.VMDiskStorage,
 	})
+	// Auto-bootstrap templates onto newly-observed nodes. The reconcile
+	// loop checks each online node's template count and fires
+	// bootstrapSvc.Bootstrap async for any node with a deficit. Slow
+	// (~10-20 min for the full 4-OS catalog) so an in-flight guard
+	// inside nodemgr prevents the every-60 s tick from stacking calls.
+	nodeMgrSvc.SetTemplateBootstrapper(bootstrapSvc)
 	// Background reconcile: same cadence as the IP pool's. Observed
 	// nodes upsert + LastSeenAt bump; unobserved nodes prune after the
 	// miss threshold, mirroring the ippool pattern. Failures are logged

--- a/internal/nodemgr/auto_bootstrap_test.go
+++ b/internal/nodemgr/auto_bootstrap_test.go
@@ -1,0 +1,181 @@
+package nodemgr_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"nimbus/internal/bootstrap"
+	"nimbus/internal/db"
+	"nimbus/internal/nodemgr"
+	"nimbus/internal/proxmox"
+)
+
+// fakeBootstrapper records every Bootstrap call so tests can assert
+// that auto-bootstrap fired for the expected nodes (and only those).
+type fakeBootstrapper struct {
+	mu    sync.Mutex
+	calls []bootstrap.Request
+	// done is closed every time a Bootstrap call returns. Tests use it
+	// to await the goroutine that runReconcile fires off.
+	done chan struct{}
+	// hold blocks Bootstrap from returning until the test signals. Used
+	// by the in-flight-guard test so the second Reconcile observes a
+	// live in-flight slot rather than a returned-already one.
+	hold chan struct{}
+}
+
+func newFakeBootstrapper() *fakeBootstrapper {
+	return &fakeBootstrapper{done: make(chan struct{}, 8)}
+}
+
+func (f *fakeBootstrapper) Bootstrap(ctx context.Context, req bootstrap.Request) (*bootstrap.Result, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, req)
+	hold := f.hold
+	f.mu.Unlock()
+	if hold != nil {
+		select {
+		case <-hold:
+		case <-ctx.Done():
+		}
+	}
+	f.done <- struct{}{}
+	return &bootstrap.Result{}, nil
+}
+
+func (f *fakeBootstrapper) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// newAutoBootstrapTestService builds a service with NodeTemplate
+// migrated so the auto-bootstrap path can read template counts.
+func newAutoBootstrapTestService(t *testing.T) (*nodemgr.Service, *db.DB, *fakePVE) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "nimbus.db")
+	database, err := db.New(dbPath, &db.User{}, &db.VM{}, &db.Node{}, &db.NodeTemplate{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	fake := &fakePVE{}
+	svc := nodemgr.New(database.DB, fake, nodemgr.Config{
+		PerVMMigrateTimeout: 5 * time.Second,
+		TaskPollInterval:    10 * time.Millisecond,
+		VacateMissThreshold: 3,
+	})
+	return svc, database, fake
+}
+
+// TestReconcile_AutoBootstrapFiresForNodeMissingTemplates covers the
+// "new node joins the cluster, has zero templates" path. Reconcile
+// should kick off Bootstrap exactly once for that node.
+func TestReconcile_AutoBootstrapFiresForNodeMissingTemplates(t *testing.T) {
+	t.Parallel()
+
+	svc, _, fake := newAutoBootstrapTestService(t)
+	fake.nodes = []proxmox.Node{
+		{Name: "alpha", Status: "online", MaxCPU: 8, MaxMem: 16 * gib},
+	}
+	bs := newFakeBootstrapper()
+	svc.SetTemplateBootstrapper(bs)
+
+	ctx := context.Background()
+	if _, _, err := svc.Reconcile(ctx, time.Minute); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	select {
+	case <-bs.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Bootstrap was never called")
+	}
+	if got := bs.callCount(); got != 1 {
+		t.Errorf("Bootstrap call count = %d, want 1", got)
+	}
+	if len(bs.calls[0].Nodes) != 1 || bs.calls[0].Nodes[0] != "alpha" {
+		t.Errorf("Bootstrap req nodes = %v, want [alpha]", bs.calls[0].Nodes)
+	}
+}
+
+// TestReconcile_NoBootstrapWhenAllTemplatesPresent covers the steady
+// state — no missing templates, no fan-out.
+func TestReconcile_NoBootstrapWhenAllTemplatesPresent(t *testing.T) {
+	t.Parallel()
+
+	svc, database, fake := newAutoBootstrapTestService(t)
+	fake.nodes = []proxmox.Node{
+		{Name: "alpha", Status: "online", MaxCPU: 8, MaxMem: 16 * gib},
+	}
+	// Seed all catalog templates — Reconcile should see count == len.
+	for i, e := range bootstrap.Catalog {
+		if err := database.WithContext(context.Background()).Create(&db.NodeTemplate{
+			Node: "alpha", OS: e.OS, VMID: 9000 + i,
+		}).Error; err != nil {
+			t.Fatalf("seed template %s: %v", e.OS, err)
+		}
+	}
+	bs := newFakeBootstrapper()
+	svc.SetTemplateBootstrapper(bs)
+
+	if _, _, err := svc.Reconcile(context.Background(), time.Minute); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	// Give the (would-be) goroutine a beat — it shouldn't fire.
+	time.Sleep(100 * time.Millisecond)
+	if got := bs.callCount(); got != 0 {
+		t.Errorf("Bootstrap fired %d times, want 0 (all templates present)", got)
+	}
+}
+
+// TestRemove_DestroysTemplatesBeforeDeleteNode covers the cleanup hook:
+// every db.NodeTemplate row for the removed node maps to a DestroyVM
+// call, and the rows are cleared.
+func TestRemove_DestroysTemplatesBeforeDeleteNode(t *testing.T) {
+	t.Parallel()
+
+	svc, database, fake := newAutoBootstrapTestService(t)
+	fake.nodes = []proxmox.Node{
+		{Name: "alpha", Status: "online", MaxCPU: 8, MaxMem: 16 * gib},
+	}
+	ctx := context.Background()
+	if _, err := svc.List(ctx); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Seed all 4 templates onto alpha.
+	for i, e := range bootstrap.Catalog {
+		if err := database.WithContext(ctx).Create(&db.NodeTemplate{
+			Node: "alpha", OS: e.OS, VMID: 9000 + i,
+		}).Error; err != nil {
+			t.Fatalf("seed template %s: %v", e.OS, err)
+		}
+	}
+	// Force the node into "drained" so Remove's gate passes.
+	if err := database.WithContext(ctx).Model(&db.Node{}).
+		Where("name = ?", "alpha").
+		Update("lock_state", "drained").Error; err != nil {
+		t.Fatalf("force drained: %v", err)
+	}
+
+	if err := svc.Remove(ctx, "alpha"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if got := len(fake.destroys); got != len(bootstrap.Catalog) {
+		t.Errorf("DestroyVM call count = %d, want %d", got, len(bootstrap.Catalog))
+	}
+	for _, c := range fake.destroys {
+		if c.Node != "alpha" {
+			t.Errorf("DestroyVM node = %q, want alpha", c.Node)
+		}
+	}
+	var remaining int64
+	_ = database.WithContext(ctx).Model(&db.NodeTemplate{}).
+		Where("node = ?", "alpha").Count(&remaining).Error
+	if remaining != 0 {
+		t.Errorf("node_templates rows for alpha = %d, want 0", remaining)
+	}
+}

--- a/internal/nodemgr/remove.go
+++ b/internal/nodemgr/remove.go
@@ -3,6 +3,7 @@ package nodemgr
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"nimbus/internal/db"
 )
@@ -42,6 +43,14 @@ func (s *Service) Remove(ctx context.Context, name string) error {
 	if len(managed) > 0 {
 		return fmt.Errorf("%d managed vm(s) reappeared on this node — re-drain before removing", len(managed))
 	}
+	// Destroy template VMs before pvecm delnode — once the node is out
+	// of the cluster, its qemu API is unreachable from the rest of the
+	// cluster and the templates would orphan as ghost VMIDs.
+	// Best-effort: a Proxmox failure here is logged but doesn't block
+	// the removal — the operator can clean up stragglers manually, and
+	// the dangling node_templates rows are cleared regardless so a
+	// future re-add re-bootstraps cleanly.
+	s.destroyNodeTemplates(ctx, name)
 	if err := s.px.DeleteNode(ctx, name); err != nil {
 		return fmt.Errorf("proxmox delete node: %w", err)
 	}
@@ -54,4 +63,38 @@ func (s *Service) Remove(ctx context.Context, name string) error {
 		return fmt.Errorf("delete db row: %w", err)
 	}
 	return nil
+}
+
+// destroyNodeTemplates removes every template VM Nimbus provisioned onto
+// `name` and clears the node_templates rows. Best-effort — individual
+// DestroyVM failures are logged and the loop continues, so a single
+// misbehaving template VM doesn't strand the whole removal flow.
+func (s *Service) destroyNodeTemplates(ctx context.Context, name string) {
+	var rows []db.NodeTemplate
+	if err := s.db.WithContext(ctx).
+		Where("node = ?", name).
+		Find(&rows).Error; err != nil {
+		log.Printf("nodemgr.Remove(%s): list templates: %v", name, err)
+		return
+	}
+	for _, r := range rows {
+		taskID, err := s.px.DestroyVM(ctx, name, r.VMID)
+		if err != nil {
+			log.Printf("nodemgr.Remove(%s): destroy template vmid=%d os=%s: %v",
+				name, r.VMID, r.OS, err)
+			continue
+		}
+		if taskID != "" {
+			if err := s.px.WaitForTask(ctx, name, taskID, s.cfg.TaskPollInterval); err != nil {
+				log.Printf("nodemgr.Remove(%s): wait destroy task vmid=%d: %v",
+					name, r.VMID, err)
+				// fall through to row delete — Proxmox accepted the call
+			}
+		}
+	}
+	if err := s.db.WithContext(ctx).
+		Where("node = ?", name).
+		Delete(&db.NodeTemplate{}).Error; err != nil {
+		log.Printf("nodemgr.Remove(%s): clear node_templates rows: %v", name, err)
+	}
 }

--- a/internal/nodemgr/service.go
+++ b/internal/nodemgr/service.go
@@ -20,6 +20,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"nimbus/internal/bootstrap"
 	"nimbus/internal/db"
 	"nimbus/internal/nodescore"
 	"nimbus/internal/proxmox"
@@ -50,8 +51,17 @@ type ProxmoxClient interface {
 	ClusterName(ctx context.Context) (string, error)
 	Version(ctx context.Context) (string, error)
 	MigrateVM(ctx context.Context, sourceNode string, vmid int, targetNode string, online bool) (string, error)
+	DestroyVM(ctx context.Context, node string, vmid int) (string, error)
 	WaitForTask(ctx context.Context, node, taskID string, interval time.Duration) error
 	DeleteNode(ctx context.Context, node string) error
+}
+
+// TemplateBootstrapper is the subset of *bootstrap.Service nodemgr depends
+// on for auto-bootstrapping templates onto newly-observed nodes. Defined
+// at the consumer per the "accept interfaces" idiom; injected via
+// SetTemplateBootstrapper to keep New's signature unchanged.
+type TemplateBootstrapper interface {
+	Bootstrap(ctx context.Context, req bootstrap.Request) (*bootstrap.Result, error)
 }
 
 // Service is the admin-facing handle for node management. Callers obtain one
@@ -67,6 +77,25 @@ type Service struct {
 	// the map to refuse mid-flight mutations on the same node.
 	drainsMu       sync.Mutex
 	drainsInFlight map[string]bool
+
+	// bootstrapper is the optional template-bootstrap dependency wired
+	// in by main.go via SetTemplateBootstrapper. nil means auto-bootstrap
+	// is disabled (e.g. tests, install-wizard mode).
+	bootstrapper TemplateBootstrapper
+
+	// bootstrapsMu guards bootstrapsInFlight. Bootstrap is slow
+	// (~10-20 min for the full 4-OS catalog) and Reconcile fires every
+	// 60 s — without this guard we'd stack parallel bootstraps onto the
+	// same node. Mirrors the drainsInFlight pattern.
+	bootstrapsMu       sync.Mutex
+	bootstrapsInFlight map[string]bool
+}
+
+// SetTemplateBootstrapper wires a bootstrap service into the nodemgr so
+// the background Reconcile loop can fan out template installs onto newly-
+// observed nodes. Idempotent — pass nil to disable.
+func (s *Service) SetTemplateBootstrapper(b TemplateBootstrapper) {
+	s.bootstrapper = b
 }
 
 // Config tunes per-VM execution timeouts and reconciler thresholds. Zero
@@ -108,10 +137,11 @@ func New(database *gorm.DB, px ProxmoxClient, cfg Config) *Service {
 		cfg.VacateMissThreshold = 3
 	}
 	return &Service{
-		db:             database,
-		px:             px,
-		cfg:            cfg,
-		drainsInFlight: make(map[string]bool),
+		db:                 database,
+		px:                 px,
+		cfg:                cfg,
+		drainsInFlight:     make(map[string]bool),
+		bootstrapsInFlight: make(map[string]bool),
 	}
 }
 
@@ -565,14 +595,114 @@ func (s *Service) Reconcile(ctx context.Context, cycleInterval time.Duration) (o
 			hwByNode[name] = hu
 		}
 	}
-	if _, err := s.reconcileObserved(ctx, nodes, hwByNode); err != nil {
+	rowsByName, err := s.reconcileObserved(ctx, nodes, hwByNode)
+	if err != nil {
 		return 0, 0, err
 	}
 	pruned, err = s.PruneMissing(ctx, cycleInterval)
 	if err != nil {
 		return len(nodes), 0, err
 	}
+	// Fan out template bootstrap onto any online node that's missing
+	// templates. Each call is async + guarded so a slow image download
+	// (~10-20 min for the full 4-OS catalog) doesn't stack across the
+	// every-60 s reconcile cadence.
+	s.maybeBootstrapMissingTemplates(ctx, nodes, rowsByName)
 	return len(nodes), pruned, nil
+}
+
+// maybeBootstrapMissingTemplates inspects each online node and kicks off
+// bootstrap.Service.Bootstrap async for any node missing one or more
+// templates. No-op when no bootstrapper is wired, when the node is
+// cordoned/draining, when arch isn't amd64 (catalog is amd64-only), or
+// when a bootstrap is already in flight for that node.
+//
+// Naturally handles two scenarios with the same code path:
+//   - new node joins the cluster → 0 templates → bootstrap fires
+//   - operator retried after a partial failure → 1-3 templates → fires
+//     for the missing ones (bootstrap is idempotent + force=false skips
+//     present ones, so it cleanly tops up).
+func (s *Service) maybeBootstrapMissingTemplates(ctx context.Context, nodes []proxmox.Node, rowsByName map[string]db.Node) {
+	if s.bootstrapper == nil {
+		return
+	}
+	expected := len(bootstrap.Catalog)
+
+	// Count templates already installed per node.
+	var rows []db.NodeTemplate
+	if err := s.db.WithContext(ctx).Find(&rows).Error; err != nil {
+		// Best-effort — skip the whole pass on DB error rather than
+		// firing bootstraps with stale info.
+		return
+	}
+	countByNode := make(map[string]int, len(nodes))
+	for _, r := range rows {
+		countByNode[r.Node]++
+	}
+
+	for _, n := range nodes {
+		if n.Status != "online" {
+			continue
+		}
+		row := rowsByName[n.Name]
+		if lockOrNone(row.LockState) != "none" {
+			continue
+		}
+		// Skip non-amd64 hosts — Catalog only ships amd64 cloud
+		// images; firing on ARM would just re-fail every cycle.
+		archARM := false
+		for _, t := range nodescore.DeriveAutoTags(autoTagInputFor(row)) {
+			if t == "arm" {
+				archARM = true
+				break
+			}
+		}
+		if archARM {
+			continue
+		}
+		if countByNode[n.Name] >= expected {
+			continue
+		}
+		if !s.acquireBootstrapSlot(n.Name) {
+			continue
+		}
+		go s.runBootstrap(n.Name)
+	}
+}
+
+// acquireBootstrapSlot reserves the in-flight slot for `node`. Returns
+// false if a bootstrap is already in flight on that node (caller skips).
+func (s *Service) acquireBootstrapSlot(node string) bool {
+	s.bootstrapsMu.Lock()
+	defer s.bootstrapsMu.Unlock()
+	if s.bootstrapsInFlight[node] {
+		return false
+	}
+	s.bootstrapsInFlight[node] = true
+	return true
+}
+
+// releaseBootstrapSlot clears the in-flight marker so the next reconcile
+// pass can retry (e.g. after a partial-failure top-up, or if the user
+// later attaches storage).
+func (s *Service) releaseBootstrapSlot(node string) {
+	s.bootstrapsMu.Lock()
+	defer s.bootstrapsMu.Unlock()
+	delete(s.bootstrapsInFlight, node)
+}
+
+// runBootstrap is the goroutine body — uses a fresh background context
+// (the parent Reconcile ctx is short-lived; bootstrap takes 10-20 min)
+// and always releases the in-flight slot on exit.
+func (s *Service) runBootstrap(node string) {
+	defer s.releaseBootstrapSlot(node)
+	// Detach from the Reconcile ctx so a 60 s tick doesn't cancel a
+	// 20 min image download. Use a generous overall cap.
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
+	defer cancel()
+	_, _ = s.bootstrapper.Bootstrap(ctx, bootstrap.Request{
+		Nodes: []string{node},
+	})
 }
 
 // Binding is what GET /api/proxmox/binding returns — the Nodes page

--- a/internal/nodemgr/service_test.go
+++ b/internal/nodemgr/service_test.go
@@ -32,6 +32,9 @@ type fakePVE struct {
 	migrateErr    error
 	deleteNodeErr error
 
+	destroys   []destroyCall
+	destroyErr error
+
 	// Hook fired right after each MigrateVM call returns. Tests use it
 	// to mutate cluster state mid-batch (e.g. fill a node) so the next
 	// migration's re-validation triggers.
@@ -43,6 +46,11 @@ type migrateCall struct {
 	VMID   int
 	Target string
 	Online bool
+}
+
+type destroyCall struct {
+	Node string
+	VMID int
 }
 
 func (f *fakePVE) GetNodes(_ context.Context) ([]proxmox.Node, error) {
@@ -114,6 +122,16 @@ func (f *fakePVE) MigrateVM(_ context.Context, source string, vmid int, target s
 		hook(call)
 	}
 	return "", nil // empty UPID skips WaitForTask
+}
+
+func (f *fakePVE) DestroyVM(_ context.Context, node string, vmid int) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.destroys = append(f.destroys, destroyCall{Node: node, VMID: vmid})
+	if f.destroyErr != nil {
+		return "", f.destroyErr
+	}
+	return "", nil
 }
 
 func (f *fakePVE) WaitForTask(_ context.Context, _, _ string, _ time.Duration) error { return nil }


### PR DESCRIPTION
- Reconcile loop now fans out bootstrap.Service.Bootstrap async for any online, unlocked, amd64 node whose db.NodeTemplate count < len(Catalog). In-flight guard mirrors drainsInFlight so the every-60s tick can't stack the slow (~10-20 min) image downloads.
- Remove now destroys each template VM via DestroyVM and clears the node_templates rows before pvecm delnode, so templates don't strand as ghost VMIDs once the node is out of the cluster. Best-effort — individual destroy failures log but don't block the removal.
- Wired bootstrap.Service into nodemgr via SetTemplateBootstrapper from main.go (kept New's signature unchanged for tests / install-wizard).

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

