### PR TITLE
fix(gopher): wipe everything on bootstrap failure + honest Configured…

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -526,7 +526,13 @@ export interface GopherSettingsView {
   // Effective subdomain — the backend collapses an empty stored value to
   // the default ("cloud") here so the UI never has to know the fallback.
   cloud_subdomain: string
-  configured: boolean
+  // credentials_saved is true when api_url + api_key are both populated.
+  // Drives the modal-after-save and password-placeholder UI states.
+  credentials_saved: boolean
+  // tunnel_active is true only when the self-bootstrap finished and a
+  // public URL is live. Drives the "Configured" pill — saved-but-failed
+  // creds reads as not-configured (match the user-facing meaning).
+  tunnel_active: boolean
 }
 
 export interface SaveGopherSettingsRequest {

--- a/frontend/src/pages/GopherTunnels.tsx
+++ b/frontend/src/pages/GopherTunnels.tsx
@@ -74,8 +74,10 @@ function GopherPanel() {
       setTimeout(() => setSaved(false), 2500)
       // SaveGopher kicks off self-bootstrap server-side when creds are
       // valid; pop the modal so the admin sees the phase indicator and
-      // (on success) gets redirected to the cloud URL.
-      if (next.configured) setBootstrapOpen(true)
+      // (on success) gets redirected to the cloud URL. Gate on
+      // credentials_saved (not tunnel_active — the bootstrap hasn't run
+      // yet, the modal is what the admin watches it run *in*).
+      if (next.credentials_saved) setBootstrapOpen(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed')
     } finally {
@@ -83,7 +85,12 @@ function GopherPanel() {
     }
   }
 
-  const configured = settings?.configured ?? false
+  // credentialsSaved gates the password "leave blank to keep" hint and
+  // the Save→modal flow above. tunnelActive drives the visible
+  // "Configured" pill — saved creds with a failed bootstrap reads as
+  // not-configured per the explicit user-facing meaning.
+  const credentialsSaved = settings?.credentials_saved ?? false
+  const tunnelActive = settings?.tunnel_active ?? false
 
   return (
     <div
@@ -94,7 +101,7 @@ function GopherPanel() {
         <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
           Gopher tunnels
         </span>
-        {configured ? (
+        {tunnelActive ? (
           <span className="n-pill n-pill-ok">
             <span className="n-pill-dot" />
             configured
@@ -134,7 +141,7 @@ function GopherPanel() {
         <div className="n-field">
           <label className="n-label" htmlFor="gopher-api-key">
             API key
-            {configured && (
+            {credentialsSaved && (
               <span style={{ marginLeft: 6, fontSize: 11, color: 'var(--ink-mute)', fontWeight: 400 }}>
                 (leave blank to keep existing)
               </span>
@@ -144,7 +151,7 @@ function GopherPanel() {
             id="gopher-api-key"
             className="n-input"
             type="password"
-            placeholder={configured ? '••••••••' : 'Paste your Gopher API key'}
+            placeholder={credentialsSaved ? '••••••••' : 'Paste your Gopher API key'}
             value={apiKey}
             onChange={(e) => setAPIKey(e.target.value)}
           />

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -540,7 +540,16 @@ type gopherSettingsView struct {
 	// empty in the DB collapses to selftunnel.DefaultCloudSubdomain ("cloud")
 	// here so the UI never has to guess the fallback.
 	CloudSubdomain string `json:"cloud_subdomain"`
-	Configured     bool   `json:"configured"`
+	// CredentialsSaved is true when both api_url and api_key are populated
+	// in the DB. Used by the SPA to decide whether to auto-open the
+	// bootstrap modal after a save and to render the "leave blank to
+	// keep" placeholder on the API-key input.
+	CredentialsSaved bool `json:"credentials_saved"`
+	// TunnelActive is true only when the self-bootstrap finished
+	// end-to-end and a public URL is live. The SPA's "Configured" pill
+	// reads this — credentials saved with a failed (or never-attempted)
+	// bootstrap reads as not-configured.
+	TunnelActive bool `json:"tunnel_active"`
 }
 
 // GetGopher handles GET /api/settings/gopher (admin only). The API key is
@@ -562,9 +571,10 @@ func (s *Settings) GetGopher(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 	response.Success(w, gopherSettingsView{
-		APIURL:         settings.APIURL,
-		CloudSubdomain: selftunnel.EffectiveCloudSubdomain(settings.CloudSubdomain),
-		Configured:     settings.APIURL != "" && settings.APIKey != "",
+		APIURL:           settings.APIURL,
+		CloudSubdomain:   selftunnel.EffectiveCloudSubdomain(settings.CloudSubdomain),
+		CredentialsSaved: settings.APIURL != "" && settings.APIKey != "",
+		TunnelActive:     settings.CloudTunnelURL != "" && settings.CloudBootstrapState == selftunnel.StateActive,
 	})
 }
 
@@ -715,10 +725,16 @@ func (s *Settings) SaveGopher(w http.ResponseWriter, r *http.Request) {
 		},
 		Success: true,
 	})
+	// On the SaveGopher response: credentials are freshly saved so
+	// CredentialsSaved == (client built without error). TunnelActive is
+	// always false here — the bootstrap was just kicked off and won't
+	// finish for 60-90 s. The SPA polls /settings/gopher/self-bootstrap
+	// for the live state.
 	response.Success(w, gopherSettingsView{
-		APIURL:         settings.APIURL,
-		CloudSubdomain: selftunnel.EffectiveCloudSubdomain(settings.CloudSubdomain),
-		Configured:     client != nil,
+		APIURL:           settings.APIURL,
+		CloudSubdomain:   selftunnel.EffectiveCloudSubdomain(settings.CloudSubdomain),
+		CredentialsSaved: client != nil,
+		TunnelActive:     settings.CloudTunnelURL != "" && settings.CloudBootstrapState == selftunnel.StateActive,
 	})
 }
 

--- a/internal/api/openapi/docs.go
+++ b/internal/api/openapi/docs.go
@@ -8134,7 +8134,12 @@ const docTemplate = `{
                     "description": "CloudSubdomain is the *effective* leftmost label of the public URL —\nempty in the DB collapses to selftunnel.DefaultCloudSubdomain (\"cloud\")\nhere so the UI never has to guess the fallback.",
                     "type": "string"
                 },
-                "configured": {
+                "credentials_saved": {
+                    "description": "CredentialsSaved is true when both api_url and api_key are populated\nin the DB. Used by the SPA to decide whether to auto-open the\nbootstrap modal after a save and to render the \"leave blank to\nkeep\" placeholder on the API-key input.",
+                    "type": "boolean"
+                },
+                "tunnel_active": {
+                    "description": "TunnelActive is true only when the self-bootstrap finished\nend-to-end and a public URL is live. The SPA's \"Configured\" pill\nreads this — credentials saved with a failed (or never-attempted)\nbootstrap reads as not-configured.",
                     "type": "boolean"
                 }
             }

--- a/internal/api/openapi/swagger.json
+++ b/internal/api/openapi/swagger.json
@@ -8127,7 +8127,12 @@
                     "description": "CloudSubdomain is the *effective* leftmost label of the public URL —\nempty in the DB collapses to selftunnel.DefaultCloudSubdomain (\"cloud\")\nhere so the UI never has to guess the fallback.",
                     "type": "string"
                 },
-                "configured": {
+                "credentials_saved": {
+                    "description": "CredentialsSaved is true when both api_url and api_key are populated\nin the DB. Used by the SPA to decide whether to auto-open the\nbootstrap modal after a save and to render the \"leave blank to\nkeep\" placeholder on the API-key input.",
+                    "type": "boolean"
+                },
+                "tunnel_active": {
+                    "description": "TunnelActive is true only when the self-bootstrap finished\nend-to-end and a public URL is live. The SPA's \"Configured\" pill\nreads this — credentials saved with a failed (or never-attempted)\nbootstrap reads as not-configured.",
                     "type": "boolean"
                 }
             }

--- a/internal/api/openapi/swagger.yaml
+++ b/internal/api/openapi/swagger.yaml
@@ -622,7 +622,19 @@ definitions:
           empty in the DB collapses to selftunnel.DefaultCloudSubdomain ("cloud")
           here so the UI never has to guess the fallback.
         type: string
-      configured:
+      credentials_saved:
+        description: |-
+          CredentialsSaved is true when both api_url and api_key are populated
+          in the DB. Used by the SPA to decide whether to auto-open the
+          bootstrap modal after a save and to render the "leave blank to
+          keep" placeholder on the API-key input.
+        type: boolean
+      tunnel_active:
+        description: |-
+          TunnelActive is true only when the self-bootstrap finished
+          end-to-end and a public URL is live. The SPA's "Configured" pill
+          reads this — credentials saved with a failed (or never-attempted)
+          bootstrap reads as not-configured.
         type: boolean
     type: object
   handlers.gpuJobView:

--- a/internal/selftunnel/service.go
+++ b/internal/selftunnel/service.go
@@ -89,6 +89,7 @@ const machineConnectTimeout = 90 * time.Second
 type settingsStore interface {
 	GetGopherSettings() (*db.GopherSettings, error)
 	SaveCloudTunnelState(state db.GopherSettings) error
+	WipeGopherSettings() error
 }
 
 // gopherClient is the slice of tunnel.Client we need.
@@ -317,7 +318,21 @@ func (s *Service) checkSudo(ctx context.Context) error {
 	return nil
 }
 
-// markFailed writes the failed state + error message to the DB.
+// markFailed records the failure on the DB row, then runs the
+// clean-slate cleanup so the operator isn't left with a half-registered
+// Gopher machine and stale API credentials they have to manually undo.
+//
+// Sequencing matters:
+//  1. Write StateFailed + error message — so the modal renders the
+//     reason even if cleanup races a still-polling SPA refresh.
+//  2. cleanupAfterFailure deletes any registered Gopher machine
+//     (cascades to tunnels) and wipes every Gopher column on the row.
+//  3. Drop the in-memory tunnel.Client — credentials are gone, the
+//     client can no longer authenticate. Re-saving from the SPA
+//     rebuilds it via the TunnelClientApplier path.
+//
+// All steps are best-effort: a stale row is preferable to a panic, and
+// the operator still has the SPA + Gopher web UI to clean up by hand.
 func (s *Service) markFailed(msg string) {
 	existing, err := s.store.GetGopherSettings()
 	if err != nil {
@@ -330,6 +345,44 @@ func (s *Service) markFailed(msg string) {
 	if err := s.store.SaveCloudTunnelState(state); err != nil {
 		log.Printf("self-bootstrap: failed to persist failure: %v", err)
 	}
+	s.cleanupAfterFailure(existing)
+}
+
+// cleanupAfterFailure tears down Gopher-side artifacts and wipes the
+// local DB row. Best-effort throughout — the goal is "no partial state
+// the operator can stumble into," not transactional certainty. Errors
+// are logged.
+//
+// Called from markFailed only. Reads the pre-failure settings (passed
+// in) since we'll wipe them mid-flow.
+func (s *Service) cleanupAfterFailure(pre *db.GopherSettings) {
+	if pre == nil {
+		return
+	}
+	// 1. Best-effort delete the machine on Gopher. DeleteMachine
+	//    cascades to all child tunnels so we don't need a separate
+	//    DeleteTunnel call. Fresh ctx — markFailed may be called from
+	//    a cancelled bootstrap ctx, but the cleanup HTTP call should
+	//    still get a fair shot.
+	if pre.CloudMachineID != "" && s.gopher != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := s.gopher.DeleteMachine(ctx, pre.CloudMachineID); err != nil {
+			log.Printf("self-bootstrap cleanup: delete machine %s: %v", pre.CloudMachineID, err)
+		}
+		cancel()
+	}
+	// 2. Wipe every Gopher column. The user's choice — partial state is
+	//    confusing, force re-paste on retry.
+	if err := s.store.WipeGopherSettings(); err != nil {
+		log.Printf("self-bootstrap cleanup: wipe gopher settings: %v", err)
+	}
+	// 3. Drop the in-memory tunnel.Client. Credentials are gone; any
+	//    further calls would 401 against Gopher. Other appliers
+	//    (provision.Service, admin tunnels handler) hold their own
+	//    clients — they self-heal when the operator next saves creds.
+	s.mu.Lock()
+	s.gopher = nil
+	s.mu.Unlock()
 }
 
 // persist merges `update` onto the current row and writes it back. Only

--- a/internal/selftunnel/service_test.go
+++ b/internal/selftunnel/service_test.go
@@ -1,0 +1,147 @@
+package selftunnel
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"nimbus/internal/db"
+	"nimbus/internal/tunnel"
+)
+
+// fakeStore is a settingsStore that holds a single GopherSettings row
+// in memory. Tracks Wipe calls so tests can assert.
+type fakeStore struct {
+	mu        sync.Mutex
+	row       db.GopherSettings
+	wipes     int
+	saveState int
+}
+
+func (f *fakeStore) GetGopherSettings() (*db.GopherSettings, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := f.row
+	return &out, nil
+}
+
+func (f *fakeStore) SaveCloudTunnelState(state db.GopherSettings) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.saveState++
+	f.row.CloudMachineID = state.CloudMachineID
+	f.row.CloudTunnelID = state.CloudTunnelID
+	f.row.CloudTunnelURL = state.CloudTunnelURL
+	f.row.CloudBootstrapState = state.CloudBootstrapState
+	f.row.CloudBootstrapError = state.CloudBootstrapError
+	return nil
+}
+
+func (f *fakeStore) WipeGopherSettings() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.wipes++
+	f.row = db.GopherSettings{}
+	return nil
+}
+
+// fakeGopher records DeleteMachine calls and lets tests script errors.
+type fakeGopher struct {
+	mu        sync.Mutex
+	deleted   []string
+	deleteErr error
+}
+
+func (f *fakeGopher) CreateMachine(_ context.Context, _ tunnel.CreateMachineRequest) (*tunnel.Machine, error) {
+	return nil, errors.New("not used in cleanup tests")
+}
+func (f *fakeGopher) GetMachine(_ context.Context, _ string) (*tunnel.Machine, error) {
+	return nil, errors.New("not used in cleanup tests")
+}
+func (f *fakeGopher) DeleteMachine(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, id)
+	return f.deleteErr
+}
+func (f *fakeGopher) CreateTunnel(_ context.Context, _ tunnel.CreateTunnelRequest) (*tunnel.Tunnel, error) {
+	return nil, errors.New("not used in cleanup tests")
+}
+
+// TestMarkFailed_DeletesMachineAndWipesRow covers the happy cleanup
+// path: a failed bootstrap with a registered Gopher machine deletes
+// the machine, wipes every Gopher column, and drops the in-memory
+// gopher client so subsequent calls can't 401 against stale creds.
+func TestMarkFailed_DeletesMachineAndWipesRow(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{row: db.GopherSettings{
+		APIURL:         "https://g.example",
+		APIKey:         "secret",
+		CloudSubdomain: "cloud",
+		CloudMachineID: "m-42",
+		CloudTunnelID:  "t-7",
+	}}
+	gopher := &fakeGopher{}
+	svc := &Service{store: store, gopher: gopher}
+
+	svc.markFailed("bootstrap script blew up")
+
+	if got := len(gopher.deleted); got != 1 || gopher.deleted[0] != "m-42" {
+		t.Errorf("DeleteMachine called %v, want [m-42]", gopher.deleted)
+	}
+	if store.wipes != 1 {
+		t.Errorf("WipeGopherSettings called %d times, want 1", store.wipes)
+	}
+	if store.row != (db.GopherSettings{}) {
+		t.Errorf("row not wiped: %+v", store.row)
+	}
+	if svc.gopher != nil {
+		t.Errorf("gopher client not cleared after wipe")
+	}
+}
+
+// TestMarkFailed_NoMachineRegistered_StillWipes covers an early
+// failure (e.g. checkSudo fails before CreateMachine). No machine to
+// delete, but credentials should still be wiped.
+func TestMarkFailed_NoMachineRegistered_StillWipes(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{row: db.GopherSettings{
+		APIURL: "https://g.example",
+		APIKey: "secret",
+	}}
+	gopher := &fakeGopher{}
+	svc := &Service{store: store, gopher: gopher}
+
+	svc.markFailed("sudo blocked")
+
+	if got := len(gopher.deleted); got != 0 {
+		t.Errorf("DeleteMachine should not be called when CloudMachineID is empty, got %v", gopher.deleted)
+	}
+	if store.wipes != 1 {
+		t.Errorf("WipeGopherSettings called %d times, want 1", store.wipes)
+	}
+}
+
+// TestMarkFailed_DeleteMachineError_StillWipes covers a Gopher-side
+// error during cleanup. The DB wipe must still happen — leaving the
+// row with stale state is worse than orphaning a machine on Gopher.
+func TestMarkFailed_DeleteMachineError_StillWipes(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{row: db.GopherSettings{
+		APIURL:         "https://g.example",
+		APIKey:         "secret",
+		CloudMachineID: "m-99",
+	}}
+	gopher := &fakeGopher{deleteErr: errors.New("gopher 500")}
+	svc := &Service{store: store, gopher: gopher}
+
+	svc.markFailed("creating tunnel timed out")
+
+	if store.wipes != 1 {
+		t.Errorf("WipeGopherSettings should run even when DeleteMachine errors; got %d", store.wipes)
+	}
+	if svc.gopher != nil {
+		t.Errorf("gopher client should be cleared even when DeleteMachine errors")
+	}
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -1352,6 +1352,29 @@ func (s *AuthService) SaveGopherSettings(next db.GopherSettings) error {
 	}).Error
 }
 
+// WipeGopherSettings clears every column on the singleton GopherSettings
+// row. Used by selftunnel after a failed bootstrap so the operator gets a
+// clean slate on retry rather than discovering stale machine_id /
+// tunnel_id / API key state mid-debug. Both credentials and self-bootstrap
+// state are wiped — see selftunnel.Service.cleanupAfterFailure for why
+// (a partial install isn't reusable; either it works end-to-end or
+// nothing about it should remain).
+func (s *AuthService) WipeGopherSettings() error {
+	if _, err := s.GetGopherSettings(); err != nil {
+		return err
+	}
+	return s.db.Model(&db.GopherSettings{}).Where("id = ?", 1).Updates(map[string]any{
+		"api_url":               "",
+		"api_key":               "",
+		"cloud_subdomain":       "",
+		"cloud_machine_id":      "",
+		"cloud_tunnel_id":       "",
+		"cloud_tunnel_url":      "",
+		"cloud_bootstrap_state": "",
+		"cloud_bootstrap_error": "",
+	}).Error
+}
+
 // SaveCloudTunnelState updates only the self-bootstrap columns on the
 // GopherSettings row. Used by selftunnel.Service to persist progress
 // (machine_id, tunnel_id, URL, state, error) without racing

--- a/internal/service/gopher_wipe_test.go
+++ b/internal/service/gopher_wipe_test.go
@@ -1,0 +1,76 @@
+package service_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"nimbus/internal/db"
+	"nimbus/internal/service"
+)
+
+// newGopherTestService spins up an AuthService with the GopherSettings
+// table migrated so the wipe path can read/write it.
+func newGopherTestService(t *testing.T) *service.AuthService {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	database, err := db.New(path, &db.User{}, &db.GopherSettings{})
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	return service.NewAuthService(database)
+}
+
+// TestWipeGopherSettings_ClearsEveryColumn covers the full clean-slate
+// behaviour: credentials, subdomain, machine/tunnel ids, URL, state,
+// and error all land back at empty after WipeGopherSettings.
+func TestWipeGopherSettings_ClearsEveryColumn(t *testing.T) {
+	t.Parallel()
+	svc := newGopherTestService(t)
+
+	if err := svc.SaveGopherSettings(db.GopherSettings{
+		APIURL:         "https://gopher.example.com",
+		APIKey:         "key-abc",
+		CloudSubdomain: "cloud",
+	}); err != nil {
+		t.Fatalf("SaveGopherSettings: %v", err)
+	}
+	if err := svc.SaveCloudTunnelState(db.GopherSettings{
+		CloudMachineID:      "m-1",
+		CloudTunnelID:       "t-1",
+		CloudTunnelURL:      "https://cloud.example.com",
+		CloudBootstrapState: "active",
+		CloudBootstrapError: "",
+	}); err != nil {
+		t.Fatalf("SaveCloudTunnelState: %v", err)
+	}
+
+	if err := svc.WipeGopherSettings(); err != nil {
+		t.Fatalf("WipeGopherSettings: %v", err)
+	}
+
+	got, err := svc.GetGopherSettings()
+	if err != nil {
+		t.Fatalf("GetGopherSettings: %v", err)
+	}
+	if got.APIURL != "" || got.APIKey != "" || got.CloudSubdomain != "" {
+		t.Errorf("creds not wiped: %+v", got)
+	}
+	if got.CloudMachineID != "" || got.CloudTunnelID != "" || got.CloudTunnelURL != "" {
+		t.Errorf("tunnel state not wiped: %+v", got)
+	}
+	if got.CloudBootstrapState != "" || got.CloudBootstrapError != "" {
+		t.Errorf("bootstrap state not wiped: %+v", got)
+	}
+}
+
+// TestWipeGopherSettings_OnEmptyRow_NoError covers calling Wipe before
+// anything was ever saved — the FirstOrCreate inside should still
+// produce a clean row, not an error.
+func TestWipeGopherSettings_OnEmptyRow_NoError(t *testing.T) {
+	t.Parallel()
+	svc := newGopherTestService(t)
+
+	if err := svc.WipeGopherSettings(); err != nil {
+		t.Errorf("WipeGopherSettings on empty row: %v", err)
+	}
+}


### PR DESCRIPTION
… pill

The "Configured" badge was just `api_url && api_key`, so saved-but-failed deployments rendered as configured even with no live tunnel. And a failed self-bootstrap left a half-registered machine on Gopher plus stale local state, with no cleanup path.

- New AuthService.WipeGopherSettings clears every Gopher column (creds, subdomain, machine/tunnel ids, URL, state, error).
- selftunnel.markFailed now best-effort DELETEs the registered machine on Gopher (cascades to tunnels) and runs the wipe. The in-memory tunnel.Client is also cleared so further calls can't 401 against stale creds.
- gopherSettingsView splits the old `configured` field into `credentials_saved` (creds present — drives modal-after-save and password-placeholder UX) and `tunnel_active` (bootstrap finished end-to-end with a public URL — drives the visible pill).
- SPA reads the two new fields appropriately.

After failure the operator gets a clean slate: they re-paste creds and retry. No orphaned Gopher machine, no half-state in the DB.

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

