### PR TITLE
fix(gopher): adopt server-created tunnel on CreateTunnel timeout + bu…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -439,7 +439,7 @@ func main() {
 		}
 	}
 
-	tunnelClient, err := tunnel.New(gopherSettings.APIURL, gopherSettings.APIKey, 15*time.Second)
+	tunnelClient, err := tunnel.New(gopherSettings.APIURL, gopherSettings.APIKey, 60*time.Second)
 	if err != nil {
 		log.Fatalf("failed to init tunnel client: %v", err)
 	}

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -708,7 +708,7 @@ func (s *Settings) SaveGopher(w http.ResponseWriter, r *http.Request) {
 
 	var client *tunnel.Client
 	if settings.APIURL != "" && settings.APIKey != "" {
-		client, err = tunnel.New(settings.APIURL, settings.APIKey, 15*time.Second)
+		client, err = tunnel.New(settings.APIURL, settings.APIKey, 60*time.Second)
 		if err != nil {
 			response.BadRequest(w, "invalid Gopher settings: "+err.Error())
 			return

--- a/internal/selftunnel/service.go
+++ b/internal/selftunnel/service.go
@@ -100,6 +100,7 @@ type gopherClient interface {
 	GetMachine(ctx context.Context, id string) (*tunnel.Machine, error)
 	DeleteMachine(ctx context.Context, id string) error
 	CreateTunnel(ctx context.Context, req tunnel.CreateTunnelRequest) (*tunnel.Tunnel, error)
+	ListTunnelsForMachine(ctx context.Context, machineID string) ([]tunnel.Tunnel, error)
 }
 
 // commandRunner runs a shell command. Real callers use exec.CommandContext;
@@ -261,7 +262,17 @@ func (s *Service) runBootstrap(ctx context.Context) error {
 		Subdomain:  subdomain,
 	})
 	if err != nil {
-		return fmt.Errorf("create tunnel: %w", err)
+		// CreateTunnel can succeed server-side and still surface an error
+		// to us — most commonly when Gopher takes longer than the http.Client
+		// timeout to respond. If we tear everything down here, the next save
+		// finds a broken half-state. Try to adopt a matching tunnel that
+		// the server has by listing first; only fail if nothing matches.
+		adopted, aerr := s.adoptCreatedTunnel(ctx, machine.ID, subdomain, s.nimbusPort)
+		if aerr != nil || adopted == nil {
+			return fmt.Errorf("create tunnel: %w", err)
+		}
+		log.Printf("self-bootstrap: adopted existing tunnel %s for machine %s after CreateTunnel error: %v", adopted.ID, machine.ID, err)
+		t = adopted
 	}
 
 	// Step 5 — record success.
@@ -272,6 +283,33 @@ func (s *Service) runBootstrap(ctx context.Context) error {
 		CloudBootstrapState: StateActive,
 		CloudBootstrapError: "",
 	})
+}
+
+// adoptCreatedTunnel checks Gopher for a tunnel matching the parameters
+// we just tried to create. Used to recover from CreateTunnel client-side
+// errors where the request actually reached and was processed by Gopher
+// (typical with http.Client timeouts under load).
+//
+// Match criteria: same machine, same target_port, and either an empty
+// configured subdomain (caller didn't pin one) or an exact subdomain
+// match. Returns nil, nil when nothing matches — the caller falls
+// through to the existing failure path.
+func (s *Service) adoptCreatedTunnel(ctx context.Context, machineID, subdomain string, port int) (*tunnel.Tunnel, error) {
+	list, err := s.gopher.ListTunnelsForMachine(ctx, machineID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range list {
+		t := list[i]
+		if t.TargetPort != port {
+			continue
+		}
+		if subdomain != "" && t.Subdomain != subdomain {
+			continue
+		}
+		return &t, nil
+	}
+	return nil, nil
 }
 
 func (s *Service) waitConnected(ctx context.Context, machineID string) error {

--- a/internal/selftunnel/service_test.go
+++ b/internal/selftunnel/service_test.go
@@ -51,6 +51,9 @@ type fakeGopher struct {
 	mu        sync.Mutex
 	deleted   []string
 	deleteErr error
+	// listTunnels scripts the response for ListTunnelsForMachine.
+	listTunnels    []tunnel.Tunnel
+	listTunnelsErr error
 }
 
 func (f *fakeGopher) CreateMachine(_ context.Context, _ tunnel.CreateMachineRequest) (*tunnel.Machine, error) {
@@ -67,6 +70,16 @@ func (f *fakeGopher) DeleteMachine(_ context.Context, id string) error {
 }
 func (f *fakeGopher) CreateTunnel(_ context.Context, _ tunnel.CreateTunnelRequest) (*tunnel.Tunnel, error) {
 	return nil, errors.New("not used in cleanup tests")
+}
+func (f *fakeGopher) ListTunnelsForMachine(_ context.Context, _ string) ([]tunnel.Tunnel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listTunnelsErr != nil {
+		return nil, f.listTunnelsErr
+	}
+	out := make([]tunnel.Tunnel, len(f.listTunnels))
+	copy(out, f.listTunnels)
+	return out, nil
 }
 
 // TestMarkFailed_DeletesMachineAndWipesRow covers the happy cleanup
@@ -143,5 +156,122 @@ func TestMarkFailed_DeleteMachineError_StillWipes(t *testing.T) {
 	}
 	if svc.gopher != nil {
 		t.Errorf("gopher client should be cleared even when DeleteMachine errors")
+	}
+}
+
+// TestAdoptCreatedTunnel covers the timeout-recovery path. CreateTunnel
+// can succeed server-side and surface a client-side error (most often
+// http.Client timeout under load); without adoption we'd tear down the
+// tunnel that was actually created. The match contract:
+//   - same machine, same target_port required
+//   - subdomain "" in the request matches anything
+//   - non-empty subdomain must match exactly
+//
+// Returning (nil, nil) means "no match — caller should fall through to
+// the existing failure path."
+func TestAdoptCreatedTunnel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		list      []tunnel.Tunnel
+		listErr   error
+		machineID string
+		subdomain string
+		port      int
+		wantID    string // "" expects nil tunnel
+		wantErr   bool
+	}{
+		{
+			name:      "empty list → no adoption",
+			machineID: "m-1",
+			port:      8080,
+			wantID:    "",
+		},
+		{
+			name: "match on machine+port (no subdomain pinned)",
+			list: []tunnel.Tunnel{
+				{ID: "t-1", MachineID: "m-1", TargetPort: 8080, Subdomain: "cloud"},
+			},
+			machineID: "m-1",
+			port:      8080,
+			wantID:    "t-1",
+		},
+		{
+			name: "match on machine+port+subdomain",
+			list: []tunnel.Tunnel{
+				{ID: "t-2", MachineID: "m-1", TargetPort: 8080, Subdomain: "cloud"},
+			},
+			machineID: "m-1",
+			subdomain: "cloud",
+			port:      8080,
+			wantID:    "t-2",
+		},
+		{
+			name: "wrong port → no adoption",
+			list: []tunnel.Tunnel{
+				{ID: "t-3", MachineID: "m-1", TargetPort: 9090, Subdomain: "cloud"},
+			},
+			machineID: "m-1",
+			port:      8080,
+			wantID:    "",
+		},
+		{
+			name: "subdomain pinned but tunnel uses a different one → no adoption",
+			list: []tunnel.Tunnel{
+				{ID: "t-4", MachineID: "m-1", TargetPort: 8080, Subdomain: "other"},
+			},
+			machineID: "m-1",
+			subdomain: "cloud",
+			port:      8080,
+			wantID:    "",
+		},
+		{
+			name: "first matching wins when multiple match",
+			list: []tunnel.Tunnel{
+				{ID: "t-5", MachineID: "m-1", TargetPort: 8080, Subdomain: "cloud"},
+				{ID: "t-6", MachineID: "m-1", TargetPort: 8080, Subdomain: "cloud"},
+			},
+			machineID: "m-1",
+			subdomain: "cloud",
+			port:      8080,
+			wantID:    "t-5",
+		},
+		{
+			name:      "list error propagates",
+			listErr:   errors.New("gopher 503"),
+			machineID: "m-1",
+			port:      8080,
+			wantErr:   true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gopher := &fakeGopher{listTunnels: tc.list, listTunnelsErr: tc.listErr}
+			svc := &Service{gopher: gopher}
+			got, err := svc.adoptCreatedTunnel(context.Background(), tc.machineID, tc.subdomain, tc.port)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantID == "" {
+				if got != nil {
+					t.Errorf("expected nil adoption, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected tunnel %s, got nil", tc.wantID)
+			}
+			if got.ID != tc.wantID {
+				t.Errorf("got tunnel %s, want %s", got.ID, tc.wantID)
+			}
+		})
 	}
 }


### PR DESCRIPTION
…mp client to 60s

CreateTunnel can succeed server-side and surface a context-deadline- exceeded to us when Gopher takes longer than the http.Client timeout to respond. Tearing everything down via cleanupAfterFailure then deletes the tunnel that was actually created — what hit alex-prod on May 9.

On any CreateTunnel error in runBootstrap step 4, list tunnels for the machine and adopt one that matches (machine_id, target_port, optional subdomain) before falling through to the failure path. Match contract in adoptCreatedTunnel.

Also bump tunnel.New client timeout from 15s → 60s in both call sites (handlers/settings.go and main.go) so transient Gopher slowness is absorbed before we ever reach the adoption fallback.

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

