### PR TITLE
fix: treat PVE 'WARNINGS: N' exitstatus as task success

### DIFF
--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -429,10 +429,15 @@ func (c *Client) CloneVM(ctx context.Context, sourceNode, targetNode string, tem
 }
 
 // WaitForTask polls a task's status until it reports stopped, returning an
-// error if exitstatus != "OK". On failure, the error body is enriched with
-// the tail of the task's log (last ~20 lines) so callers don't have to SSH
-// into a Proxmox node to find out *why* a task failed. Polls every
-// interval; total wait is bounded by ctx deadline.
+// error if exitstatus is not a success sentinel. On failure, the error body
+// is enriched with the tail of the task's log (last ~20 lines) so callers
+// don't have to SSH into a Proxmox node to find out *why* a task failed.
+// Polls every interval; total wait is bounded by ctx deadline.
+//
+// Success sentinels: "OK" (clean) and any "WARNINGS: N" (N>0, task completed
+// but emitted N warnings — vzcreate on Debian 12 emits the benign
+// "Systemd 252 detected. You may need to enable nesting." every run, and
+// treating it as failure would tear down a perfectly good container).
 func (c *Client) WaitForTask(ctx context.Context, node, taskID string, interval time.Duration) error {
 	if interval == 0 {
 		interval = 2 * time.Second
@@ -446,6 +451,10 @@ func (c *Client) WaitForTask(ctx context.Context, node, taskID string, interval 
 		}
 		if st.Status == "stopped" {
 			if st.ExitStatus == "OK" {
+				return nil
+			}
+			if strings.HasPrefix(st.ExitStatus, "WARNINGS:") {
+				log.Printf("task %s completed with %s", taskID, st.ExitStatus)
 				return nil
 			}
 			// Fetch the task log tail on a separate context so a ctx

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -295,6 +295,16 @@ func TestClient_WaitForTask(t *testing.T) {
 		}
 	})
 
+	t.Run("WARNINGS exit status treated as success", func(t *testing.T) {
+		_, c := newMockPVE(t, func(w http.ResponseWriter, r *http.Request) {
+			writeEnvelope(w, map[string]string{"status": "stopped", "exitstatus": "WARNINGS: 1"})
+		})
+		err := c.WaitForTask(context.Background(), "node1", "UPID:warn", 10*time.Millisecond)
+		if err != nil {
+			t.Errorf("expected WARNINGS to be treated as success, got: %v", err)
+		}
+	})
+
 	t.Run("ctx cancellation aborts polling", func(t *testing.T) {
 		_, c := newMockPVE(t, func(w http.ResponseWriter, r *http.Request) {
 			writeEnvelope(w, map[string]string{"status": "running"})


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Resolves #__

## Changes Made
<!-- List the main changes -->
- Provisioning a VPC sometimes surfaces a warning which was getting treated as failure despite successful create.
- 

## Testing
<!-- Describe how you tested these changes -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] All tests passing

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

