### PR TITLE
fix(selftunnel): take over a conflicting subdomain instead of failing

### DIFF
--- a/frontend/src/pages/GopherTunnels.tsx
+++ b/frontend/src/pages/GopherTunnels.tsx
@@ -85,10 +85,15 @@ function GopherPanel() {
     }
   }
 
-  // credentialsSaved gates the password "leave blank to keep" hint and
-  // the Save→modal flow above. tunnelActive drives the visible
-  // "Configured" pill — saved creds with a failed bootstrap reads as
-  // not-configured per the explicit user-facing meaning.
+  // Two distinct concepts, two distinct pills:
+  //  - credentialsSaved: api_url + api_key are stored. Operators
+  //    intuit "I configured this" the moment they save creds.
+  //  - tunnelActive: the dashboard's own cloud tunnel is up. This
+  //    is downstream of credentialsSaved (requires the self-bootstrap
+  //    to install rathole on the host + register the tunnel).
+  // Showing only the latter under one "configured" label was
+  // misleading: a successful save with a still-pending bootstrap
+  // read as "not configured" even though creds were obviously stored.
   const credentialsSaved = settings?.credentials_saved ?? false
   const tunnelActive = settings?.tunnel_active ?? false
 
@@ -97,27 +102,14 @@ function GopherPanel() {
       className="glass"
       style={{ padding: '24px 28px', display: 'flex', flexDirection: 'column', gap: 18 }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
         <span style={{ fontSize: 15, fontWeight: 600, color: 'var(--ink)' }}>
           Gopher tunnels
         </span>
-        {tunnelActive ? (
-          <span className="n-pill n-pill-ok">
-            <span className="n-pill-dot" />
-            configured
-          </span>
-        ) : (
-          <span
-            className="n-pill"
-            style={{
-              color: 'var(--ink-mute)',
-              background: 'rgba(20,18,28,0.04)',
-              border: '1px solid var(--line)',
-            }}
-          >
-            not configured
-          </span>
-        )}
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <StatusPill ok={credentialsSaved} okText="credentials saved" muteText="no credentials" />
+          <StatusPill ok={tunnelActive} okText="cloud tunnel active" muteText="cloud tunnel inactive" />
+        </div>
       </div>
 
       <p style={{ margin: 0, fontSize: 13, color: 'var(--ink-body)', lineHeight: 1.55 }}>
@@ -206,6 +198,34 @@ function GopherPanel() {
       </form>
       {bootstrapOpen && <SelfBootstrapModal onClose={() => setBootstrapOpen(false)} />}
     </div>
+  )
+}
+
+// StatusPill — shared shape for the credentials-saved / cloud-tunnel-
+// active indicators. ok=true renders the green dot pill; ok=false
+// renders the muted/neutral pill. Two pills sit side-by-side so the
+// distinction between "creds stored" and "tunnel actually live" is
+// visible at a glance instead of collapsed into one ambiguous label.
+function StatusPill({ ok, okText, muteText }: { ok: boolean; okText: string; muteText: string }) {
+  if (ok) {
+    return (
+      <span className="n-pill n-pill-ok">
+        <span className="n-pill-dot" />
+        {okText}
+      </span>
+    )
+  }
+  return (
+    <span
+      className="n-pill"
+      style={{
+        color: 'var(--ink-mute)',
+        background: 'rgba(20,18,28,0.04)',
+        border: '1px solid var(--line)',
+      }}
+    >
+      {muteText}
+    </span>
   )
 }
 

--- a/internal/provision/service.go
+++ b/internal/provision/service.go
@@ -887,7 +887,7 @@ func (s *Service) Provision(ctx context.Context, req Request, progress ProgressR
 			tunnelError = "Guest agent did not confirm readiness — bootstrap skipped." +
 				" Re-run manually once the VM is up:\n  curl " + machineObj.BootstrapURL + " | sh"
 		default:
-			if berr := runTunnelBootstrap(ctx, s.px, target, newVMID, machineObj.BootstrapURL, req.Hostname); berr != nil {
+			if berr := runTunnelBootstrap(ctx, s.px, target, newVMID, machineObj.BootstrapURL, req.Hostname, username); berr != nil {
 				log.Printf("tunnel: bootstrap failed: %v", berr)
 				tunnelError = "tunnel bootstrap failed: " + berr.Error()
 			} else {

--- a/internal/provision/tunnel.go
+++ b/internal/provision/tunnel.go
@@ -44,20 +44,26 @@ const (
 // path is virtio-serial through the host hypervisor, so this works
 // identically on vmbr0 and on isolated SDN subnets.
 //
-// machineName is exported as GOPHER_MACHINE_NAME so the bootstrap script
-// skips its interactive `/dev/tty` prompt — there's no PTY here.
+// machineName is exported as GOPHER_MACHINE_NAME and sshUser as
+// GOPHER_SSH_USER so the bootstrap script skips its interactive
+// `/dev/tty` prompts — there's no PTY here. Both are required by
+// Gopher's POST /machines/register or it 400s with
+// "token, name, and username are required".
 //
 // Returns nil on success; any non-zero exit + the captured stdout/stderr
 // is wrapped into the error so the caller can record it on tunnel_error.
-func runTunnelBootstrap(ctx context.Context, px AgentRunner, node string, vmid int, bootstrapURL, machineName string) error {
+func runTunnelBootstrap(ctx context.Context, px AgentRunner, node string, vmid int, bootstrapURL, machineName, sshUser string) error {
 	if bootstrapURL == "" {
 		return errors.New("empty bootstrap URL")
 	}
+	if sshUser == "" {
+		return errors.New("empty SSH user (cloud-init default user is required by gopher's machine register)")
+	}
 
-	// Single-quote URL + machine name so the shell doesn't interpret
-	// special characters from Gopher's path (tokens) or the hostname.
-	// Set GOPHER_MACHINE_NAME on the receiving shell — the script reads
-	// it before it would otherwise prompt over /dev/tty.
+	// Single-quote URL + machine name + ssh user so the shell doesn't
+	// interpret special characters from Gopher's path (tokens) or the
+	// values. Set both env vars on the receiving shell — the script
+	// reads them before it would otherwise prompt over /dev/tty.
 	//
 	// Download then exec, instead of `curl ... | sh`. The pipe form was
 	// silently masking curl failures: if curl exits non-zero (4xx, DNS
@@ -72,7 +78,8 @@ func runTunnelBootstrap(ctx context.Context, px AgentRunner, node string, vmid i
 		"set -e",
 		"_T=$(mktemp)",
 		fmt.Sprintf("curl -fsSL %s -o \"$_T\"", quote(bootstrapURL)),
-		fmt.Sprintf("GOPHER_MACHINE_NAME=%s sh \"$_T\"", quote(machineName)),
+		fmt.Sprintf("GOPHER_MACHINE_NAME=%s GOPHER_SSH_USER=%s sh \"$_T\"",
+			quote(machineName), quote(sshUser)),
 		"_RC=$?",
 		"rm -f \"$_T\"",
 		// Verify the rathole client unit came up. Without this the

--- a/internal/selftunnel/service.go
+++ b/internal/selftunnel/service.go
@@ -100,6 +100,8 @@ type gopherClient interface {
 	GetMachine(ctx context.Context, id string) (*tunnel.Machine, error)
 	DeleteMachine(ctx context.Context, id string) error
 	CreateTunnel(ctx context.Context, req tunnel.CreateTunnelRequest) (*tunnel.Tunnel, error)
+	DeleteTunnel(ctx context.Context, id string) error
+	ListTunnels(ctx context.Context) ([]tunnel.Tunnel, error)
 	ListTunnelsForMachine(ctx context.Context, machineID string) ([]tunnel.Tunnel, error)
 }
 
@@ -268,11 +270,25 @@ func (s *Service) runBootstrap(ctx context.Context) error {
 		// finds a broken half-state. Try to adopt a matching tunnel that
 		// the server has by listing first; only fail if nothing matches.
 		adopted, aerr := s.adoptCreatedTunnel(ctx, machine.ID, subdomain, s.nimbusPort)
-		if aerr != nil || adopted == nil {
+		if aerr == nil && adopted != nil {
+			log.Printf("self-bootstrap: adopted existing tunnel %s for machine %s after CreateTunnel error: %v", adopted.ID, machine.ID, err)
+			t = adopted
+		} else if isSubdomainConflict(err) {
+			// 409 with subdomain-already-exists: a previous Nimbus run
+			// (or another Nimbus pointed at this Gopher) registered a
+			// machine + tunnel under the same subdomain, then died /
+			// re-registered. The orphan tunnel sits attached to a stale
+			// machine_id our adopt-by-machine logic can't see. Find it
+			// across ALL tunnels, delete it, then retry CreateTunnel —
+			// the operator chose this subdomain, they own it.
+			retried, rerr := s.replaceConflictingTunnel(ctx, machine.ID, subdomain, s.nimbusPort)
+			if rerr != nil {
+				return fmt.Errorf("create tunnel (after subdomain conflict): %w", rerr)
+			}
+			t = retried
+		} else {
 			return fmt.Errorf("create tunnel: %w", err)
 		}
-		log.Printf("self-bootstrap: adopted existing tunnel %s for machine %s after CreateTunnel error: %v", adopted.ID, machine.ID, err)
-		t = adopted
 	}
 
 	// Step 5 — record success.
@@ -283,6 +299,64 @@ func (s *Service) runBootstrap(ctx context.Context) error {
 		CloudBootstrapState: StateActive,
 		CloudBootstrapError: "",
 	})
+}
+
+// isSubdomainConflict matches Gopher's 409 + "subdomain already exists"
+// shape. CreateTunnel surfaces this when the operator picked a
+// subdomain that's already attached to a different machine — most
+// often a manually-configured tunnel they want Nimbus to take over,
+// or an orphan from a previous Nimbus run that re-registered as a
+// new machine. Either way, the takeover path replaces it.
+func isSubdomainConflict(err error) bool {
+	var he *tunnel.HTTPError
+	if !errors.As(err, &he) {
+		return false
+	}
+	if he.Status != 409 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(he.Body), "subdomain")
+}
+
+// replaceConflictingTunnel handles the takeover-on-409 case. Lists
+// every tunnel on Gopher, finds the one bound to `subdomain`, deletes
+// it, then retries CreateTunnel under our `machineID`. The operator
+// implicitly opted into this by re-saving with the conflicting
+// subdomain — we treat their save as an "I own this subdomain"
+// declaration. Returns the freshly-created tunnel; surfaces any
+// retry/list failure verbatim so the operator sees what blocked it.
+func (s *Service) replaceConflictingTunnel(ctx context.Context, machineID, subdomain string, port int) (*tunnel.Tunnel, error) {
+	all, err := s.gopher.ListTunnels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list tunnels: %w", err)
+	}
+	var conflicting *tunnel.Tunnel
+	for i := range all {
+		if all[i].Subdomain == subdomain {
+			conflicting = &all[i]
+			break
+		}
+	}
+	if conflicting == nil {
+		// 409 came back but the conflict isn't visible in our list —
+		// could be a race or a Gopher account-scope mismatch. Bail
+		// rather than blindly retry into the same 409.
+		return nil, fmt.Errorf("subdomain %q reported as conflicting but not found in tunnels list", subdomain)
+	}
+	log.Printf("self-bootstrap: replacing conflicting tunnel %s (subdomain=%s, machine=%s) with one owned by machine %s",
+		conflicting.ID, subdomain, conflicting.MachineID, machineID)
+	if err := s.gopher.DeleteTunnel(ctx, conflicting.ID); err != nil {
+		return nil, fmt.Errorf("delete conflicting tunnel %s: %w", conflicting.ID, err)
+	}
+	t, err := s.gopher.CreateTunnel(ctx, tunnel.CreateTunnelRequest{
+		MachineID:  machineID,
+		TargetPort: port,
+		Subdomain:  subdomain,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("retry create tunnel after delete: %w", err)
+	}
+	return t, nil
 }
 
 // adoptCreatedTunnel checks Gopher for a tunnel matching the parameters

--- a/internal/selftunnel/service_test.go
+++ b/internal/selftunnel/service_test.go
@@ -81,6 +81,19 @@ func (f *fakeGopher) ListTunnelsForMachine(_ context.Context, _ string) ([]tunne
 	copy(out, f.listTunnels)
 	return out, nil
 }
+func (f *fakeGopher) ListTunnels(_ context.Context) ([]tunnel.Tunnel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listTunnelsErr != nil {
+		return nil, f.listTunnelsErr
+	}
+	out := make([]tunnel.Tunnel, len(f.listTunnels))
+	copy(out, f.listTunnels)
+	return out, nil
+}
+func (f *fakeGopher) DeleteTunnel(_ context.Context, _ string) error {
+	return nil
+}
 
 // TestMarkFailed_DeletesMachineAndWipesRow covers the happy cleanup
 // path: a failed bootstrap with a registered Gopher machine deletes
@@ -271,6 +284,126 @@ func TestAdoptCreatedTunnel(t *testing.T) {
 			}
 			if got.ID != tc.wantID {
 				t.Errorf("got tunnel %s, want %s", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+// recordingGopher extends fakeGopher with capture+script support for
+// the takeover-on-409 path. CreateTunnel returns a scripted error the
+// first time and a scripted result on the retry; DeleteTunnel records
+// the id deleted so the test can assert the conflicting tunnel was
+// removed before the retry.
+type recordingGopher struct {
+	fakeGopher
+	createCalls    int
+	createErrFirst error
+	createResult   *tunnel.Tunnel
+	deletedTunnels []string
+}
+
+func (g *recordingGopher) CreateTunnel(_ context.Context, _ tunnel.CreateTunnelRequest) (*tunnel.Tunnel, error) {
+	g.mu.Lock()
+	g.createCalls++
+	call := g.createCalls
+	g.mu.Unlock()
+	if call == 1 && g.createErrFirst != nil {
+		return nil, g.createErrFirst
+	}
+	return g.createResult, nil
+}
+func (g *recordingGopher) DeleteTunnel(_ context.Context, id string) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.deletedTunnels = append(g.deletedTunnels, id)
+	return nil
+}
+
+// TestReplaceConflictingTunnel covers the takeover path: when
+// CreateTunnel returns 409 "subdomain already exists", we list every
+// tunnel cluster-wide, delete the one bound to that subdomain, and
+// retry under our machine. Operator workflow: they manually set up a
+// Gopher tunnel earlier, now want Nimbus to take it over by saving
+// the same subdomain.
+func TestReplaceConflictingTunnel_DeletesOrphanAndRetries(t *testing.T) {
+	t.Parallel()
+	conflict := tunnel.Tunnel{
+		ID:         "t-orphan",
+		MachineID:  "m-old",
+		Subdomain:  "nimbus",
+		TargetPort: 8080,
+	}
+	created := &tunnel.Tunnel{
+		ID:         "t-new",
+		MachineID:  "m-new",
+		Subdomain:  "nimbus",
+		TargetPort: 8080,
+		TunnelURL:  "https://nimbus.altsuite.co",
+	}
+	g := &recordingGopher{
+		fakeGopher: fakeGopher{
+			listTunnels: []tunnel.Tunnel{conflict},
+		},
+		createResult: created,
+	}
+	svc := &Service{gopher: g, nimbusPort: 8080}
+
+	got, err := svc.replaceConflictingTunnel(context.Background(), "m-new", "nimbus", 8080)
+	if err != nil {
+		t.Fatalf("replaceConflictingTunnel: %v", err)
+	}
+	if got == nil || got.ID != "t-new" {
+		t.Fatalf("expected new tunnel t-new, got %+v", got)
+	}
+	if len(g.deletedTunnels) != 1 || g.deletedTunnels[0] != "t-orphan" {
+		t.Errorf("expected DeleteTunnel(t-orphan), got %v", g.deletedTunnels)
+	}
+	if g.createCalls != 1 {
+		t.Errorf("createCalls = %d, want 1 (the retry)", g.createCalls)
+	}
+}
+
+// TestReplaceConflictingTunnel_NoMatch surfaces the bail path: 409
+// happened but our list doesn't show the conflicting subdomain (race
+// or scope mismatch). Surface the situation rather than blindly retry
+// into another 409.
+func TestReplaceConflictingTunnel_NoMatch_Errors(t *testing.T) {
+	t.Parallel()
+	g := &recordingGopher{
+		fakeGopher: fakeGopher{listTunnels: []tunnel.Tunnel{}},
+	}
+	svc := &Service{gopher: g, nimbusPort: 8080}
+
+	_, err := svc.replaceConflictingTunnel(context.Background(), "m-new", "nimbus", 8080)
+	if err == nil {
+		t.Fatal("expected error when conflict not found in tunnel list")
+	}
+	if len(g.deletedTunnels) != 0 {
+		t.Errorf("should not have deleted anything when no conflict found; deleted=%v", g.deletedTunnels)
+	}
+}
+
+// TestIsSubdomainConflict covers the predicate that decides whether
+// to enter the takeover path.
+func TestIsSubdomainConflict(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"409 subdomain", &tunnel.HTTPError{Status: 409, Body: "subdomain already exists"}, true},
+		{"409 case-insensitive", &tunnel.HTTPError{Status: 409, Body: "Subdomain conflict"}, true},
+		{"409 not subdomain", &tunnel.HTTPError{Status: 409, Body: "machine not found"}, false},
+		{"500 subdomain", &tunnel.HTTPError{Status: 500, Body: "subdomain database error"}, false},
+		{"plain error", errors.New("something else"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isSubdomainConflict(tc.err); got != tc.want {
+				t.Errorf("isSubdomainConflict(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
The cloud-tunnel save was failing with 'create tunnel: gopher returned HTTP 409: subdomain already exists' whenever the operator picked a subdomain that already had a tunnel attached to a *different* machine on Gopher. Two real-world causes:

  1. The operator manually configured a tunnel on Gopher (e.g. nimbus.altsuite) and is now saving the same subdomain in Nimbus to take it over.
  2. A previous Nimbus run registered as machine M1 + tunnel T1 with subdomain S; that run died, the next run registered as M2, and CreateTunnel(S) for M2 collides with the orphan T1 still bound to M1.

The existing adopt-on-error path only looks at tunnels under our *new* machine_id, so neither case recovers — the cleanup-after-failure path then wipes credentials and the SPA shows 'not configured', which the operator finds confusing because they just typed everything in.

This adds a takeover branch: when CreateTunnel returns 409 and the body mentions 'subdomain', look across every tunnel (not just our machine's), find the one bound to the conflicting subdomain, delete it, and retry CreateTunnel under our machine. Operator's save is treated as an 'I own this subdomain' declaration.

The existing adopt-on-timeout path stays as the first attempt — only falls into takeover when adopt finds nothing. So a benign timeout that produced our own tunnel still gets adopted; only a true cross-machine conflict triggers the destructive replace.

Tests cover the predicate (isSubdomainConflict) + the happy takeover path + the bail-when-list-doesn't-show-conflict guard.

## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- 
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

