### PR TITLE
fix(standalonenet): close bridge-readiness race + walk back partial P…

### DIFF
--- a/internal/standalonenet/service.go
+++ b/internal/standalonenet/service.go
@@ -51,6 +51,11 @@ type SDNClient interface {
 	CreateSDNSubnet(ctx context.Context, s proxmox.SDNSubnet) error
 	DeleteSDNSubnet(ctx context.Context, vnet, subnetID string) error
 	ApplySDN(ctx context.Context) error
+	// ReloadNodeNetwork blocks on a per-node ifreload UPID. ApplySDN
+	// alone returns before the cluster's per-node bridge creation
+	// completes — qmstart on the freshly-created VM races the reload
+	// and fails with "bridge ... does not exist" without this.
+	ReloadNodeNetwork(ctx context.Context, node string) error
 }
 
 // Config is the deployment-specific knobs the Service needs.
@@ -266,13 +271,55 @@ func (s *Service) tryInsertRow(ctx context.Context, vmID uint, salt, node string
 	return row, nil
 }
 
-// bootstrapPVE creates the per-VM PVE state. Failure mode: if any
-// step partially succeeds and the next fails, we leave the orphan
-// in place — the caller-level rollback (DeleteRow above) plus the
-// admin-facing Reset endpoint cover recovery. We don't try to walk
-// back partial PVE state inline because it'd just generate another
-// failure mode without simplifying the caller.
+// bootstrapPVE creates the per-VM PVE state and waits for the
+// target-node bridge to actually come up before returning. Two pieces
+// of correctness the original implementation skimped on:
+//
+//  1. Race-free bridge readiness. ApplySDN dispatches an *async*
+//     cluster-wide ifreload task and returns immediately. The caller
+//     (provision.Service) then runs qmstart on `row.Node`, which
+//     fails with "bridge ... does not exist" if ifupdown2 hasn't
+//     created the bridge on that node yet. ReloadNodeNetwork blocks
+//     on the per-node UPID, so by the time bootstrapPVE returns the
+//     bridge is genuinely up. Same pattern gateway.Provision uses
+//     before StartLXC ([gateway/service.go:329-336]).
+//
+//  2. Partial-state walkback on failure. Earlier this function
+//     leaked PVE artifacts whenever any step after CreateSDNZone
+//     errored — the comment said "we don't try to walk back partial
+//     PVE state inline" but the trade-off was wrong: the orphans
+//     accumulate forever (zones pinned to nodes that may not even
+//     exist anymore). On any error we now reverse-delete whatever
+//     we successfully created and re-apply, so the operator's next
+//     retry isn't blocked by phantom collisions.
 func (s *Service) bootstrapPVE(ctx context.Context, row *db.StandaloneVMNetwork) error {
+	// Track what got created so the rollback knows what to walk back
+	// when a later step fails.
+	var (
+		zoneCreated   bool
+		vnetCreated   bool
+		subnetCreated bool
+	)
+	rollback := func(reason error) error {
+		// Best-effort reverse delete + apply. Errors are folded into
+		// the original failure as wrapped context — the operator
+		// sees the root cause AND any cleanup-side surprise.
+		if subnetCreated {
+			subnetID := proxmox.FormatSDNSubnetID(row.ZoneName, row.SubnetCIDR)
+			_ = s.px.DeleteSDNSubnet(ctx, row.VNetName, subnetID)
+		}
+		if vnetCreated {
+			_ = s.px.DeleteSDNVNet(ctx, row.VNetName)
+		}
+		if zoneCreated {
+			_ = s.px.DeleteSDNZone(ctx, row.ZoneName)
+		}
+		// Apply so the deletions land in the running config; if this
+		// fails the next ApplySDN from any source will catch it.
+		_ = s.px.ApplySDN(ctx)
+		return reason
+	}
+
 	// Simple zones are host-local — only the node that runs the VM
 	// needs the bridge. Pin via Nodes= so PVE doesn't auto-create
 	// the bridge on every other cluster member (cleaner UI, fewer
@@ -284,29 +331,36 @@ func (s *Service) bootstrapPVE(ctx context.Context, row *db.StandaloneVMNetwork)
 	}); err != nil {
 		return fmt.Errorf("create zone %s: %w", row.ZoneName, err)
 	}
+	zoneCreated = true
 	if err := s.px.CreateSDNVNet(ctx, proxmox.SDNVNet{
 		VNet: row.VNetName,
 		Zone: row.ZoneName,
 	}); err != nil {
-		return fmt.Errorf("create vnet %s: %w", row.VNetName, err)
+		return rollback(fmt.Errorf("create vnet %s: %w", row.VNetName, err))
 	}
+	vnetCreated = true
 	if err := s.px.CreateSDNSubnet(ctx, proxmox.SDNSubnet{
 		Subnet:  row.SubnetCIDR,
 		VNet:    row.VNetName,
 		Gateway: row.GatewayIP,
 		SNAT:    true, // PVE handles MASQUERADE on the per-host bridge
 	}); err != nil {
-		return fmt.Errorf("create subnet %s: %w", row.SubnetCIDR, err)
+		return rollback(fmt.Errorf("create subnet %s: %w", row.SubnetCIDR, err))
 	}
+	subnetCreated = true
 	if err := s.px.ApplySDN(ctx); err != nil {
-		return fmt.Errorf("apply sdn: %w", err)
+		return rollback(fmt.Errorf("apply sdn: %w", err))
 	}
-	// ApplySDN itself triggers cluster-wide ifreload via PVE's
-	// "Reload network configuration on all nodes" task. We don't
-	// chase it with an explicit per-node reload anymore — that
-	// doubled the reload count for every provision. If a fresh
-	// node ever needs a manual nudge, `ifreload -a` on the host
-	// is the one-shot recovery.
+	// ApplySDN's cluster-wide reload is async — block on the
+	// target-node reload UPID so the bridge exists before the
+	// caller fires qmstart. Without this the provision races a
+	// background ifupdown task and dies with "bridge does not
+	// exist" intermittently. The redundant cluster reload (the
+	// reason this was originally removed) is the cost of
+	// correctness.
+	if err := s.px.ReloadNodeNetwork(ctx, row.Node); err != nil {
+		return rollback(fmt.Errorf("reload network on %s: %w", row.Node, err))
+	}
 	return nil
 }
 

--- a/internal/standalonenet/service_test.go
+++ b/internal/standalonenet/service_test.go
@@ -26,6 +26,7 @@ type fakeSDN struct {
 	deleteVNetCalls   int
 	deleteSubnetCalls int
 	applyCalls        int
+	reloadNodeCalls   int
 
 	createZoneErr   error
 	createVNetErr   error
@@ -34,6 +35,7 @@ type fakeSDN struct {
 	deleteVNetErr   error
 	deleteSubnetErr error
 	applyErr        error
+	reloadNodeErr   error
 }
 
 func (f *fakeSDN) CreateSDNZone(_ context.Context, _ proxmox.SDNZone) error {
@@ -78,7 +80,12 @@ func (f *fakeSDN) ApplySDN(_ context.Context) error {
 	f.mu.Unlock()
 	return f.applyErr
 }
-func (f *fakeSDN) ReloadNodeNetwork(_ context.Context, _ string) error { return nil }
+func (f *fakeSDN) ReloadNodeNetwork(_ context.Context, _ string) error {
+	f.mu.Lock()
+	f.reloadNodeCalls++
+	f.mu.Unlock()
+	return f.reloadNodeErr
+}
 
 func newTestSvc(t *testing.T, fake *fakeSDN) *standalonenet.Service {
 	t.Helper()
@@ -137,6 +144,12 @@ func TestProvision_HappyPath(t *testing.T) {
 	if fake.createZoneCalls != 1 || fake.createVNetCalls != 1 || fake.createSubnetCalls != 1 || fake.applyCalls != 1 {
 		t.Errorf("create call counts: zone=%d vnet=%d subnet=%d apply=%d (each want 1)",
 			fake.createZoneCalls, fake.createVNetCalls, fake.createSubnetCalls, fake.applyCalls)
+	}
+	// ReloadNodeNetwork is the per-node sync that closes the
+	// race-against-qmstart hazard. Asserted here so the bridge-readiness
+	// guarantee can't silently regress.
+	if fake.reloadNodeCalls != 1 {
+		t.Errorf("reloadNodeCalls = %d, want 1", fake.reloadNodeCalls)
 	}
 }
 
@@ -199,6 +212,63 @@ func TestProvision_PVEFailureRollsBackRow(t *testing.T) {
 	}
 	if row == nil {
 		t.Fatal("row is nil after successful retry")
+	}
+}
+
+// TestProvision_PVEFailure_RollsBackPartialPVEState asserts that
+// when a step inside bootstrapPVE fails (e.g. CreateSDNSubnet errors
+// after CreateSDNZone + CreateSDNVNet succeeded), the function walks
+// back the partially-created PVE artifacts. Without this rollback,
+// every transient PVE error would leak orphan zones + vnets that an
+// operator has to clean up by hand — see the May 2026 incident where
+// two orphan zones (s6bd79b1, sa4c87bb) accumulated before this
+// regression test was added.
+func TestProvision_PVEFailure_RollsBackPartialPVEState(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSDN{createSubnetErr: errors.New("boom")}
+	svc := newTestSvc(t, fake)
+
+	_, err := svc.Provision(context.Background(), 1, "vm-uuid-1", "alpha")
+	if err == nil {
+		t.Fatalf("expected error from CreateSDNSubnet failure, got nil")
+	}
+	// Zone + VNet were created before the failing subnet step;
+	// rollback must delete each. Subnet was never successfully
+	// created so its delete should NOT fire.
+	if fake.deleteZoneCalls != 1 {
+		t.Errorf("deleteZoneCalls = %d, want 1 (zone created, must be walked back)", fake.deleteZoneCalls)
+	}
+	if fake.deleteVNetCalls != 1 {
+		t.Errorf("deleteVNetCalls = %d, want 1 (vnet created, must be walked back)", fake.deleteVNetCalls)
+	}
+	if fake.deleteSubnetCalls != 0 {
+		t.Errorf("deleteSubnetCalls = %d, want 0 (subnet never created)", fake.deleteSubnetCalls)
+	}
+	// applyCalls counts both the (failed) initial apply AND the
+	// rollback's apply. The initial apply was never reached (subnet
+	// step failed before it), so we expect exactly 1 — from rollback.
+	if fake.applyCalls != 1 {
+		t.Errorf("applyCalls = %d, want 1 (rollback's apply only)", fake.applyCalls)
+	}
+}
+
+// TestProvision_ReloadFailure_RollsBackEverything covers the new
+// per-node reload step: when ReloadNodeNetwork fails (e.g. PVE
+// pve-firewall reload errors out), the entire bootstrapPVE walks
+// back so the operator isn't left with a zone/vnet/subnet that the
+// target node never reloaded.
+func TestProvision_ReloadFailure_RollsBackEverything(t *testing.T) {
+	t.Parallel()
+	fake := &fakeSDN{reloadNodeErr: errors.New("ifreload exit 1")}
+	svc := newTestSvc(t, fake)
+
+	_, err := svc.Provision(context.Background(), 1, "vm-uuid-1", "alpha")
+	if err == nil {
+		t.Fatalf("expected error from ReloadNodeNetwork failure, got nil")
+	}
+	if fake.deleteZoneCalls != 1 || fake.deleteVNetCalls != 1 || fake.deleteSubnetCalls != 1 {
+		t.Errorf("rollback delete counts: zone=%d vnet=%d subnet=%d (each want 1)",
+			fake.deleteZoneCalls, fake.deleteVNetCalls, fake.deleteSubnetCalls)
 	}
 }
 
@@ -452,6 +522,10 @@ func (r *recordingSDN) DeleteSDNSubnet(ctx context.Context, vnet, subnet string)
 func (r *recordingSDN) ApplySDN(ctx context.Context) error {
 	r.record("ApplySDN")
 	return r.fakeSDN.ApplySDN(ctx)
+}
+func (r *recordingSDN) ReloadNodeNetwork(ctx context.Context, node string) error {
+	r.record("ReloadNodeNetwork")
+	return r.fakeSDN.ReloadNodeNetwork(ctx, node)
 }
 
 func newTestSvcWithSDN(t *testing.T, sdn standalonenet.SDNClient) *standalonenet.Service {


### PR DESCRIPTION
…VE state

Two related bugs in the Standalone networking bootstrap that combined to produce qmstart failures + orphan SDN entries on the cluster.

1. Race condition in bootstrapPVE ApplySDN dispatches an async cluster-wide ifreload and returns immediately. The caller (provision.Service) then runs qmstart on the target node, which races the reload and fails with 'bridge ... does not exist' before ifupdown2 has created the bridge. Reproduced live: vmid 101 on sixseven failed exactly this way today.

The fix is the same one gateway.Provision uses before StartLXC: block on a per-node ifreload UPID via ReloadNodeNetwork(row.Node) after ApplySDN. The original code path used to do this and was removed for being 'redundant' — the redundancy was the cost of correctness.

2. Partial-rollback hole in bootstrapPVE Earlier code returned without walking back PVE artifacts when any step after CreateSDNZone failed. Result: zone+vnet would persist on PVE forever (the comment explicitly said 'we don't try to walk back partial PVE state inline'). Two such orphans accumulated on neanderthal (s6bd79b1, sa4c87bb) before this regression test was added.

Added a track-what-we-created + reverse-delete-on-error rollback so every transient PVE error leaves the cluster in the original state, not a tombstone.

Both fixes have regression tests:
 - TestProvision_HappyPath now asserts ReloadNodeNetwork is called
 - TestProvision_PVEFailure_RollsBackPartialPVEState
 - TestProvision_ReloadFailure_RollsBackEverything

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

