### PR TITLE
fix(standalonenet): namespace SDN zone names by per-instance ID

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -178,6 +178,7 @@ func main() {
 		&db.VPCMembership{},
 		&db.GatewayLXCIP{},
 		&db.NetworkingV1Settings{},
+		&db.InstanceSettings{},
 		ippool.Model(),
 	)
 	if err != nil {
@@ -643,6 +644,20 @@ func main() {
 		log.Printf("startup: reaped %d stuck operation(s)", reaped)
 	}
 
+	// Per-Nimbus-install identity — namespaces cluster-shared names
+	// (today: SDN zones in standalonenet) so two instances pointed at
+	// the same Proxmox cluster don't collide on names that derive from
+	// shared inputs like recycled vmids. Lazy-init on first boot;
+	// persisted afterwards. Failure is non-fatal — we degrade to the
+	// legacy purely-vmid-derived naming, which is fine for single-
+	// instance prod and only collides in multi-instance dev.
+	instanceID, err := authSvc.GetOrCreateInstanceID()
+	if err != nil {
+		log.Printf("warning: instance id init: %v — falling back to vmid-only zone names", err)
+	} else {
+		log.Printf("nimbus instance id: %s", instanceID)
+	}
+
 	// Networking-v1 Standalone primitive — per-VM Simple zone with
 	// PVE-native SNAT. Wired before the legacy vnetmgr so new
 	// provisions default to it; legacy SubnetResolver path remains
@@ -650,7 +665,8 @@ func main() {
 	// during the deprecation window. Construction failure (bad
 	// CIDR) is logged and downgrades to legacy-only mode.
 	standaloneNetSvc, snErr := standalonenet.New(pveClient, database.DB, standalonenet.Config{
-		PoolCIDR: cfg.StandalonePoolCIDR,
+		PoolCIDR:   cfg.StandalonePoolCIDR,
+		InstanceID: instanceID,
 	})
 	if snErr != nil {
 		log.Printf("warning: standalonenet disabled (%v) — provisions fall back to legacy SDN path", snErr)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -889,3 +889,15 @@ type NetworkingV1Settings struct {
 	LXCIPPoolEnd   string `gorm:"column:lxc_ip_pool_end;default:''"`
 	LXCStorage     string `gorm:"column:lxc_storage;default:'local-lvm'"`
 }
+
+// InstanceSettings is a singleton (ID=1) holding Nimbus's per-install
+// identity. InstanceID is generated on first boot and persisted; every
+// cluster-shared name Nimbus produces (today: SDN zones in standalonenet,
+// extensible to selftunnel/gopher machine name, future Proxmox tag-based
+// orphan cleanup) mixes it in so two Nimbus instances against the same
+// PVE cluster (typical in dev) don't collide on names that derive from
+// shared inputs like cluster-recycled vmids.
+type InstanceSettings struct {
+	ID         uint   `gorm:"primaryKey"`
+	InstanceID string `gorm:"column:instance_id;not null;default:''"`
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -1430,6 +1430,35 @@ func (s *AuthService) SaveNetworkingV1Settings(next db.NetworkingV1Settings) err
 	}).Error
 }
 
+// GetOrCreateInstanceID returns this Nimbus install's stable identity,
+// generating + persisting one on first call. Used to namespace
+// cluster-shared names (SDN zones, etc.) so multiple Nimbus instances
+// against the same Proxmox cluster don't collide on names that derive
+// from shared inputs like cluster-recycled vmids. Idempotent.
+//
+// 16 random bytes hex-encoded (32 chars). Not RFC 4122 — we don't need
+// the version/variant bits, just enough entropy that two instances
+// never collide. crypto/rand is the source.
+func (s *AuthService) GetOrCreateInstanceID() (string, error) {
+	var row db.InstanceSettings
+	if err := s.db.FirstOrCreate(&row, db.InstanceSettings{ID: 1}).Error; err != nil {
+		return "", fmt.Errorf("load instance settings: %w", err)
+	}
+	if row.InstanceID != "" {
+		return row.InstanceID, nil
+	}
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate instance id: %w", err)
+	}
+	id := hex.EncodeToString(buf)
+	if err := s.db.Model(&db.InstanceSettings{}).Where("id = ?", 1).
+		Update("instance_id", id).Error; err != nil {
+		return "", fmt.Errorf("persist instance id: %w", err)
+	}
+	return id, nil
+}
+
 // GetGPUSettings returns the GX10 / GPU plane settings, creating an empty
 // row on first call. Empty BaseURL or Enabled=false means the GPU plane is
 // effectively off — VMs receive no inference env vars and the jobs API

--- a/internal/standalonenet/service.go
+++ b/internal/standalonenet/service.go
@@ -67,6 +67,13 @@ type Config struct {
 	// supernet but break the mental model of "this VM has its own
 	// network." Default 24.
 	SubnetSize int
+	// InstanceID namespaces zone names across multiple Nimbus instances
+	// pointed at the same Proxmox cluster. Without it, two instances
+	// derive identical SDN zone names from a recycled vmid and stomp
+	// each other's PVE state — see service.GetOrCreateInstanceID. Empty
+	// is allowed (single-instance dev/prod) and degrades to the legacy
+	// purely-vmid-derived naming.
+	InstanceID string
 }
 
 // Service is the Standalone VM network manager. Provision creates
@@ -152,10 +159,19 @@ func (s *Service) Provision(ctx context.Context, vmID uint, vmIdentifier, node s
 	// DB unique constraints on zone_name and subnet_cidr act as the
 	// collision detector — the salt-and-retry handles birthday hits
 	// without holding application-level locks.
+	//
+	// InstanceID prefix namespaces the salt so two Nimbus instances
+	// against the same PVE cluster (typical in dev) don't both compute
+	// the same zone for a recycled vmid. Empty InstanceID degrades to
+	// legacy naming — fine for single-instance prod.
+	base := vmIdentifier
+	if s.cfg.InstanceID != "" {
+		base = s.cfg.InstanceID + "|" + vmIdentifier
+	}
 	for attempt := 0; attempt < maxCollisionRetries; attempt++ {
-		salt := vmIdentifier
+		salt := base
 		if attempt > 0 {
-			salt = fmt.Sprintf("%s#%d", vmIdentifier, attempt)
+			salt = fmt.Sprintf("%s#%d", base, attempt)
 		}
 		row, err := s.tryInsertRow(ctx, vmID, salt, node)
 		if err == nil {

--- a/internal/standalonenet/service_test.go
+++ b/internal/standalonenet/service_test.go
@@ -231,6 +231,62 @@ func TestProvision_CollisionRetriesWithSalt(t *testing.T) {
 	}
 }
 
+// TestProvision_InstanceIDNamespacesZoneNames covers the multi-Nimbus
+// scenario: two Service instances pointed at the same Proxmox cluster
+// must derive different zone names for the same vmid, otherwise they
+// collide on PVE-side state when vmids get recycled. Cluster-shared
+// names need to be namespaced by the per-install InstanceID.
+//
+// Sets up two services (each with their own DB + their own InstanceID)
+// and asserts that Provisioning the same vmid produces distinct zone
+// names. Also pins the back-compat: empty InstanceID matches the
+// legacy purely-vmid-derived naming.
+func TestProvision_InstanceIDNamespacesZoneNames(t *testing.T) {
+	t.Parallel()
+	mk := func(instanceID string) *standalonenet.Service {
+		path := filepath.Join(t.TempDir(), "test.db")
+		database, err := db.New(path, &db.StandaloneVMNetwork{})
+		if err != nil {
+			t.Fatalf("db.New: %v", err)
+		}
+		svc, err := standalonenet.New(&fakeSDN{}, database.DB, standalonenet.Config{
+			PoolCIDR:   "10.128.0.0/9",
+			InstanceID: instanceID,
+		})
+		if err != nil {
+			t.Fatalf("standalonenet.New: %v", err)
+		}
+		return svc
+	}
+
+	rowA, err := mk("alpha-instance").Provision(context.Background(), 1, "vm-1", "alpha")
+	if err != nil {
+		t.Fatalf("instance A Provision: %v", err)
+	}
+	rowB, err := mk("beta-instance").Provision(context.Background(), 1, "vm-1", "alpha")
+	if err != nil {
+		t.Fatalf("instance B Provision: %v", err)
+	}
+	if rowA.ZoneName == rowB.ZoneName {
+		t.Errorf("two instances produced same zone %q for vmid=1; namespacing failed", rowA.ZoneName)
+	}
+
+	// Empty InstanceID falls back to the legacy purely-vmid-derived
+	// naming so single-instance prod isn't disturbed by the change.
+	rowLegacy1, err := mk("").Provision(context.Background(), 1, "vm-1", "alpha")
+	if err != nil {
+		t.Fatalf("legacy 1 Provision: %v", err)
+	}
+	rowLegacy2, err := mk("").Provision(context.Background(), 1, "vm-1", "alpha")
+	if err != nil {
+		t.Fatalf("legacy 2 Provision: %v", err)
+	}
+	if rowLegacy1.ZoneName != rowLegacy2.ZoneName {
+		t.Errorf("legacy mode (empty InstanceID) should be deterministic, got %q vs %q",
+			rowLegacy1.ZoneName, rowLegacy2.ZoneName)
+	}
+}
+
 // TestProvision_ClearsPreSeededOrphan covers the "Destroy was
 // skipped entirely" failure mode directly: a row exists for vmID
 // without ever having gone through Provision in this test, and


### PR DESCRIPTION
When two Nimbus instances point at the same Proxmox cluster (typical in dev), they collide on SDN zone names because the zone name was derived from sha256("vm-<vmid>") alone, and PVE's vmid pool is cluster-wide and recycled. Symptom: a fresh provision fails at VM start with "bridge 's<7hex>' does not exist" because the zone with that name was created by the other instance pinned to a different node.

Add db.InstanceSettings (singleton, ID=1) holding a stable per-install hex identifier, lazy-initialized on first boot. standalonenet.Config gains an InstanceID field that's mixed into the salt before sha256, so two instances with different IDs derive different zone names for the same vmid. Empty InstanceID degrades to legacy purely-vmid-derived naming so single-instance prod sees no behavior change.

Doesn't fix the gopher self-tunnel machine name (currently hostname-based) or the VPC zone naming (salted by ownerID/name — lower collision risk). Those are separate scope.

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

